### PR TITLE
feat: add TOON format support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "homepage": "https://github.com/clawdbot/lobster#readme",
   "license": "MIT",
   "dependencies": {
+    "@toon-format/toon": "^1.0.0",
     "ajv": "^8.17.1",
     "yaml": "^2.8.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@toon-format/toon':
+        specifier: ^1.0.0
+        version: 1.4.0
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -41,21 +44,25 @@ packages:
     resolution: {integrity: sha512-QWjG3YVsDlIvDTBUPmtPiyqP34ZQpFJqQh2JO94pBih11lFxQ0IGVMEXDhmW3WdiSFPZSJsZGzWynalM9eg+RA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@0.15.15':
     resolution: {integrity: sha512-4W0YsmMSbNzzExOWhk+6zNfmJEmKFqSjFIn8CKLtYFvH8kF6KjoW4/0HNsDNYW5Fz+KOut/2JgkvxAiKH+r0zA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@0.15.15':
     resolution: {integrity: sha512-agP3e+eQ6tE5tqN6VI4Uukx2yvjwYFjtrDMcB19J7PmGOaFRwuMuT0sNWK/9guvhuS9aCINNZTi3kEhMy9Qgng==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@0.15.15':
     resolution: {integrity: sha512-L2qE9NhhUafsJOO4pofLx/0hW5IB0sfJa6bS85q0j+ySaI0f3CxMaAadrZLFSuqHWB3oF18B5yvzaPWsc2ohbQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@0.15.15':
     resolution: {integrity: sha512-B7f4VAS/E78n8zy6XZlNeyYOtWTel4BJn/22Ap2yEAlNzO34ot8dGfpLk6MqTUWJrRnARwVBVmc3wRVrsOT5yg==}
@@ -66,6 +73,9 @@ packages:
     resolution: {integrity: sha512-ZM9T3/OpaQ3qvrk/VuHO2EQmhNH4cOZdr/b/Ju9VKwBr+ahhqMn3W5srrplWQWxfsb0yd1yBj7iD0jdAps2iLg==}
     cpu: [x64]
     os: [win32]
+
+  '@toon-format/toon@1.4.0':
+    resolution: {integrity: sha512-bjdhhIPjnX2oVk+pKy/nD3bwuESDLX/5fwW0TxwpV7Q4PVNkiRSv1S0sPeuy9TI4PfAlulow1HShdmMTnYvoLg==}
 
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
@@ -129,6 +139,8 @@ snapshots:
 
   '@oxlint/win32-x64@0.15.15':
     optional: true
+
+  '@toon-format/toon@1.4.0': {}
 
   '@types/node@22.19.7':
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { runPipeline } from './runtime.js';
 import { encodeToken } from './token.js';
 import { decodeResumeToken, parseResumeArgs } from './resume.js';
 import { runWorkflowFile } from './workflows/file.js';
+import { encode as encodeToon } from '@toon-format/toon';
 
 export async function runCli(argv) {
   const registry = createDefaultRegistry();
@@ -54,7 +55,10 @@ export async function runCli(argv) {
 }
 
 async function handleRun({ argv, registry }) {
-  const { mode, rest, filePath, argsJson } = parseRunArgs(argv);
+  const { mode, format, rest, filePath, argsJson } = parseRunArgs(argv);
+  const serialize = format === 'toon'
+    ? (data: unknown) => encodeToon(data)
+    : (data: unknown) => JSON.stringify(data, null, 2);
   const normalizedMode = normalizeMode(mode);
 
   const workflowFile = filePath
@@ -67,7 +71,7 @@ async function handleRun({ argv, registry }) {
         parsedArgs = JSON.parse(argsJson);
       } catch {
         if (mode === 'tool') {
-          writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: 'run --args-json must be valid JSON' } });
+          writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: 'run --args-json must be valid JSON' } }, serialize);
           process.exitCode = 2;
           return;
         }
@@ -97,7 +101,7 @@ async function handleRun({ argv, registry }) {
             status: 'needs_approval',
             output: [],
             requiresApproval: output.requiresApproval ?? null,
-          });
+          }, serialize);
           return;
         }
 
@@ -106,18 +110,18 @@ async function handleRun({ argv, registry }) {
           status: 'ok',
           output: output.output,
           requiresApproval: null,
-        });
+        }, serialize);
         return;
       }
 
       if (output.status === 'ok' && output.output.length) {
-        process.stdout.write(JSON.stringify(output.output, null, 2));
+        process.stdout.write(serialize(output.output));
         process.stdout.write('\n');
       }
       return;
     } catch (err) {
       if (normalizedMode === 'tool') {
-        writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });
+        writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } }, serialize);
         process.exitCode = 1;
         return;
       }
@@ -134,7 +138,7 @@ async function handleRun({ argv, registry }) {
     pipeline = parsePipeline(pipelineString);
   } catch (err) {
     if (mode === 'tool') {
-      writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err?.message ?? String(err) } });
+      writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err?.message ?? String(err) } }, serialize);
       process.exitCode = 2;
       return;
     }
@@ -178,7 +182,7 @@ async function handleRun({ argv, registry }) {
             ...approval,
             resumeToken,
           },
-        });
+        }, serialize);
         return;
       }
 
@@ -187,18 +191,18 @@ async function handleRun({ argv, registry }) {
         status: 'ok',
         output: output.items,
         requiresApproval: null,
-      });
+      }, serialize);
       return;
     }
 
-    // Human mode: if the last command didn't render, print JSON.
+    // Human mode: if the last command didn't render, print the output.
     if (!output.rendered) {
-      process.stdout.write(JSON.stringify(output.items, null, 2));
+      process.stdout.write(serialize(output.items));
       process.stdout.write('\n');
     }
   } catch (err) {
     if (normalizedMode === 'tool') {
-      writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });
+      writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } }, serialize);
       process.exitCode = 1;
       return;
     }
@@ -210,6 +214,7 @@ async function handleRun({ argv, registry }) {
 function parseRunArgs(argv) {
   const rest = [];
   let mode = 'human';
+  let format = 'json';
   let filePath = null;
   let argsJson = null;
 
@@ -227,6 +232,20 @@ function parseRunArgs(argv) {
 
     if (tok.startsWith('--mode=')) {
       mode = tok.slice('--mode='.length) || 'human';
+      continue;
+    }
+
+    if (tok === '--format') {
+      const value = argv[i + 1];
+      if (value) {
+        format = value;
+        i++;
+      }
+      continue;
+    }
+
+    if (tok.startsWith('--format=')) {
+      format = tok.slice('--format='.length) || 'json';
       continue;
     }
 
@@ -261,7 +280,7 @@ function parseRunArgs(argv) {
     rest.push(tok);
   }
 
-  return { mode, rest, filePath, argsJson };
+  return { mode, format, rest, filePath, argsJson };
 }
 
 function normalizeMode(mode) {
@@ -287,8 +306,8 @@ async function resolveWorkflowFile(candidate) {
   if (!stat.isFile()) throw new Error('Workflow path is not a file');
 
   const ext = extname(resolved).toLowerCase();
-  if (!['.lobster', '.yaml', '.yml', '.json'].includes(ext)) {
-    throw new Error('Workflow file must end in .lobster, .yaml, .yml, or .json');
+  if (!['.lobster', '.yaml', '.yml', '.json', '.toon'].includes(ext)) {
+    throw new Error('Workflow file must end in .lobster, .yaml, .yml, .json, or .toon');
   }
 
   return resolved;
@@ -439,12 +458,13 @@ async function handleDoctor({ argv, registry }) {
   });
 }
 
-function writeToolEnvelope(payload) {
+function writeToolEnvelope(payload, serialize?: (data: unknown) => string) {
   const envelope = {
     protocolVersion: 1,
     ...payload,
   };
-  process.stdout.write(JSON.stringify(envelope, null, 2));
+  const fn = serialize ?? ((data: unknown) => JSON.stringify(data, null, 2));
+  process.stdout.write(fn(envelope));
   process.stdout.write('\n');
 }
 
@@ -454,6 +474,7 @@ function helpText() {
     `  lobster '<pipeline>'\n` +
     `  lobster run --mode tool '<pipeline>'\n` +
     `  lobster run path/to/workflow.lobster\n` +
+    `  lobster run path/to/workflow.toon\n` +
     `  lobster run --file path/to/workflow.lobster --args-json '{...}'\n` +
     `  lobster resume --token <token> --approve yes|no\n` +
     `  lobster doctor\n` +

--- a/src/renderers/json.ts
+++ b/src/renderers/json.ts
@@ -1,7 +1,21 @@
+import { encode as encodeToon } from '@toon-format/toon';
+
 export function createJsonRenderer(stdout) {
   return {
     json(items) {
       stdout.write(JSON.stringify(items, null, 2));
+      stdout.write('\n');
+    },
+    lines(lines) {
+      for (const line of lines) stdout.write(String(line) + '\n');
+    },
+  };
+}
+
+export function createToonRenderer(stdout) {
+  return {
+    json(items) {
+      stdout.write(encodeToon(items));
       stdout.write('\n');
     },
     lines(lines) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1,6 +1,7 @@
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { decode as decodeToon } from '@toon-format/toon';
 
 import { randomUUID } from 'node:crypto';
 
@@ -79,10 +80,17 @@ type WorkflowResumeState = {
 export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> {
   const text = await fsp.readFile(filePath, 'utf8');
   const ext = path.extname(filePath).toLowerCase();
-  const parsed = ext === '.json' ? JSON.parse(text) : parseYaml(text);
+  let parsed: unknown;
+  if (ext === '.json') {
+    parsed = JSON.parse(text);
+  } else if (ext === '.toon') {
+    parsed = decodeToon(text);
+  } else {
+    parsed = parseYaml(text);
+  }
 
   if (!parsed || typeof parsed !== 'object') {
-    throw new Error('Workflow file must be a JSON/YAML object');
+    throw new Error('Workflow file must be a JSON/YAML/TOON object');
   }
 
   const steps = (parsed as WorkflowFile).steps;

--- a/test/workflow_toon.test.ts
+++ b/test/workflow_toon.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { loadWorkflowFile } from '../src/workflows/file.js';
+import { runWorkflowFile } from '../src/workflows/file.js';
+import { encode as encodeToon } from '@toon-format/toon';
+
+test('loadWorkflowFile parses .toon workflow files', async () => {
+  const workflow = {
+    name: 'toon-test',
+    steps: [
+      {
+        id: 'hello',
+        command: "node -e \"process.stdout.write(JSON.stringify({msg:'hello from toon'}))\"",
+      },
+    ],
+  };
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-toon-'));
+  const filePath = path.join(tmpDir, 'workflow.toon');
+  await fsp.writeFile(filePath, encodeToon(workflow), 'utf8');
+
+  const loaded = await loadWorkflowFile(filePath);
+  assert.equal(loaded.name, 'toon-test');
+  assert.equal(loaded.steps.length, 1);
+  assert.equal(loaded.steps[0].id, 'hello');
+});
+
+test('runWorkflowFile executes a .toon workflow', async () => {
+  const workflow = {
+    name: 'toon-run',
+    steps: [
+      {
+        id: 'greet',
+        command: "node -e \"process.stdout.write(JSON.stringify({greeting:'hallo'}))\"",
+      },
+    ],
+  };
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-toon-run-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.toon');
+  await fsp.writeFile(filePath, encodeToon(workflow), 'utf8');
+
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ greeting: 'hallo' }]);
+});


### PR DESCRIPTION
## Summary
- Accept `.toon` workflow files alongside `.json`/`.yaml`/`.yml` in `loadWorkflowFile()` and `resolveWorkflowFile()`
- Add `--format toon` CLI flag for TOON-encoded output (tool envelopes, pipeline results, workflow output)
- Add `createToonRenderer` in `src/renderers/json.ts` for pipeline rendering
- TOON (Token-Oriented Object Notation) is ~40% more token-efficient than JSON — ideal for LLM-driven workflows

## Changes
| File | Change |
|------|--------|
| `package.json` | Add `@toon-format/toon` dependency |
| `src/workflows/file.ts` | Parse `.toon` files via `decodeToon()` |
| `src/cli.ts` | Accept `.toon` extension, add `--format toon` flag, wire serializer through all output paths |
| `src/renderers/json.ts` | Add `createToonRenderer` |
| `test/workflow_toon.test.ts` | Tests for loading and executing `.toon` workflows |

## Test plan
- [x] All 49 tests pass (47 existing + 2 new TOON tests)
- [x] `loadWorkflowFile` correctly parses `.toon` workflow files
- [x] `runWorkflowFile` executes `.toon` workflows end-to-end
- [ ] Manual test with `lobster run --format toon workflow.toon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)