### PR TITLE
fix(stdlib): remove unused Transport type and transport variable

### DIFF
--- a/src/commands/stdlib/llm_task_invoke.ts
+++ b/src/commands/stdlib/llm_task_invoke.ts
@@ -146,8 +146,6 @@ type CacheEntry = {
   storedAt: string;
 };
 
-type Transport = 'clawd';
-
 export const llmTaskInvokeCommand = {
   name: 'llm_task.invoke',
   meta: {
@@ -198,7 +196,6 @@ export const llmTaskInvokeCommand = {
     const env = ctx.env ?? process.env;
 
     const clawdUrl = String(env.CLAWD_URL ?? '').trim();
-    const transport: Transport = 'clawd';
     if (!clawdUrl) {
       throw new Error('llm_task.invoke requires CLAWD_URL (run via Clawdbot gateway)');
     }


### PR DESCRIPTION
## Summary

- Dead code left over from the clawd-only refactor in 5679042.
- Remove dead `Transport` type alias and `transport` variable in `llm_task_invoke.ts`
- Left over from the clawd-only refactor in 5679042, causes `oxlint` `no-unused-vars` error

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] Existing `llm_task.invoke` tests still pass

## Use of AI 

- Generated with [Claude Code](https://claude.com/claude-code)
