### PR TITLE
feat: add commands.list for pipeline discovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -297,5 +297,5 @@ function helpText() {
     `  lobster 'exec --json "echo [1,2,3]" | json'\n` +
     `  lobster run --mode tool 'exec --json "echo [1]" | approve --prompt "ok?"'\n\n` +
     `Commands:\n` +
-    `  exec, head, json, pick, table, where, approve, clawd.invoke, state.get, state.set, diff.last, workflows.list, workflows.run\n`;
+    `  exec, head, json, pick, table, where, approve, clawd.invoke, state.get, state.set, diff.last, commands.list, workflows.list, workflows.run\n`;
 }

--- a/src/commands/commands_list.ts
+++ b/src/commands/commands_list.ts
@@ -1,0 +1,40 @@
+export const commandsListCommand = {
+  name: 'commands.list',
+  help() {
+    return (
+      `commands.list — list available Lobster pipeline commands\n\n` +
+      `Usage:\n` +
+      `  commands.list\n\n` +
+      `Notes:\n` +
+      `  - Intended for agents (e.g. Clawdbot) to discover available pipeline stages dynamically.\n` +
+      `  - Output includes the command name and a short description extracted from help().\n`
+    );
+  },
+  async run({ input, ctx }) {
+    // Drain input
+    for await (const _ of input) {
+      // no-op
+    }
+
+    const names = ctx.registry.list();
+    const output = names.map((name) => {
+      const cmd = ctx.registry.get(name);
+      const help = typeof cmd?.help === 'function' ? String(cmd.help()) : '';
+      const firstLine = help.split('\n').find((l) => l.trim().length > 0) ?? '';
+
+      // Expected pattern: "name — description" but fall back to the line as-is.
+      const desc = firstLine.includes('—') ? firstLine.split('—').slice(1).join('—').trim() : firstLine.trim();
+
+      return {
+        name,
+        description: desc,
+      };
+    });
+
+    return {
+      output: (async function* () {
+        for (const item of output) yield item;
+      })(),
+    };
+  },
+};

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -10,6 +10,7 @@ import { stateGetCommand, stateSetCommand } from "./stdlib/state.js";
 import { diffLastCommand } from "./stdlib/diff_last.js";
 import { workflowsListCommand } from "./workflows/workflows_list.js";
 import { workflowsRunCommand } from "./workflows/workflows_run.js";
+import { commandsListCommand } from "./commands_list.js";
 import { gogGmailSearchCommand } from "./stdlib/gog_gmail_search.js";
 import { gogGmailSendCommand } from "./stdlib/gog_gmail_send.js";
 import { emailTriageCommand } from "./stdlib/email_triage.js";
@@ -31,6 +32,7 @@ export function createDefaultRegistry() {
     diffLastCommand,
     workflowsListCommand,
     workflowsRunCommand,
+    commandsListCommand,
     gogGmailSearchCommand,
     gogGmailSendCommand,
     emailTriageCommand,

--- a/test/commands_list.test.ts
+++ b/test/commands_list.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createDefaultRegistry } from '../src/commands/registry.js';
+
+function streamOf(items) {
+  return (async function* () {
+    for (const item of items) yield item;
+  })();
+}
+
+test('commands.list returns command inventory including stdlib + workflows', async () => {
+  const registry = createDefaultRegistry();
+  const cmd = registry.get('commands.list');
+  assert.ok(cmd, 'commands.list should be registered');
+
+  const res = await cmd.run({
+    input: streamOf([]),
+    args: { _: [] },
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: process.env,
+      registry,
+      mode: 'tool',
+      render: { json() {}, lines() {} },
+    },
+  });
+
+  const items = [];
+  for await (const it of res.output) items.push(it);
+
+  const names = items.map((x) => x.name).sort();
+
+  // A couple representative commands we always expect.
+  assert.ok(names.includes('exec'));
+  assert.ok(names.includes('json'));
+  assert.ok(names.includes('workflows.list'));
+  assert.ok(names.includes('commands.list'));
+
+  const self = items.find((x) => x.name === 'commands.list');
+  assert.ok(self);
+  assert.equal(typeof self.description, 'string');
+  assert.ok(self.description.length > 0);
+});


### PR DESCRIPTION
Adds `commands.list` so agents (e.g. Clawdbot) can discover the available Lobster pipeline stages dynamically.

- New command: `commands.list`
- Outputs `{ name, description }` for each registered command (description derived from the first non-empty line of `help()`)
- Registers the command and updates CLI help text

Testing:
- `pnpm test`
