### PR TITLE
fix: resolve ${VAR} templates against environment variables

### DIFF
--- a/test/fixtures/env-test.lobster
+++ b/test/fixtures/env-test.lobster
@@ -1,0 +1,6 @@
+name: env-test
+env:
+  TEST_VAR: "${TEST_VAR}"
+steps:
+  - id: test
+    command: node -e "process.stdout.write(process.env.TEST_VAR || 'undefined')"

--- a/test/workflow_env.test.ts
+++ b/test/workflow_env.test.ts
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile } from '../src/workflows/file.js';
+
+async function runSimpleWorkflow(workflow: object, extraEnv?: Record<string, string>) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-env-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir, ...extraEnv };
+
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env,
+      mode: 'tool',
+    },
+  });
+
+  return result;
+}
+
+test('env var substitution resolves from process.env', async () => {
+  const workflow = {
+    name: 'env-from-process',
+    env: { MY_TEST_VAR: '${MY_TEST_VAR}' },
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(process.env.MY_TEST_VAR || \'missing\')"',
+      },
+    ],
+  };
+
+  const result = await runSimpleWorkflow(workflow, { MY_TEST_VAR: 'hello' });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['hello']);
+});
+
+test('workflow-level env overrides parent env', async () => {
+  const workflow = {
+    name: 'workflow-override',
+    env: { MY_VAR: 'workflow' },
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(process.env.MY_VAR)"',
+      },
+    ],
+  };
+
+  const result = await runSimpleWorkflow(workflow, { MY_VAR: 'parent' });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['workflow']);
+});
+
+test('step-level env overrides workflow-level env', async () => {
+  const workflow = {
+    name: 'step-override',
+    env: { MY_VAR: 'workflow' },
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(process.env.MY_VAR)"',
+        env: { MY_VAR: 'step' },
+      },
+    ],
+  };
+
+  const result = await runSimpleWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['step']);
+});
+
+test('args take precedence over env in template substitution', async () => {
+  const workflow = {
+    name: 'args-precedence',
+    args: { NAME: { default: 'arg-value' } },
+    env: { NAME: '${NAME}' },
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(process.env.NAME)"',
+      },
+    ],
+  };
+
+  const result = await runSimpleWorkflow(workflow, { NAME: 'env-value' });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['arg-value']);
+});
+
+test('env vars resolve in command templates', async () => {
+  const workflow = {
+    name: 'command-template-env',
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(\'${CMD_VAR}\')"',
+      },
+    ],
+  };
+
+  const result = await runSimpleWorkflow(workflow, { CMD_VAR: 'resolved' });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['resolved']);
+});
+
+test('relative cwd resolves from workflow file directory', async () => {
+  // Use realpath to resolve macOS /var -> /private/var symlink
+  const tmpDir = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-cwd-')));
+  const scriptsDir = path.join(tmpDir, 'scripts');
+  await fsp.mkdir(scriptsDir, { recursive: true });
+
+  const workflow = {
+    name: 'relative-cwd',
+    cwd: './scripts',
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(process.cwd())"',
+      },
+    ],
+  };
+
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const stateDir = path.join(tmpDir, 'state');
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env,
+      mode: 'tool',
+    },
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [scriptsDir]);
+});


### PR DESCRIPTION
#### Summary

`resolveArgsTemplate()` only looked up `${VAR}` from workflow args (passed via `--args-json`), so `env: { MY_VAR: "${MY_VAR}" }` in workflow YAML produced the literal string `"${MY_VAR}"` instead of the actual value from `process.env`. This also affected `${VAR}` in `command`, `stdin`, and `cwd` fields.

The fix threads the accumulated environment through `resolveTemplate`, `resolveStdin`, and `resolveCwd` so `${VAR}` falls back to the process/workflow environment when not found in args. Args still take precedence over env vars.

Also adds relative `cwd` resolution — `cwd: ./scripts` now resolves relative to the workflow file's directory instead of being passed as-is to `spawn()`.

lobster-biscuit

#### Repro Steps

1. Create a workflow file with `env: { TEST_VAR: "${TEST_VAR}" }`
2. Run `TEST_VAR=hello lobster run --file workflow.lobster`
3. The step's `process.env.TEST_VAR` is the literal `"${TEST_VAR}"` instead of `"hello"`

#### Root Cause

`resolveArgsTemplate` only checked `args` (workflow-defined args from `--args-json`). It had no fallback to the environment, so any `${VAR}` not defined in `args` was returned verbatim.

#### Behavior Changes

- `${VAR}` in `env`, `command`, `stdin`, and `cwd` values now resolves from the environment when not found in workflow args
- Precedence: args > env > literal (unchanged match kept as-is)
- Relative `cwd` values (e.g. `./scripts`) now resolve relative to the workflow file directory
- No breaking changes to existing behavior — unresolved `${VAR}` still pass through as before

#### Tests

6 new tests in `test/workflow_env.test.ts`:

| Test | Result |
|---|---|
| env var substitution resolves from process.env | ✅ |
| workflow-level env overrides parent env | ✅ |
| step-level env overrides workflow-level env | ✅ |
| args take precedence over env in template substitution | ✅ |
| env vars resolve in command templates | ✅ |
| relative cwd resolves from workflow file directory | ✅ |

All 53 tests pass (47 existing + 6 new).

`pnpm build && pnpm test` — clean.

#### Manual Testing

```
$ TEST_VAR=hello node bin/lobster.js run --file test/fixtures/env-test.lobster
["hello"]
```

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: planned + reviewed
- Agent notes: ~25 lines of source changes; all optional `env` params preserve backward compatibility