### PR TITLE
fix(windows): improve CLI startup and build script compatibility

### DIFF
--- a/bin/lobster.js
+++ b/bin/lobster.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -10,9 +10,10 @@ const __dirname = dirname(__filename);
 async function load() {
   const distEntry = join(__dirname, "../dist/src/cli.js");
   if (existsSync(distEntry)) {
-    return import(distEntry);
+    return import(pathToFileURL(distEntry).href);
   }
-  return import(join(__dirname, "../src/cli.js"));
+  const srcEntry = join(__dirname, "../src/cli.js");
+  return import(pathToFileURL(srcEntry).href);
 }
 
 const mod = await load();

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "main": "./dist/src/sdk/index.js",
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "pnpm clean && tsc -p tsconfig.json",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "pnpm clean && pnpm exec tsc -p tsconfig.json",
     "prepack": "pnpm build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "oxlint --tsconfig tsconfig.json src test",


### PR DESCRIPTION
## Summary

This PR improves Windows compatibility in two places:

1. `bin/lobster.js`
- uses `pathToFileURL(...).href` for dynamic imports so the CLI starts correctly on Windows under Node ESM

2. `package.json`
- replaces `rm -rf dist` with a Node-based cleanup command
- updates the build script to use `pnpm exec tsc`

## Why

Before this change, Lobster failed to start correctly on Windows because the CLI entrypoint used dynamic `import()` with absolute filesystem paths. Under Node ESM on Windows, raw paths like `C:\...` are not valid module specifiers and caused:

`ERR_UNSUPPORTED_ESM_URL_SCHEME`

This affected multiple commands, including:

- `node ./bin/lobster.js --help`
- `node ./bin/lobster.js doctor`
- `lobster run --file ...`

In addition, the existing `clean` and `build` scripts were not portable to Windows shells.

## Tested on Windows

- `node ./bin/lobster.js --help`
- `node ./bin/lobster.js doctor`
- `lobster run --file ...`

These now work correctly.