### PR TITLE
fix(parser): preserve JSON escapes in quoted args

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -61,6 +61,11 @@ function tokenizeCommand(input) {
 
     if (quote) {
       if (quote === "'") {
+        if (ch === '\\' && input[i + 1] === quote) {
+          current += quote;
+          i++;
+          continue;
+        }
         if (ch === quote) {
           quote = null;
           continue;

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -33,3 +33,11 @@ test('parsePipeline keeps single-quoted args literal', () => {
   assert.equal(p.length, 1);
   assert.equal(p[0].args['args-json'], '{"x":"a\\\\nb"}');
 });
+
+test('parsePipeline preserves escaped apostrophes in single-quoted args', () => {
+  const p = parsePipeline("openclaw.invoke --args-json '{\"prompt\":\"don\\'t\"}'");
+  assert.equal(p.length, 1);
+  const raw = p[0].args['args-json'];
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.prompt, "don't");
+});


### PR DESCRIPTION
## Summary
- fix `tokenizeCommand` so quoted parsing does not strip arbitrary backslashes
- preserve escape sequences like `\\n` / `\\t` in double-quoted tokens
- keep single-quoted content literal
- add parser regression tests for `--args-json` handling

## Why
`--args-json` payloads (especially prompt-rich JSON) could be corrupted during tokenization because backslashes were always consumed in quoted mode. This broke valid JSON before command handlers parsed it.

## Validation
- `pnpm build`
- `node --test dist/test/parser.test.js`

---
fix #17 