### PR TITLE
fix: parser mishandles escapes in quoted arguments

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,10 +60,20 @@ function tokenizeCommand(input) {
     const ch = input[i];
 
     if (quote) {
+      // In single-quoted strings, everything is literal (no escape processing)
+      if (quote === "'") {
+        if (ch === "'") {
+          quote = null;
+          continue;
+        }
+        current += ch;
+        continue;
+      }
+      // In double-quoted strings, preserve escape sequences (backslash + next char)
       if (ch === '\\') {
         const next = input[i + 1];
         if (next) {
-          current += next;
+          current += ch + next;
           i++;
           continue;
         }

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -18,3 +18,19 @@ test('parsePipeline keeps quoted pipes', () => {
   assert.equal(p.length, 2);
   assert.deepEqual(p[0].args._, ['echo', 'a|b']);
 });
+
+test('single-quoted strings are fully literal (no escape processing)', () => {
+  const p = parsePipeline("exec echo 'hello\\nworld'");
+  assert.deepEqual(p[0].args._, ['echo', 'hello\\nworld']);
+});
+
+test('double-quoted strings preserve escape sequences', () => {
+  const p = parsePipeline('exec echo "line1\\nline2"');
+  assert.deepEqual(p[0].args._, ['echo', 'line1\\nline2']);
+});
+
+test('--args-json with escaped JSON in double quotes', () => {
+  const p = parsePipeline('invoke --args-json "{\\"prompt\\":\\"line1\\\\nline2\\"}"');
+  // Backslashes are preserved in double-quoted strings: \" stays as \"
+  assert.equal(p[0].args['args-json'], '{\\"prompt\\":\\"line1\\\\nline2\\"}');
+});


### PR DESCRIPTION
## Summary

Fix `tokenizeCommand` escape handling in single-quoted and double-quoted strings.

## Problem

Two failure modes reported in #17:

1. **Single-quoted strings**: `'{"prompt":"don'\'t"}'` — escaped apostrophes caused `Unclosed quote` errors because escape processing was active inside single quotes
2. **Double-quoted strings**: `"{\"prompt\":\"line1\\nline2\"}"` — backslash was stripped during escape processing, corrupting JSON escape sequences

## Fix

- **Single-quoted strings**: Skip escape processing entirely (all chars are literal, matching POSIX shell semantics)
- **Double-quoted strings**: Preserve both the backslash and the next character (`current += ch + next`) instead of stripping the backslash

## Tests

Added 3 new tests to `test/parser.test.ts`:
- Single-quoted strings are fully literal
- Double-quoted strings preserve escape sequences
- `--args-json` with escaped JSON in double quotes

All 50 existing tests continue to pass (the 1 pre-existing failure in `two approve gates can be resumed sequentially` is unrelated).

Fixes #17