### PR TITLE
feat: structured input requests, step flow control, and error recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,17 +19,19 @@ Guidance for coding assistants operating in this repository.
 ## Approval And Resume
 
 - Treat `status: "needs_approval"` as a hard stop.
+- Treat `status: "needs_input"` as a hard stop.
 - Never auto-approve on behalf of a user.
-- Resume only after explicit user decision:
+- Resume only after explicit user decision or input:
   - `lobster resume --token <resumeToken> --approve yes|no`
+  - `lobster resume --token <resumeToken> --response-json '<json>'`
+  - `lobster resume --token <resumeToken> --cancel`
 
 ## Output Handling
 
-- Parse the tool envelope JSON fields: `ok`, `status`, `output`, `requiresApproval`, `error`.
+- Parse the tool envelope JSON fields: `ok`, `status`, `output`, `requiresApproval`, `requiresInput`, `error`.
 - On `ok: false`, surface the error and stop.
 
 ## Safety And Shell Usage
 
 - For workflow-file commands, prefer environment variables (`LOBSTER_ARG_*`) for untrusted or quoted values.
 - Avoid embedding unsafe user strings directly into shell command text.
-

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,15 +5,20 @@ import { encodeToken } from './token.js';
 import { decodeResumeToken, parseResumeArgs } from './resume.js';
 import { runWorkflowFile } from './workflows/file.js';
 import { randomUUID } from 'node:crypto';
+import { Ajv } from 'ajv';
 import { deleteStateJson, readStateJson, writeStateJson } from './state/store.js';
 
 type PipelineResumeState = {
   pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
   resumeAtIndex: number;
   items: unknown[];
+  haltType?: 'approval_request' | 'input_request';
+  inputSchema?: unknown;
   prompt?: string;
   createdAt: string;
 };
+
+const pipelineInputAjv = new Ajv({ allErrors: false, strict: false });
 
 export async function runCli(argv) {
   const registry = createDefaultRegistry();
@@ -108,6 +113,18 @@ async function handleRun({ argv, registry }) {
             status: 'needs_approval',
             output: [],
             requiresApproval: output.requiresApproval ?? null,
+            requiresInput: null,
+          });
+          return;
+        }
+
+        if (output.status === 'needs_input') {
+          writeToolEnvelope({
+            ok: true,
+            status: 'needs_input',
+            output: [],
+            requiresApproval: null,
+            requiresInput: output.requiresInput ?? null,
           });
           return;
         }
@@ -117,6 +134,7 @@ async function handleRun({ argv, registry }) {
           status: 'ok',
           output: output.output,
           requiresApproval: null,
+          requiresInput: null,
         });
         return;
       }
@@ -167,15 +185,16 @@ async function handleRun({ argv, registry }) {
     });
 
     if (normalizedMode === 'tool') {
-      const approval = output.halted && output.items.length === 1 && output.items[0]?.type === 'approval_request'
-        ? output.items[0]
-        : null;
+      const halted = output.halted && output.items.length === 1 ? output.items[0] : null;
+      const approval = halted?.type === 'approval_request' ? halted : null;
+      const inputRequest = halted?.type === 'input_request' ? halted : null;
 
       if (approval) {
         const stateKey = await savePipelineResumeState(process.env, {
           pipeline,
           resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
           items: approval.items,
+          haltType: 'approval_request',
           prompt: approval.prompt,
           createdAt: new Date().toISOString(),
         });
@@ -195,6 +214,42 @@ async function handleRun({ argv, registry }) {
             ...approval,
             resumeToken,
           },
+          requiresInput: null,
+        });
+        return;
+      }
+
+      if (inputRequest) {
+        const stateKey = await savePipelineResumeState(process.env, {
+          pipeline,
+          resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
+          items: inputRequest.items ?? [],
+          haltType: 'input_request',
+          inputSchema: inputRequest.responseSchema,
+          prompt: inputRequest.prompt,
+          createdAt: new Date().toISOString(),
+        });
+
+        const resumeToken = encodeToken({
+          protocolVersion: 1,
+          v: 1,
+          kind: 'pipeline-resume',
+          stateKey,
+        });
+
+        writeToolEnvelope({
+          ok: true,
+          status: 'needs_input',
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            type: 'input_request',
+            prompt: inputRequest.prompt,
+            responseSchema: inputRequest.responseSchema,
+            defaults: inputRequest.defaults,
+            subject: inputRequest.subject,
+            resumeToken,
+          },
         });
         return;
       }
@@ -204,6 +259,7 @@ async function handleRun({ argv, registry }) {
         status: 'ok',
         output: output.items,
         requiresApproval: null,
+        requiresInput: null,
       });
       return;
     }
@@ -313,11 +369,13 @@ async function resolveWorkflowFile(candidate) {
 
 async function handleResume({ argv, registry }) {
   const mode = 'tool';
-  let approved: boolean;
+  let approved: boolean | undefined;
+  let response: unknown = undefined;
   let payload: any;
   try {
     const parsed = parseResumeArgs(argv);
     approved = parsed.approved;
+    response = parsed.response;
     payload = decodeResumeToken(parsed.token);
   } catch (err) {
     writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err?.message ?? String(err) } });
@@ -325,18 +383,15 @@ async function handleResume({ argv, registry }) {
     return;
   }
 
-  if (!approved) {
-    if (payload.kind === 'workflow-file' && payload.stateKey) {
-      await deleteStateJson({ env: process.env, key: payload.stateKey });
-    }
-    if (payload.kind === 'pipeline-resume' && payload.stateKey) {
-      await deleteStateJson({ env: process.env, key: payload.stateKey });
-    }
-    writeToolEnvelope({ ok: true, status: 'cancelled', output: [], requiresApproval: null });
-    return;
-  }
-
   if (payload.kind === 'workflow-file') {
+    if (approved === false) {
+      if (payload.stateKey) {
+        await deleteStateJson({ env: process.env, key: payload.stateKey });
+      }
+      writeToolEnvelope({ ok: true, status: 'cancelled', output: [], requiresApproval: null, requiresInput: null });
+      return;
+    }
+
     try {
       const output = await runWorkflowFile({
         filePath: payload.filePath,
@@ -349,7 +404,8 @@ async function handleResume({ argv, registry }) {
           registry,
         },
         resume: payload,
-        approved: true,
+        approved,
+        response,
       });
 
       if (output.status === 'needs_approval') {
@@ -358,11 +414,29 @@ async function handleResume({ argv, registry }) {
           status: 'needs_approval',
           output: [],
           requiresApproval: output.requiresApproval ?? null,
+          requiresInput: null,
         });
         return;
       }
 
-      writeToolEnvelope({ ok: true, status: 'ok', output: output.output, requiresApproval: null });
+      if (output.status === 'needs_input') {
+        writeToolEnvelope({
+          ok: true,
+          status: 'needs_input',
+          output: [],
+          requiresApproval: null,
+          requiresInput: output.requiresInput ?? null,
+        });
+        return;
+      }
+
+      writeToolEnvelope({
+        ok: true,
+        status: 'ok',
+        output: output.output,
+        requiresApproval: null,
+        requiresInput: null,
+      });
       return;
     } catch (err) {
       writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });
@@ -370,6 +444,7 @@ async function handleResume({ argv, registry }) {
       return;
     }
   }
+
   const previousStateKey = payload.stateKey;
   let resumeState: PipelineResumeState;
   try {
@@ -379,8 +454,86 @@ async function handleResume({ argv, registry }) {
     process.exitCode = 1;
     return;
   }
+
+  if (resumeState.haltType === 'approval_request') {
+    if (response !== undefined) {
+      writeToolEnvelope({
+        ok: false,
+        error: { type: 'parse_error', message: 'pipeline approval resumes require --approve yes|no' },
+      });
+      process.exitCode = 2;
+      return;
+    }
+    if (typeof approved !== 'boolean') {
+      writeToolEnvelope({
+        ok: false,
+        error: { type: 'parse_error', message: 'pipeline approval resumes require --approve yes|no' },
+      });
+      process.exitCode = 2;
+      return;
+    }
+    if (approved === false) {
+      await deleteStateJson({ env: process.env, key: previousStateKey });
+      writeToolEnvelope({ ok: true, status: 'cancelled', output: [], requiresApproval: null, requiresInput: null });
+      return;
+    }
+  }
+
+  if (resumeState.haltType === 'input_request') {
+    if (approved !== undefined) {
+      writeToolEnvelope({
+        ok: false,
+        error: { type: 'parse_error', message: 'pipeline input resumes require --response-json <json>' },
+      });
+      process.exitCode = 2;
+      return;
+    }
+    if (response === undefined) {
+      writeToolEnvelope({
+        ok: false,
+        error: { type: 'parse_error', message: 'pipeline input resumes require --response-json <json>' },
+      });
+      process.exitCode = 2;
+      return;
+    }
+    try {
+      validatePipelineInputResponse(resumeState.inputSchema, response);
+    } catch (err) {
+      writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err?.message ?? String(err) } });
+      process.exitCode = 2;
+      return;
+    }
+  }
+
+  if (!resumeState.haltType) {
+    if (response !== undefined) {
+      writeToolEnvelope({
+        ok: false,
+        error: { type: 'parse_error', message: 'legacy pipeline resumes require --approve yes|no' },
+      });
+      process.exitCode = 2;
+      return;
+    }
+    if (typeof approved !== 'boolean') {
+      writeToolEnvelope({
+        ok: false,
+        error: { type: 'parse_error', message: 'legacy pipeline resumes require --approve yes|no' },
+      });
+      process.exitCode = 2;
+      return;
+    }
+    if (approved === false) {
+      await deleteStateJson({ env: process.env, key: previousStateKey });
+      writeToolEnvelope({ ok: true, status: 'cancelled', output: [], requiresApproval: null, requiresInput: null });
+      return;
+    }
+  }
+
   const remaining = resumeState.pipeline.slice(resumeState.resumeAtIndex);
-  const input = streamFromItems(resumeState.items);
+  const inputItems = resumeState.haltType === 'input_request'
+    ? [response]
+    : resumeState.items;
+  const input = streamFromItems(inputItems);
 
   try {
     const output = await runPipeline({
@@ -394,15 +547,16 @@ async function handleResume({ argv, registry }) {
       input,
     });
 
-    const approval = output.halted && output.items.length === 1 && output.items[0]?.type === 'approval_request'
-      ? output.items[0]
-      : null;
+    const halted3 = output.halted && output.items.length === 1 ? output.items[0] : null;
+    const approval = halted3?.type === 'approval_request' ? halted3 : null;
+    const inputRequest = halted3?.type === 'input_request' ? halted3 : null;
 
     if (approval) {
       const nextStateKey = await savePipelineResumeState(process.env, {
         pipeline: remaining,
         resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
         items: approval.items,
+        haltType: 'approval_request',
         prompt: approval.prompt,
         createdAt: new Date().toISOString(),
       });
@@ -420,12 +574,55 @@ async function handleResume({ argv, registry }) {
         status: 'needs_approval',
         output: [],
         requiresApproval: { ...approval, resumeToken },
+        requiresInput: null,
+      });
+      return;
+    }
+
+    if (inputRequest) {
+      const nextStateKey = await savePipelineResumeState(process.env, {
+        pipeline: remaining,
+        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
+        items: inputRequest.items ?? [],
+        haltType: 'input_request',
+        inputSchema: inputRequest.responseSchema,
+        prompt: inputRequest.prompt,
+        createdAt: new Date().toISOString(),
+      });
+      await deleteStateJson({ env: process.env, key: previousStateKey });
+
+      const resumeToken = encodeToken({
+        protocolVersion: 1,
+        v: 1,
+        kind: 'pipeline-resume',
+        stateKey: nextStateKey,
+      });
+
+      writeToolEnvelope({
+        ok: true,
+        status: 'needs_input',
+        output: [],
+        requiresApproval: null,
+        requiresInput: {
+          type: 'input_request',
+          prompt: inputRequest.prompt,
+          responseSchema: inputRequest.responseSchema,
+          defaults: inputRequest.defaults,
+          subject: inputRequest.subject,
+          resumeToken,
+        },
       });
       return;
     }
 
     await deleteStateJson({ env: process.env, key: previousStateKey });
-    writeToolEnvelope({ ok: true, status: 'ok', output: output.items, requiresApproval: null });
+    writeToolEnvelope({
+      ok: true,
+      status: 'ok',
+      output: output.items,
+      requiresApproval: null,
+      requiresInput: null,
+    });
   } catch (err) {
     writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });
     process.exitCode = 1;
@@ -453,7 +650,23 @@ async function loadPipelineResumeState(env: Record<string, string | undefined>, 
   if (!Array.isArray(data.pipeline)) throw new Error('Invalid pipeline resume state');
   if (typeof data.resumeAtIndex !== 'number') throw new Error('Invalid pipeline resume state');
   if (!Array.isArray(data.items)) throw new Error('Invalid pipeline resume state');
+  if (data.haltType !== undefined && !['approval_request', 'input_request'].includes(data.haltType)) {
+    throw new Error('Invalid pipeline resume state');
+  }
   return data as PipelineResumeState;
+}
+
+function validatePipelineInputResponse(schema: unknown, response: unknown) {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return;
+  }
+  const validator = pipelineInputAjv.compile(schema as object);
+  const ok = validator(response);
+  if (ok) return;
+  const first = validator.errors?.[0];
+  const pathValue = first?.instancePath || '/';
+  const reason = first?.message ? ` ${first.message}` : '';
+  throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
 }
 
 async function readVersion() {
@@ -507,6 +720,7 @@ async function handleDoctor({ argv, registry }) {
       notes: argv.length ? argv : undefined,
     }],
     requiresApproval: null,
+    requiresInput: null,
   });
 }
 
@@ -527,6 +741,7 @@ function helpText() {
     `  lobster run path/to/workflow.lobster\n` +
     `  lobster run --file path/to/workflow.lobster --args-json '{...}'\n` +
     `  lobster resume --token <token> --approve yes|no\n` +
+    `  lobster resume --token <token> --response-json '{...}'\n` +
     `  lobster doctor\n` +
     `  lobster version\n` +
     `  lobster help <command>\n\n` +
@@ -537,5 +752,5 @@ function helpText() {
     `  lobster 'exec --json "echo [1,2,3]" | json'\n` +
     `  lobster run --mode tool 'exec --json "echo [1]" | approve --prompt "ok?"'\n\n` +
     `Commands:\n` +
-    `  exec, head, json, pick, table, where, approve, openclaw.invoke, llm.invoke, llm_task.invoke, state.get, state.set, diff.last, commands.list, workflows.list, workflows.run\n`;
+    `  exec, head, json, pick, table, where, approve, ask, openclaw.invoke, llm.invoke, llm_task.invoke, state.get, state.set, diff.last, commands.list, workflows.list, workflows.run\n`;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,22 +3,15 @@ import { createDefaultRegistry } from './commands/registry.js';
 import { runPipeline } from './runtime.js';
 import { encodeToken } from './token.js';
 import { decodeResumeToken, parseResumeArgs } from './resume.js';
-import { runWorkflowFile } from './workflows/file.js';
-import { randomUUID } from 'node:crypto';
-import { Ajv } from 'ajv';
-import { deleteStateJson, readStateJson, writeStateJson } from './state/store.js';
-
-type PipelineResumeState = {
-  pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
-  resumeAtIndex: number;
-  items: unknown[];
-  haltType?: 'approval_request' | 'input_request';
-  inputSchema?: unknown;
-  prompt?: string;
-  createdAt: string;
-};
-
-const pipelineInputAjv = new Ajv({ allErrors: false, strict: false });
+import { WorkflowResumeArgumentError, runWorkflowFile } from './workflows/file.js';
+import { deleteStateJson } from './state/store.js';
+import {
+  extractPipelineHalt,
+  loadPipelineResumeState,
+  PipelineResumeState,
+  savePipelineResumeState,
+  validatePipelineInputResponse,
+} from './pipeline_resume_state.js';
 
 export async function runCli(argv) {
   const registry = createDefaultRegistry();
@@ -185,9 +178,7 @@ async function handleRun({ argv, registry }) {
     });
 
     if (normalizedMode === 'tool') {
-      const halted = output.halted && output.items.length === 1 ? output.items[0] : null;
-      const approval = halted?.type === 'approval_request' ? halted : null;
-      const inputRequest = halted?.type === 'input_request' ? halted : null;
+      const { approval, inputRequest } = extractPipelineHalt(output);
 
       if (approval) {
         const stateKey = await savePipelineResumeState(process.env, {
@@ -371,11 +362,13 @@ async function handleResume({ argv, registry }) {
   const mode = 'tool';
   let approved: boolean | undefined;
   let response: unknown = undefined;
+  let cancel = false;
   let payload: any;
   try {
     const parsed = parseResumeArgs(argv);
     approved = parsed.approved;
     response = parsed.response;
+    cancel = Boolean(parsed.cancel);
     payload = decodeResumeToken(parsed.token);
   } catch (err) {
     writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err?.message ?? String(err) } });
@@ -384,14 +377,6 @@ async function handleResume({ argv, registry }) {
   }
 
   if (payload.kind === 'workflow-file') {
-    if (approved === false) {
-      if (payload.stateKey) {
-        await deleteStateJson({ env: process.env, key: payload.stateKey });
-      }
-      writeToolEnvelope({ ok: true, status: 'cancelled', output: [], requiresApproval: null, requiresInput: null });
-      return;
-    }
-
     try {
       const output = await runWorkflowFile({
         filePath: payload.filePath,
@@ -406,6 +391,7 @@ async function handleResume({ argv, registry }) {
         resume: payload,
         approved,
         response,
+        cancel,
       });
 
       if (output.status === 'needs_approval') {
@@ -430,6 +416,17 @@ async function handleResume({ argv, registry }) {
         return;
       }
 
+      if (output.status === 'cancelled') {
+        writeToolEnvelope({
+          ok: true,
+          status: 'cancelled',
+          output: [],
+          requiresApproval: null,
+          requiresInput: null,
+        });
+        return;
+      }
+
       writeToolEnvelope({
         ok: true,
         status: 'ok',
@@ -439,6 +436,11 @@ async function handleResume({ argv, registry }) {
       });
       return;
     } catch (err) {
+      if (err instanceof WorkflowResumeArgumentError) {
+        writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err.message } });
+        process.exitCode = 2;
+        return;
+      }
       writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });
       process.exitCode = 1;
       return;
@@ -452,6 +454,12 @@ async function handleResume({ argv, registry }) {
   } catch (err) {
     writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });
     process.exitCode = 1;
+    return;
+  }
+
+  if (cancel) {
+    await deleteStateJson({ env: process.env, key: previousStateKey });
+    writeToolEnvelope({ ok: true, status: 'cancelled', output: [], requiresApproval: null, requiresInput: null });
     return;
   }
 
@@ -547,9 +555,7 @@ async function handleResume({ argv, registry }) {
       input,
     });
 
-    const halted3 = output.halted && output.items.length === 1 ? output.items[0] : null;
-    const approval = halted3?.type === 'approval_request' ? halted3 : null;
-    const inputRequest = halted3?.type === 'input_request' ? halted3 : null;
+    const { approval, inputRequest } = extractPipelineHalt(output);
 
     if (approval) {
       const nextStateKey = await savePipelineResumeState(process.env, {
@@ -635,40 +641,6 @@ function streamFromItems(items: unknown[]) {
   })();
 }
 
-async function savePipelineResumeState(env: Record<string, string | undefined>, state: PipelineResumeState) {
-  const stateKey = `pipeline_resume_${randomUUID()}`;
-  await writeStateJson({ env, key: stateKey, value: state });
-  return stateKey;
-}
-
-async function loadPipelineResumeState(env: Record<string, string | undefined>, stateKey: string) {
-  const stored = await readStateJson({ env, key: stateKey });
-  if (!stored || typeof stored !== 'object') {
-    throw new Error('Pipeline resume state not found');
-  }
-  const data = stored as Partial<PipelineResumeState>;
-  if (!Array.isArray(data.pipeline)) throw new Error('Invalid pipeline resume state');
-  if (typeof data.resumeAtIndex !== 'number') throw new Error('Invalid pipeline resume state');
-  if (!Array.isArray(data.items)) throw new Error('Invalid pipeline resume state');
-  if (data.haltType !== undefined && !['approval_request', 'input_request'].includes(data.haltType)) {
-    throw new Error('Invalid pipeline resume state');
-  }
-  return data as PipelineResumeState;
-}
-
-function validatePipelineInputResponse(schema: unknown, response: unknown) {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
-    return;
-  }
-  const validator = pipelineInputAjv.compile(schema as object);
-  const ok = validator(response);
-  if (ok) return;
-  const first = validator.errors?.[0];
-  const pathValue = first?.instancePath || '/';
-  const reason = first?.message ? ` ${first.message}` : '';
-  throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
-}
-
 async function readVersion() {
   const { readFile } = await import('node:fs/promises');
   const { fileURLToPath } = await import('node:url');
@@ -742,6 +714,7 @@ function helpText() {
     `  lobster run --file path/to/workflow.lobster --args-json '{...}'\n` +
     `  lobster resume --token <token> --approve yes|no\n` +
     `  lobster resume --token <token> --response-json '{...}'\n` +
+    `  lobster resume --token <token> --cancel\n` +
     `  lobster doctor\n` +
     `  lobster version\n` +
     `  lobster help <command>\n\n` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,15 +1,13 @@
 import { parsePipeline } from './parser.js';
 import { createDefaultRegistry } from './commands/registry.js';
 import { runPipeline } from './runtime.js';
-import { encodeToken } from './token.js';
 import { decodeResumeToken, parseResumeArgs } from './resume.js';
 import { WorkflowResumeArgumentError, runWorkflowFile } from './workflows/file.js';
 import { deleteStateJson } from './state/store.js';
 import {
-  extractPipelineHalt,
+  finalizePipelineToolRun,
   loadPipelineResumeState,
   PipelineResumeState,
-  savePipelineResumeState,
   validatePipelineInputResponse,
 } from './pipeline_resume_state.js';
 
@@ -155,7 +153,7 @@ async function handleRun({ argv, registry }) {
   try {
     pipeline = parsePipeline(pipelineString);
   } catch (err) {
-    if (mode === 'tool') {
+    if (normalizedMode === 'tool') {
       writeToolEnvelope({ ok: false, error: { type: 'parse_error', message: err?.message ?? String(err) } });
       process.exitCode = 2;
       return;
@@ -178,79 +176,17 @@ async function handleRun({ argv, registry }) {
     });
 
     if (normalizedMode === 'tool') {
-      const { approval, inputRequest } = extractPipelineHalt(output);
-
-      if (approval) {
-        const stateKey = await savePipelineResumeState(process.env, {
-          pipeline,
-          resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-          items: approval.items,
-          haltType: 'approval_request',
-          prompt: approval.prompt,
-          createdAt: new Date().toISOString(),
-        });
-
-        const resumeToken = encodeToken({
-          protocolVersion: 1,
-          v: 1,
-          kind: 'pipeline-resume',
-          stateKey,
-        });
-
-        writeToolEnvelope({
-          ok: true,
-          status: 'needs_approval',
-          output: [],
-          requiresApproval: {
-            ...approval,
-            resumeToken,
-          },
-          requiresInput: null,
-        });
-        return;
-      }
-
-      if (inputRequest) {
-        const stateKey = await savePipelineResumeState(process.env, {
-          pipeline,
-          resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-          items: inputRequest.items ?? [],
-          haltType: 'input_request',
-          inputSchema: inputRequest.responseSchema,
-          prompt: inputRequest.prompt,
-          createdAt: new Date().toISOString(),
-        });
-
-        const resumeToken = encodeToken({
-          protocolVersion: 1,
-          v: 1,
-          kind: 'pipeline-resume',
-          stateKey,
-        });
-
-        writeToolEnvelope({
-          ok: true,
-          status: 'needs_input',
-          output: [],
-          requiresApproval: null,
-          requiresInput: {
-            type: 'input_request',
-            prompt: inputRequest.prompt,
-            responseSchema: inputRequest.responseSchema,
-            defaults: inputRequest.defaults,
-            subject: inputRequest.subject,
-            resumeToken,
-          },
-        });
-        return;
-      }
-
+      const finalized = await finalizePipelineToolRun({
+        env: process.env,
+        pipeline,
+        output,
+      });
       writeToolEnvelope({
         ok: true,
-        status: 'ok',
-        output: output.items,
-        requiresApproval: null,
-        requiresInput: null,
+        status: finalized.status,
+        output: finalized.output,
+        requiresApproval: finalized.requiresApproval,
+        requiresInput: finalized.requiresInput,
       });
       return;
     }
@@ -554,80 +490,18 @@ async function handleResume({ argv, registry }) {
       mode,
       input,
     });
-
-    const { approval, inputRequest } = extractPipelineHalt(output);
-
-    if (approval) {
-      const nextStateKey = await savePipelineResumeState(process.env, {
-        pipeline: remaining,
-        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-        items: approval.items,
-        haltType: 'approval_request',
-        prompt: approval.prompt,
-        createdAt: new Date().toISOString(),
-      });
-      await deleteStateJson({ env: process.env, key: previousStateKey });
-
-      const resumeToken = encodeToken({
-        protocolVersion: 1,
-        v: 1,
-        kind: 'pipeline-resume',
-        stateKey: nextStateKey,
-      });
-
-      writeToolEnvelope({
-        ok: true,
-        status: 'needs_approval',
-        output: [],
-        requiresApproval: { ...approval, resumeToken },
-        requiresInput: null,
-      });
-      return;
-    }
-
-    if (inputRequest) {
-      const nextStateKey = await savePipelineResumeState(process.env, {
-        pipeline: remaining,
-        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-        items: inputRequest.items ?? [],
-        haltType: 'input_request',
-        inputSchema: inputRequest.responseSchema,
-        prompt: inputRequest.prompt,
-        createdAt: new Date().toISOString(),
-      });
-      await deleteStateJson({ env: process.env, key: previousStateKey });
-
-      const resumeToken = encodeToken({
-        protocolVersion: 1,
-        v: 1,
-        kind: 'pipeline-resume',
-        stateKey: nextStateKey,
-      });
-
-      writeToolEnvelope({
-        ok: true,
-        status: 'needs_input',
-        output: [],
-        requiresApproval: null,
-        requiresInput: {
-          type: 'input_request',
-          prompt: inputRequest.prompt,
-          responseSchema: inputRequest.responseSchema,
-          defaults: inputRequest.defaults,
-          subject: inputRequest.subject,
-          resumeToken,
-        },
-      });
-      return;
-    }
-
-    await deleteStateJson({ env: process.env, key: previousStateKey });
+    const finalized = await finalizePipelineToolRun({
+      env: process.env,
+      pipeline: remaining,
+      output,
+      previousStateKey,
+    });
     writeToolEnvelope({
       ok: true,
-      status: 'ok',
-      output: output.items,
-      requiresApproval: null,
-      requiresInput: null,
+      status: finalized.status,
+      output: finalized.output,
+      requiresApproval: finalized.requiresApproval,
+      requiresInput: finalized.requiresInput,
     });
   } catch (err) {
     writeToolEnvelope({ ok: false, error: { type: 'runtime_error', message: err?.message ?? String(err) } });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,6 +130,28 @@ async function handleRun({ argv, registry }) {
         return;
       }
 
+      if (output.status === 'needs_approval') {
+        process.stdout.write(JSON.stringify({
+          status: 'needs_approval',
+          output: [],
+          requiresApproval: output.requiresApproval ?? null,
+          requiresInput: null,
+        }, null, 2));
+        process.stdout.write('\n');
+        return;
+      }
+
+      if (output.status === 'needs_input') {
+        process.stdout.write(JSON.stringify({
+          status: 'needs_input',
+          output: [],
+          requiresApproval: null,
+          requiresInput: output.requiresInput ?? null,
+        }, null, 2));
+        process.stdout.write('\n');
+        return;
+      }
+
       if (output.status === 'ok' && output.output.length) {
         process.stdout.write(JSON.stringify(output.output, null, 2));
         process.stdout.write('\n');

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -10,6 +10,7 @@ import { templateCommand } from "./stdlib/template.js";
 import { mapCommand } from "./stdlib/map.js";
 import { groupByCommand } from "./stdlib/group_by.js";
 import { approveCommand } from "./stdlib/approve.js";
+import { askCommand } from "./stdlib/ask.js";
 import { clawdInvokeCommand, openclawInvokeCommand } from "./stdlib/openclaw_invoke.js";
 import { llmInvokeCommand } from "./stdlib/llm_invoke.js";
 import { llmTaskInvokeCommand } from "./stdlib/llm_task_invoke.js";
@@ -38,6 +39,7 @@ export function createDefaultRegistry() {
     mapCommand,
     groupByCommand,
     approveCommand,
+    askCommand,
     openclawInvokeCommand,
     clawdInvokeCommand,
     llmInvokeCommand,

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -30,11 +30,16 @@ function validateAskResponse(schema, response) {
 }
 
 function parseInteractiveCandidates(text) {
+  let parsed;
   try {
-    return [JSON.parse(text)];
+    parsed = JSON.parse(text);
   } catch {
     return [text, { decision: text }];
   }
+  if (typeof parsed === 'string') {
+    return [parsed, { decision: parsed }];
+  }
+  return [parsed];
 }
 
 export const askCommand = {

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -37,7 +37,7 @@ function parseInteractiveCandidates(text) {
   if (typeof parsed === 'string') {
     return [parsed, { decision: parsed }];
   }
-  return [parsed];
+  return [parsed, text];
 }
 
 export const askCommand = {

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -18,7 +18,12 @@ function isInteractive(stdin) {
 }
 
 function validateAskResponse(schema, response) {
-  const validator = sharedAjv.compile(schema);
+  let validator;
+  try {
+    validator = sharedAjv.compile(schema);
+  } catch {
+    throw new Error('ask response schema is invalid');
+  }
   const ok = validator(response);
   if (ok) return;
   const first = validator.errors?.[0];

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -11,16 +11,14 @@
  *   ... | ask --subject-from-stdin --prompt "Review this draft:"
  */
 
-import { Ajv } from 'ajv';
+import { sharedAjv } from '../../validation.js';
 
 function isInteractive(stdin) {
   return Boolean(stdin.isTTY);
 }
 
-const askInputAjv = new Ajv({ allErrors: false, strict: false });
-
 function validateAskResponse(schema, response) {
-  const validator = askInputAjv.compile(schema);
+  const validator = sharedAjv.compile(schema);
   const ok = validator(response);
   if (ok) return;
   const first = validator.errors?.[0];

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -1,0 +1,123 @@
+/**
+ * ask — pause workflow and request structured freeform input from the user.
+ *
+ * In tool mode (or non-interactive), emits a `needs_input` envelope and halts.
+ * The OpenClaw plugin converts the resumeToken into a session-scoped requestId
+ * so the user can respond via resumeByRequest.
+ *
+ * Usage:
+ *   ... | ask --prompt "Approve, reject, or send feedback:"
+ *   ... | ask --prompt "Feedback?" --schema '{"type":"object","properties":{"decision":{"type":"string"},"feedback":{"type":"string"}},"required":["decision"]}'
+ *   ... | ask --subject-from-stdin --prompt "Review this draft:"
+ */
+
+function isInteractive(stdin) {
+  return Boolean(stdin.isTTY);
+}
+
+export const askCommand = {
+  name: 'ask',
+  meta: {
+    description: 'Pause and request structured input from the user',
+    argsSchema: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', description: 'Question or instruction to show', default: 'Input required' },
+        schema: { type: 'string', description: 'JSON Schema string for the expected response' },
+        'subject-from-stdin': { type: 'boolean', description: 'Use stdin content as the subject (preview text)' },
+        emit: { type: 'boolean', description: 'Force emit mode' },
+        _: { type: 'array', items: { type: 'string' } },
+      },
+      required: [],
+    },
+    sideEffects: [],
+  },
+  help() {
+    return [
+      'ask — pause workflow and request structured input from the user',
+      '',
+      'Usage:',
+      '  ... | ask --prompt "Approve, reject, or send feedback:"',
+      '  ... | ask --prompt "Feedback?" --schema \'{"type":"object","properties":{"decision":{"type":"string"},"feedback":{"type":"string"}},"required":["decision"]}\'',
+      '  ... | ask --subject-from-stdin --prompt "Review this draft:"',
+      '',
+      'Notes:',
+      '  - In tool mode (or non-interactive), emits a needs_input envelope and halts.',
+      '  - OpenClaw converts the resumeToken into a requestId for resumeByRequest.',
+      '  - Use --schema to constrain the response shape (JSON Schema).',
+      '  - Use --subject-from-stdin to embed the current pipeline value as preview text.',
+    ].join('\n');
+  },
+  async run({ input, args, ctx }) {
+    const prompt = typeof args.prompt === 'string' ? args.prompt : 'Input required';
+    const subjectFromStdin = Boolean(args['subject-from-stdin'] ?? args.subjectFromStdin);
+    const schemaRaw = typeof args.schema === 'string' ? args.schema : null;
+
+    const items = [];
+    for await (const item of input) items.push(item);
+
+    // Default response schema: decision (approve/reject/redraft) + optional feedback
+    const defaultSchema = {
+      type: 'object',
+      properties: {
+        decision: { type: 'string', enum: ['approve', 'reject', 'redraft'] },
+        feedback: { type: 'string', description: 'Feedback for redraft (required when decision is redraft)' },
+      },
+      required: ['decision'],
+    };
+
+    let responseSchema = defaultSchema;
+    if (schemaRaw) {
+      let parsedSchema;
+      try {
+        parsedSchema = JSON.parse(schemaRaw);
+      } catch {
+        throw new Error('ask --schema must be valid JSON');
+      }
+      if (!parsedSchema || typeof parsedSchema !== 'object' || Array.isArray(parsedSchema)) {
+        throw new Error('ask --schema must decode to a JSON schema object');
+      }
+      responseSchema = parsedSchema;
+    }
+
+    // Build subject from stdin if requested
+    let subject: { text: string } | undefined;
+    if (subjectFromStdin && items.length > 0) {
+      const preview = items
+        .map((item) => (typeof item === 'string' ? item : JSON.stringify(item)))
+        .join('\n')
+        .slice(0, 2000);
+      subject = { text: preview };
+    }
+
+    const emit = Boolean(args.emit) || ctx.mode === 'tool' || !isInteractive(ctx.stdin);
+
+    if (emit) {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt,
+            responseSchema,
+            ...(subject ? { subject } : {}),
+            items,
+          };
+        })(),
+      };
+    }
+
+    // Interactive fallback: simple readline
+    ctx.stdout.write(`${prompt}\n> `);
+    const { readLineFromStream } = await import('../../read_line.js');
+    const raw = await readLineFromStream(ctx.stdin, { timeoutMs: 0 });
+    const text = String(raw ?? '').trim();
+
+    // Try to parse as JSON, otherwise treat as freeform decision
+    try {
+      return { output: (async function* () { yield JSON.parse(text); })() };
+    } catch {
+      return { output: (async function* () { yield { decision: text }; })() };
+    }
+  },
+};

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -42,7 +42,7 @@ function parseInteractiveCandidates(text) {
   if (typeof parsed === 'string') {
     return [parsed, { decision: parsed }];
   }
-  return [parsed, text];
+  return [parsed];
 }
 
 export const askCommand = {

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -11,8 +11,30 @@
  *   ... | ask --subject-from-stdin --prompt "Review this draft:"
  */
 
+import { Ajv } from 'ajv';
+
 function isInteractive(stdin) {
   return Boolean(stdin.isTTY);
+}
+
+const askInputAjv = new Ajv({ allErrors: false, strict: false });
+
+function validateAskResponse(schema, response) {
+  const validator = askInputAjv.compile(schema);
+  const ok = validator(response);
+  if (ok) return;
+  const first = validator.errors?.[0];
+  const pathValue = first?.instancePath || '/';
+  const reason = first?.message ? ` ${first.message}` : '';
+  throw new Error(`ask response failed schema validation at ${pathValue}:${reason}`);
+}
+
+function parseInteractiveCandidates(text) {
+  try {
+    return [JSON.parse(text)];
+  } catch {
+    return [text, { decision: text }];
+  }
 }
 
 export const askCommand = {
@@ -113,11 +135,15 @@ export const askCommand = {
     const raw = await readLineFromStream(ctx.stdin, { timeoutMs: 0 });
     const text = String(raw ?? '').trim();
 
-    // Try to parse as JSON, otherwise treat as freeform decision
-    try {
-      return { output: (async function* () { yield JSON.parse(text); })() };
-    } catch {
-      return { output: (async function* () { yield { decision: text }; })() };
+    let lastError;
+    for (const candidate of parseInteractiveCandidates(text)) {
+      try {
+        validateAskResponse(responseSchema, candidate);
+        return { output: (async function* () { yield candidate; })() };
+      } catch (err) {
+        lastError = err;
+      }
     }
+    throw lastError ?? new Error('ask response failed schema validation');
   },
 };

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -17,13 +17,15 @@ function isInteractive(stdin) {
   return Boolean(stdin.isTTY);
 }
 
-function validateAskResponse(schema, response) {
-  let validator;
+function compileAskValidator(schema) {
   try {
-    validator = sharedAjv.compile(schema);
+    return sharedAjv.compile(schema);
   } catch {
     throw new Error('ask response schema is invalid');
   }
+}
+
+function validateAskResponse(validator, response) {
   const ok = validator(response);
   if (ok) return;
   const first = validator.errors?.[0];
@@ -109,6 +111,7 @@ export const askCommand = {
       }
       responseSchema = parsedSchema;
     }
+    const responseValidator = compileAskValidator(responseSchema);
 
     // Build subject from stdin if requested
     let subject: { text: string } | undefined;
@@ -146,7 +149,7 @@ export const askCommand = {
     let lastError;
     for (const candidate of parseInteractiveCandidates(text)) {
       try {
-        validateAskResponse(responseSchema, candidate);
+        validateAskResponse(responseValidator, candidate);
         return { output: (async function* () { yield candidate; })() };
       } catch (err) {
         lastError = err;

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -1,27 +1,20 @@
-import { randomUUID } from 'node:crypto';
 import { Writable } from 'node:stream';
 import path from 'node:path';
-import { Ajv } from 'ajv';
 
 import { createDefaultRegistry } from '../commands/registry.js';
 import { parsePipeline } from '../parser.js';
 import { decodeResumeToken } from '../resume.js';
 import { runPipeline } from '../runtime.js';
 import { encodeToken } from '../token.js';
-import { readStateJson, writeStateJson, deleteStateJson } from '../state/store.js';
+import { deleteStateJson } from '../state/store.js';
 import { WorkflowResumeArgumentError, runWorkflowFile } from '../workflows/file.js';
-
-type PipelineResumeState = {
-  pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
-  resumeAtIndex: number;
-  items: unknown[];
-  haltType?: 'approval_request' | 'input_request';
-  inputSchema?: unknown;
-  prompt?: string;
-  createdAt: string;
-};
-
-const pipelineInputAjv = new Ajv({ allErrors: false, strict: false });
+import {
+  extractPipelineHalt,
+  loadPipelineResumeState,
+  PipelineResumeState,
+  savePipelineResumeState,
+  validatePipelineInputResponse,
+} from '../pipeline_resume_state.js';
 
 type ToolRunContext = {
   cwd?: string;
@@ -135,9 +128,7 @@ export async function runToolRequest({
       signal: runtime.signal,
     });
 
-    const halted = output.halted && output.items.length === 1 ? output.items[0] : null;
-    const approval = halted?.type === 'approval_request' ? halted : null;
-    const inputRequest = halted?.type === 'input_request' ? halted : null;
+    const { approval, inputRequest } = extractPipelineHalt(output);
 
     if (approval) {
       const stateKey = await savePipelineResumeState(runtime.env, {
@@ -200,11 +191,13 @@ export async function resumeToolRequest({
   token,
   approved,
   response,
+  cancel,
   ctx = {},
 }: {
   token: string;
   approved?: boolean;
   response?: unknown;
+  cancel?: boolean;
   ctx?: ToolRunContext;
 }): Promise<ToolEnvelope> {
   const runtime = createToolContext(ctx);
@@ -216,12 +209,13 @@ export async function resumeToolRequest({
     return errorEnvelope('parse_error', err?.message ?? String(err));
   }
 
-  if (typeof approved === 'boolean' && response !== undefined) {
-    return errorEnvelope('parse_error', 'resume accepts either approved or response, not both');
+  const intentCount = Number(typeof approved === 'boolean') + Number(response !== undefined) + Number(cancel === true);
+  if (intentCount > 1) {
+    return errorEnvelope('parse_error', 'resume accepts only one of approved, response, or cancel');
   }
 
-  if (approved === undefined && response === undefined) {
-    return errorEnvelope('parse_error', 'resume requires approved or response');
+  if (intentCount === 0) {
+    return errorEnvelope('parse_error', 'resume requires approved, response, or cancel');
   }
 
   if (payload.kind === 'workflow-file') {
@@ -232,6 +226,7 @@ export async function resumeToolRequest({
         resume: payload,
         approved,
         response,
+        cancel,
       });
 
       if (output.status === 'needs_approval') {
@@ -258,6 +253,11 @@ export async function resumeToolRequest({
     resumeState = await loadPipelineResumeState(runtime.env, payload.stateKey);
   } catch (err: any) {
     return errorEnvelope('runtime_error', err?.message ?? String(err));
+  }
+
+  if (cancel === true) {
+    await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+    return okEnvelope('cancelled', [], null, null);
   }
 
   if (resumeState.haltType === 'approval_request') {
@@ -321,9 +321,7 @@ export async function resumeToolRequest({
       input,
     });
 
-    const halted2 = output.halted && output.items.length === 1 ? output.items[0] : null;
-    const approval = halted2?.type === 'approval_request' ? halted2 : null;
-    const inputRequest = halted2?.type === 'input_request' ? halted2 : null;
+    const { approval, inputRequest } = extractPipelineHalt(output);
 
     if (approval) {
       const nextStateKey = await savePipelineResumeState(runtime.env, {
@@ -437,40 +435,6 @@ function streamFromItems(items: unknown[]) {
       yield item;
     }
   })();
-}
-
-async function savePipelineResumeState(env: Record<string, string | undefined>, state: PipelineResumeState) {
-  const stateKey = `pipeline_resume_${randomUUID()}`;
-  await writeStateJson({ env, key: stateKey, value: state });
-  return stateKey;
-}
-
-async function loadPipelineResumeState(env: Record<string, string | undefined>, stateKey: string) {
-  const stored = await readStateJson({ env, key: stateKey });
-  if (!stored || typeof stored !== 'object') {
-    throw new Error('Pipeline resume state not found');
-  }
-  const data = stored as Partial<PipelineResumeState>;
-  if (!Array.isArray(data.pipeline)) throw new Error('Invalid pipeline resume state');
-  if (typeof data.resumeAtIndex !== 'number') throw new Error('Invalid pipeline resume state');
-  if (!Array.isArray(data.items)) throw new Error('Invalid pipeline resume state');
-  if (data.haltType !== undefined && !['approval_request', 'input_request'].includes(data.haltType)) {
-    throw new Error('Invalid pipeline resume state');
-  }
-  return data as PipelineResumeState;
-}
-
-function validatePipelineInputResponse(schema: unknown, response: unknown) {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
-    return;
-  }
-  const validator = pipelineInputAjv.compile(schema as object);
-  const ok = validator(response);
-  if (ok) return;
-  const first = validator.errors?.[0];
-  const pathValue = first?.instancePath || '/';
-  const reason = first?.message ? ` ${first.message}` : '';
-  throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
 }
 
 async function resolveWorkflowFile(candidate: string, cwd: string) {

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { Writable } from 'node:stream';
 import path from 'node:path';
+import { Ajv } from 'ajv';
 
 import { createDefaultRegistry } from '../commands/registry.js';
 import { parsePipeline } from '../parser.js';
@@ -14,9 +15,13 @@ type PipelineResumeState = {
   pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
   resumeAtIndex: number;
   items: unknown[];
+  haltType?: 'approval_request' | 'input_request';
+  inputSchema?: unknown;
   prompt?: string;
   createdAt: string;
 };
+
+const pipelineInputAjv = new Ajv({ allErrors: false, strict: false });
 
 type ToolRunContext = {
   cwd?: string;
@@ -33,13 +38,21 @@ type ToolRunContext = {
 type ToolEnvelope = {
   protocolVersion: 1;
   ok: boolean;
-  status?: 'ok' | 'needs_approval' | 'cancelled';
+  status?: 'ok' | 'needs_approval' | 'needs_input' | 'cancelled';
   output?: unknown[];
   requiresApproval?: {
     type?: 'approval_request';
     prompt: string;
     items: unknown[];
     preview?: string;
+    resumeToken?: string;
+  } | null;
+  requiresInput?: {
+    type?: 'input_request';
+    prompt: string;
+    responseSchema: unknown;
+    defaults?: unknown;
+    subject: unknown;
     resumeToken?: string;
   } | null;
   error?: {
@@ -86,12 +99,15 @@ export async function runToolRequest({
       });
 
       if (output.status === 'needs_approval') {
-        return okEnvelope('needs_approval', [], output.requiresApproval ?? null);
+        return okEnvelope('needs_approval', [], output.requiresApproval ?? null, null);
+      }
+      if (output.status === 'needs_input') {
+        return okEnvelope('needs_input', [], null, output.requiresInput ?? null);
       }
       if (output.status === 'cancelled') {
-        return okEnvelope('cancelled', [], null);
+        return okEnvelope('cancelled', [], null, null);
       }
-      return okEnvelope('ok', output.output, null);
+      return okEnvelope('ok', output.output, null, null);
     } catch (err: any) {
       return errorEnvelope('runtime_error', err?.message ?? String(err));
     }
@@ -119,15 +135,16 @@ export async function runToolRequest({
       signal: runtime.signal,
     });
 
-    const approval = output.halted && output.items.length === 1 && output.items[0]?.type === 'approval_request'
-      ? output.items[0]
-      : null;
+    const halted = output.halted && output.items.length === 1 ? output.items[0] : null;
+    const approval = halted?.type === 'approval_request' ? halted : null;
+    const inputRequest = halted?.type === 'input_request' ? halted : null;
 
     if (approval) {
       const stateKey = await savePipelineResumeState(runtime.env, {
         pipeline: parsed,
         resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
         items: approval.items,
+        haltType: 'approval_request',
         prompt: approval.prompt,
         createdAt: new Date().toISOString(),
       });
@@ -142,10 +159,38 @@ export async function runToolRequest({
       return okEnvelope('needs_approval', [], {
         ...approval,
         resumeToken,
+      }, null);
+    }
+
+    if (inputRequest) {
+      const stateKey = await savePipelineResumeState(runtime.env, {
+        pipeline: parsed,
+        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
+        items: inputRequest.items ?? [],
+        haltType: 'input_request',
+        inputSchema: inputRequest.responseSchema,
+        prompt: inputRequest.prompt,
+        createdAt: new Date().toISOString(),
+      });
+
+      const resumeToken = encodeToken({
+        protocolVersion: 1,
+        v: 1,
+        kind: 'pipeline-resume',
+        stateKey,
+      });
+
+      return okEnvelope('needs_input', [], null, {
+        type: 'input_request',
+        prompt: inputRequest.prompt,
+        responseSchema: inputRequest.responseSchema,
+        defaults: inputRequest.defaults,
+        subject: inputRequest.subject,
+        resumeToken,
       });
     }
 
-    return okEnvelope('ok', output.items, null);
+    return okEnvelope('ok', output.items, null, null);
   } catch (err: any) {
     return errorEnvelope('runtime_error', err?.message ?? String(err));
   }
@@ -154,10 +199,12 @@ export async function runToolRequest({
 export async function resumeToolRequest({
   token,
   approved,
+  response,
   ctx = {},
 }: {
   token: string;
-  approved: boolean;
+  approved?: boolean;
+  response?: unknown;
   ctx?: ToolRunContext;
 }): Promise<ToolEnvelope> {
   const runtime = createToolContext(ctx);
@@ -169,32 +216,41 @@ export async function resumeToolRequest({
     return errorEnvelope('parse_error', err?.message ?? String(err));
   }
 
-  if (!approved) {
-    if (payload.kind === 'workflow-file' && payload.stateKey) {
-      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-    }
-    if (payload.kind === 'pipeline-resume' && payload.stateKey) {
-      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-    }
-    return okEnvelope('cancelled', [], null);
+  if (typeof approved === 'boolean' && response !== undefined) {
+    return errorEnvelope('parse_error', 'resume accepts either approved or response, not both');
+  }
+
+  if (approved === undefined && response === undefined) {
+    return errorEnvelope('parse_error', 'resume requires approved or response');
   }
 
   if (payload.kind === 'workflow-file') {
+    if (approved === false) {
+      if (payload.stateKey) {
+        await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+      }
+      return okEnvelope('cancelled', [], null, null);
+    }
+
     try {
       const output = await runWorkflowFile({
         filePath: payload.filePath,
         ctx: runtime,
         resume: payload,
-        approved: true,
+        approved,
+        response,
       });
 
       if (output.status === 'needs_approval') {
-        return okEnvelope('needs_approval', [], output.requiresApproval ?? null);
+        return okEnvelope('needs_approval', [], output.requiresApproval ?? null, null);
+      }
+      if (output.status === 'needs_input') {
+        return okEnvelope('needs_input', [], null, output.requiresInput ?? null);
       }
       if (output.status === 'cancelled') {
-        return okEnvelope('cancelled', [], null);
+        return okEnvelope('cancelled', [], null, null);
       }
-      return okEnvelope('ok', output.output, null);
+      return okEnvelope('ok', output.output, null, null);
     } catch (err: any) {
       return errorEnvelope('runtime_error', err?.message ?? String(err));
     }
@@ -207,8 +263,51 @@ export async function resumeToolRequest({
     return errorEnvelope('runtime_error', err?.message ?? String(err));
   }
 
+  if (resumeState.haltType === 'approval_request') {
+    if (response !== undefined) {
+      return errorEnvelope('parse_error', 'pipeline approval resumes require approved=true|false');
+    }
+    if (typeof approved !== 'boolean') {
+      return errorEnvelope('parse_error', 'pipeline approval resumes require approved=true|false');
+    }
+    if (approved === false) {
+      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+      return okEnvelope('cancelled', [], null, null);
+    }
+  }
+
+  if (resumeState.haltType === 'input_request') {
+    if (approved !== undefined) {
+      return errorEnvelope('parse_error', 'pipeline input resumes require response');
+    }
+    if (response === undefined) {
+      return errorEnvelope('parse_error', 'pipeline input resumes require response');
+    }
+    try {
+      validatePipelineInputResponse(resumeState.inputSchema, response);
+    } catch (err: any) {
+      return errorEnvelope('parse_error', err?.message ?? String(err));
+    }
+  }
+
+  if (!resumeState.haltType) {
+    if (response !== undefined) {
+      return errorEnvelope('parse_error', 'legacy pipeline resumes require approved=true|false');
+    }
+    if (typeof approved !== 'boolean') {
+      return errorEnvelope('parse_error', 'legacy pipeline resumes require approved=true|false');
+    }
+    if (approved === false) {
+      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+      return okEnvelope('cancelled', [], null, null);
+    }
+  }
+
   const remaining = resumeState.pipeline.slice(resumeState.resumeAtIndex);
-  const input = streamFromItems(resumeState.items);
+  const inputItems = resumeState.haltType === 'input_request'
+    ? [response]
+    : resumeState.items;
+  const input = streamFromItems(inputItems);
 
   try {
     const output = await runPipeline({
@@ -225,15 +324,16 @@ export async function resumeToolRequest({
       input,
     });
 
-    const approval = output.halted && output.items.length === 1 && output.items[0]?.type === 'approval_request'
-      ? output.items[0]
-      : null;
+    const halted2 = output.halted && output.items.length === 1 ? output.items[0] : null;
+    const approval = halted2?.type === 'approval_request' ? halted2 : null;
+    const inputRequest = halted2?.type === 'input_request' ? halted2 : null;
 
     if (approval) {
       const nextStateKey = await savePipelineResumeState(runtime.env, {
         pipeline: remaining,
         resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
         items: approval.items,
+        haltType: 'approval_request',
         prompt: approval.prompt,
         createdAt: new Date().toISOString(),
       });
@@ -249,11 +349,40 @@ export async function resumeToolRequest({
       return okEnvelope('needs_approval', [], {
         ...approval,
         resumeToken,
+      }, null);
+    }
+
+    if (inputRequest) {
+      const nextStateKey = await savePipelineResumeState(runtime.env, {
+        pipeline: remaining,
+        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
+        items: inputRequest.items ?? [],
+        haltType: 'input_request',
+        inputSchema: inputRequest.responseSchema,
+        prompt: inputRequest.prompt,
+        createdAt: new Date().toISOString(),
+      });
+      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+
+      const resumeToken = encodeToken({
+        protocolVersion: 1,
+        v: 1,
+        kind: 'pipeline-resume',
+        stateKey: nextStateKey,
+      });
+
+      return okEnvelope('needs_input', [], null, {
+        type: 'input_request',
+        prompt: inputRequest.prompt,
+        responseSchema: inputRequest.responseSchema,
+        defaults: inputRequest.defaults,
+        subject: inputRequest.subject,
+        resumeToken,
       });
     }
 
     await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-    return okEnvelope('ok', output.items, null);
+    return okEnvelope('ok', output.items, null, null);
   } catch (err: any) {
     return errorEnvelope('runtime_error', err?.message ?? String(err));
   }
@@ -281,13 +410,19 @@ export function createCaptureStream() {
   });
 }
 
-function okEnvelope(status: 'ok' | 'needs_approval' | 'cancelled', output: unknown[], requiresApproval: ToolEnvelope['requiresApproval']) {
+function okEnvelope(
+  status: 'ok' | 'needs_approval' | 'needs_input' | 'cancelled',
+  output: unknown[],
+  requiresApproval: ToolEnvelope['requiresApproval'],
+  requiresInput: ToolEnvelope['requiresInput'],
+) {
   return {
     protocolVersion: 1 as const,
     ok: true,
     status,
     output,
     requiresApproval,
+    requiresInput,
   };
 }
 
@@ -322,7 +457,23 @@ async function loadPipelineResumeState(env: Record<string, string | undefined>, 
   if (!Array.isArray(data.pipeline)) throw new Error('Invalid pipeline resume state');
   if (typeof data.resumeAtIndex !== 'number') throw new Error('Invalid pipeline resume state');
   if (!Array.isArray(data.items)) throw new Error('Invalid pipeline resume state');
+  if (data.haltType !== undefined && !['approval_request', 'input_request'].includes(data.haltType)) {
+    throw new Error('Invalid pipeline resume state');
+  }
   return data as PipelineResumeState;
+}
+
+function validatePipelineInputResponse(schema: unknown, response: unknown) {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return;
+  }
+  const validator = pipelineInputAjv.compile(schema as object);
+  const ok = validator(response);
+  if (ok) return;
+  const first = validator.errors?.[0];
+  const pathValue = first?.instancePath || '/';
+  const reason = first?.message ? ` ${first.message}` : '';
+  throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
 }
 
 async function resolveWorkflowFile(candidate: string, cwd: string) {

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -5,14 +5,12 @@ import { createDefaultRegistry } from '../commands/registry.js';
 import { parsePipeline } from '../parser.js';
 import { decodeResumeToken } from '../resume.js';
 import { runPipeline } from '../runtime.js';
-import { encodeToken } from '../token.js';
 import { deleteStateJson } from '../state/store.js';
 import { WorkflowResumeArgumentError, runWorkflowFile } from '../workflows/file.js';
 import {
-  extractPipelineHalt,
+  finalizePipelineToolRun,
   loadPipelineResumeState,
   PipelineResumeState,
-  savePipelineResumeState,
   validatePipelineInputResponse,
 } from '../pipeline_resume_state.js';
 
@@ -45,7 +43,7 @@ type ToolEnvelope = {
     prompt: string;
     responseSchema: unknown;
     defaults?: unknown;
-    subject: unknown;
+    subject?: unknown;
     resumeToken?: string;
   } | null;
   error?: {
@@ -127,61 +125,17 @@ export async function runToolRequest({
       llmAdapters: runtime.llmAdapters,
       signal: runtime.signal,
     });
-
-    const { approval, inputRequest } = extractPipelineHalt(output);
-
-    if (approval) {
-      const stateKey = await savePipelineResumeState(runtime.env, {
-        pipeline: parsed,
-        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-        items: approval.items,
-        haltType: 'approval_request',
-        prompt: approval.prompt,
-        createdAt: new Date().toISOString(),
-      });
-
-      const resumeToken = encodeToken({
-        protocolVersion: 1,
-        v: 1,
-        kind: 'pipeline-resume',
-        stateKey,
-      });
-
-      return okEnvelope('needs_approval', [], {
-        ...approval,
-        resumeToken,
-      }, null);
-    }
-
-    if (inputRequest) {
-      const stateKey = await savePipelineResumeState(runtime.env, {
-        pipeline: parsed,
-        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-        items: inputRequest.items ?? [],
-        haltType: 'input_request',
-        inputSchema: inputRequest.responseSchema,
-        prompt: inputRequest.prompt,
-        createdAt: new Date().toISOString(),
-      });
-
-      const resumeToken = encodeToken({
-        protocolVersion: 1,
-        v: 1,
-        kind: 'pipeline-resume',
-        stateKey,
-      });
-
-      return okEnvelope('needs_input', [], null, {
-        type: 'input_request',
-        prompt: inputRequest.prompt,
-        responseSchema: inputRequest.responseSchema,
-        defaults: inputRequest.defaults,
-        subject: inputRequest.subject,
-        resumeToken,
-      });
-    }
-
-    return okEnvelope('ok', output.items, null, null);
+    const finalized = await finalizePipelineToolRun({
+      env: runtime.env,
+      pipeline: parsed,
+      output,
+    });
+    return okEnvelope(
+      finalized.status,
+      finalized.output,
+      finalized.requiresApproval,
+      finalized.requiresInput,
+    );
   } catch (err: any) {
     return errorEnvelope('runtime_error', err?.message ?? String(err));
   }
@@ -320,64 +274,18 @@ export async function resumeToolRequest({
       signal: runtime.signal,
       input,
     });
-
-    const { approval, inputRequest } = extractPipelineHalt(output);
-
-    if (approval) {
-      const nextStateKey = await savePipelineResumeState(runtime.env, {
-        pipeline: remaining,
-        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-        items: approval.items,
-        haltType: 'approval_request',
-        prompt: approval.prompt,
-        createdAt: new Date().toISOString(),
-      });
-      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-
-      const resumeToken = encodeToken({
-        protocolVersion: 1,
-        v: 1,
-        kind: 'pipeline-resume',
-        stateKey: nextStateKey,
-      });
-
-      return okEnvelope('needs_approval', [], {
-        ...approval,
-        resumeToken,
-      }, null);
-    }
-
-    if (inputRequest) {
-      const nextStateKey = await savePipelineResumeState(runtime.env, {
-        pipeline: remaining,
-        resumeAtIndex: (output.haltedAt?.index ?? -1) + 1,
-        items: inputRequest.items ?? [],
-        haltType: 'input_request',
-        inputSchema: inputRequest.responseSchema,
-        prompt: inputRequest.prompt,
-        createdAt: new Date().toISOString(),
-      });
-      await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-
-      const resumeToken = encodeToken({
-        protocolVersion: 1,
-        v: 1,
-        kind: 'pipeline-resume',
-        stateKey: nextStateKey,
-      });
-
-      return okEnvelope('needs_input', [], null, {
-        type: 'input_request',
-        prompt: inputRequest.prompt,
-        responseSchema: inputRequest.responseSchema,
-        defaults: inputRequest.defaults,
-        subject: inputRequest.subject,
-        resumeToken,
-      });
-    }
-
-    await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-    return okEnvelope('ok', output.items, null, null);
+    const finalized = await finalizePipelineToolRun({
+      env: runtime.env,
+      pipeline: remaining,
+      output,
+      previousStateKey: payload.stateKey,
+    });
+    return okEnvelope(
+      finalized.status,
+      finalized.output,
+      finalized.requiresApproval,
+      finalized.requiresInput,
+    );
   } catch (err: any) {
     return errorEnvelope('runtime_error', err?.message ?? String(err));
   }

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -225,13 +225,6 @@ export async function resumeToolRequest({
   }
 
   if (payload.kind === 'workflow-file') {
-    if (approved === false) {
-      if (payload.stateKey) {
-        await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-      }
-      return okEnvelope('cancelled', [], null, null);
-    }
-
     try {
       const output = await runWorkflowFile({
         filePath: payload.filePath,
@@ -252,7 +245,11 @@ export async function resumeToolRequest({
       }
       return okEnvelope('ok', output.output, null, null);
     } catch (err: any) {
-      return errorEnvelope('runtime_error', err?.message ?? String(err));
+      const message = err?.message ?? String(err);
+      if (isWorkflowResumeArgumentError(message)) {
+        return errorEnvelope('parse_error', message);
+      }
+      return errorEnvelope('runtime_error', message);
     }
   }
 
@@ -474,6 +471,11 @@ function validatePipelineInputResponse(schema: unknown, response: unknown) {
   const pathValue = first?.instancePath || '/';
   const reason = first?.message ? ` ${first.message}` : '';
   throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
+}
+
+function isWorkflowResumeArgumentError(message: string) {
+  return message.includes('Workflow resume requires --approve yes|no for approval requests')
+    || message.includes('Workflow resume requires --response-json for input requests');
 }
 
 async function resolveWorkflowFile(candidate: string, cwd: string) {

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -9,7 +9,7 @@ import { decodeResumeToken } from '../resume.js';
 import { runPipeline } from '../runtime.js';
 import { encodeToken } from '../token.js';
 import { readStateJson, writeStateJson, deleteStateJson } from '../state/store.js';
-import { runWorkflowFile } from '../workflows/file.js';
+import { WorkflowResumeArgumentError, runWorkflowFile } from '../workflows/file.js';
 
 type PipelineResumeState = {
   pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
@@ -246,7 +246,7 @@ export async function resumeToolRequest({
       return okEnvelope('ok', output.output, null, null);
     } catch (err: any) {
       const message = err?.message ?? String(err);
-      if (isWorkflowResumeArgumentError(message)) {
+      if (err instanceof WorkflowResumeArgumentError) {
         return errorEnvelope('parse_error', message);
       }
       return errorEnvelope('runtime_error', message);
@@ -471,11 +471,6 @@ function validatePipelineInputResponse(schema: unknown, response: unknown) {
   const pathValue = first?.instancePath || '/';
   const reason = first?.message ? ` ${first.message}` : '';
   throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
-}
-
-function isWorkflowResumeArgumentError(message: string) {
-  return message.includes('Workflow resume requires --approve yes|no for approval requests')
-    || message.includes('Workflow resume requires --response-json for input requests');
 }
 
 async function resolveWorkflowFile(candidate: string, cwd: string) {

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
-import { readStateJson, writeStateJson } from './state/store.js';
+import { encodeToken } from './token.js';
+import { deleteStateJson, readStateJson, writeStateJson } from './state/store.js';
 import { sharedAjv } from './validation.js';
 
 export type PipelineResumeState = {
@@ -25,9 +26,48 @@ export type PipelineInputRequest = {
   prompt: string;
   responseSchema: unknown;
   defaults?: unknown;
-  subject: unknown;
+  subject?: unknown;
   items?: unknown[];
 };
+
+export type PipelineRunOutput = {
+  items: unknown[];
+  halted?: boolean;
+  haltedAt?: { index: number } | null;
+};
+
+export type PipelineToolRunResolution =
+  | {
+    status: 'needs_approval';
+    output: [];
+    requiresApproval: {
+      type: 'approval_request';
+      prompt: string;
+      items: unknown[];
+      preview?: string;
+      resumeToken: string;
+    };
+    requiresInput: null;
+  }
+  | {
+    status: 'needs_input';
+    output: [];
+    requiresApproval: null;
+    requiresInput: {
+      type: 'input_request';
+      prompt: string;
+      responseSchema: unknown;
+      defaults?: unknown;
+      subject?: unknown;
+      resumeToken: string;
+    };
+  }
+  | {
+    status: 'ok';
+    output: unknown[];
+    requiresApproval: null;
+    requiresInput: null;
+  };
 
 export function extractPipelineHalt(output: {
   halted?: boolean;
@@ -43,6 +83,87 @@ export function extractPipelineHalt(output: {
     ? halted as unknown as PipelineInputRequest
     : null;
   return { approval, inputRequest };
+}
+
+export async function finalizePipelineToolRun(params: {
+  env: Record<string, string | undefined>;
+  pipeline: PipelineResumeState['pipeline'];
+  output: PipelineRunOutput;
+  previousStateKey?: string;
+}): Promise<PipelineToolRunResolution> {
+  const { approval, inputRequest } = extractPipelineHalt(params.output);
+  if (approval) {
+    const nextStateKey = await savePipelineResumeState(params.env, {
+      pipeline: params.pipeline,
+      resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
+      items: approval.items,
+      haltType: 'approval_request',
+      prompt: approval.prompt,
+      createdAt: new Date().toISOString(),
+    });
+    if (params.previousStateKey) {
+      await deleteStateJson({ env: params.env, key: params.previousStateKey });
+    }
+    const resumeToken = encodeToken({
+      protocolVersion: 1,
+      v: 1,
+      kind: 'pipeline-resume',
+      stateKey: nextStateKey,
+    });
+    return {
+      status: 'needs_approval',
+      output: [],
+      requiresApproval: {
+        ...approval,
+        resumeToken,
+      },
+      requiresInput: null,
+    };
+  }
+
+  if (inputRequest) {
+    const nextStateKey = await savePipelineResumeState(params.env, {
+      pipeline: params.pipeline,
+      resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
+      items: inputRequest.items ?? [],
+      haltType: 'input_request',
+      inputSchema: inputRequest.responseSchema,
+      prompt: inputRequest.prompt,
+      createdAt: new Date().toISOString(),
+    });
+    if (params.previousStateKey) {
+      await deleteStateJson({ env: params.env, key: params.previousStateKey });
+    }
+    const resumeToken = encodeToken({
+      protocolVersion: 1,
+      v: 1,
+      kind: 'pipeline-resume',
+      stateKey: nextStateKey,
+    });
+    return {
+      status: 'needs_input',
+      output: [],
+      requiresApproval: null,
+      requiresInput: {
+        type: 'input_request',
+        prompt: inputRequest.prompt,
+        responseSchema: inputRequest.responseSchema,
+        ...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : {}),
+        ...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : {}),
+        resumeToken,
+      },
+    };
+  }
+
+  if (params.previousStateKey) {
+    await deleteStateJson({ env: params.env, key: params.previousStateKey });
+  }
+  return {
+    status: 'ok',
+    output: params.output.items,
+    requiresApproval: null,
+    requiresInput: null,
+  };
 }
 
 export async function savePipelineResumeState(
@@ -73,10 +194,15 @@ export async function loadPipelineResumeState(
 }
 
 export function validatePipelineInputResponse(schema: unknown, response: unknown) {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+  if (schema === undefined) {
     return;
   }
-  const validator = sharedAjv.compile(schema as object);
+  let validator;
+  try {
+    validator = sharedAjv.compile(schema as any);
+  } catch {
+    throw new Error('pipeline input response schema is invalid');
+  }
   const ok = validator(response);
   if (ok) return;
   const first = validator.errors?.[0];

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -195,7 +195,7 @@ export async function loadPipelineResumeState(
 
 export function validatePipelineInputResponse(schema: unknown, response: unknown) {
   if (schema === undefined) {
-    return;
+    throw new Error('pipeline input response schema is missing');
   }
   let validator;
   try {

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto';
+
+import { readStateJson, writeStateJson } from './state/store.js';
+import { sharedAjv } from './validation.js';
+
+export type PipelineResumeState = {
+  pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
+  resumeAtIndex: number;
+  items: unknown[];
+  haltType?: 'approval_request' | 'input_request';
+  inputSchema?: unknown;
+  prompt?: string;
+  createdAt: string;
+};
+
+export type PipelineApprovalRequest = {
+  type: 'approval_request';
+  prompt: string;
+  items: unknown[];
+  preview?: string;
+};
+
+export type PipelineInputRequest = {
+  type: 'input_request';
+  prompt: string;
+  responseSchema: unknown;
+  defaults?: unknown;
+  subject: unknown;
+  items?: unknown[];
+};
+
+export function extractPipelineHalt(output: {
+  halted?: boolean;
+  items: unknown[];
+}) {
+  const halted = output.halted && output.items.length === 1
+    ? output.items[0] as Record<string, unknown>
+    : null;
+  const approval = halted?.type === 'approval_request'
+    ? halted as unknown as PipelineApprovalRequest
+    : null;
+  const inputRequest = halted?.type === 'input_request'
+    ? halted as unknown as PipelineInputRequest
+    : null;
+  return { approval, inputRequest };
+}
+
+export async function savePipelineResumeState(
+  env: Record<string, string | undefined>,
+  state: PipelineResumeState,
+) {
+  const stateKey = `pipeline_resume_${randomUUID()}`;
+  await writeStateJson({ env, key: stateKey, value: state });
+  return stateKey;
+}
+
+export async function loadPipelineResumeState(
+  env: Record<string, string | undefined>,
+  stateKey: string,
+) {
+  const stored = await readStateJson({ env, key: stateKey });
+  if (!stored || typeof stored !== 'object') {
+    throw new Error('Pipeline resume state not found');
+  }
+  const data = stored as Partial<PipelineResumeState>;
+  if (!Array.isArray(data.pipeline)) throw new Error('Invalid pipeline resume state');
+  if (typeof data.resumeAtIndex !== 'number') throw new Error('Invalid pipeline resume state');
+  if (!Array.isArray(data.items)) throw new Error('Invalid pipeline resume state');
+  if (data.haltType !== undefined && !['approval_request', 'input_request'].includes(data.haltType)) {
+    throw new Error('Invalid pipeline resume state');
+  }
+  return data as PipelineResumeState;
+}
+
+export function validatePipelineInputResponse(schema: unknown, response: unknown) {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return;
+  }
+  const validator = sharedAjv.compile(schema as object);
+  const ok = validator(response);
+  if (ok) return;
+  const first = validator.errors?.[0];
+  const pathValue = first?.instancePath || '/';
+  const reason = first?.message ? ` ${first.message}` : '';
+  throw new Error(`pipeline input response failed schema validation at ${pathValue}:${reason}`);
+}

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -125,7 +125,8 @@ export async function finalizePipelineToolRun(params: {
     const nextStateKey = await savePipelineResumeState(params.env, {
       pipeline: params.pipeline,
       resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
-      items: inputRequest.items ?? [],
+      // Input resumes inject the submitted response as next input; halt items are unused.
+      items: [],
       haltType: 'input_request',
       inputSchema: inputRequest.responseSchema,
       prompt: inputRequest.prompt,

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -9,7 +9,7 @@ export type PipelineResumePayload = {
 };
 
 export function parseResumeArgs(argv) {
-  const args = { decision: null, token: null };
+  const args = { decision: null, token: null, responseJson: null };
 
   for (let i = 0; i < argv.length; i++) {
     const tok = argv[i];
@@ -35,15 +35,36 @@ export function parseResumeArgs(argv) {
       args.decision = tok.slice('--decision='.length);
       continue;
     }
+    if (tok === '--response-json') {
+      args.responseJson = argv[i + 1];
+      i++;
+      continue;
+    }
+    if (tok.startsWith('--response-json=')) {
+      args.responseJson = tok.slice('--response-json='.length);
+      continue;
+    }
   }
 
   if (!args.token) throw new Error('resume requires --token');
-  if (!args.decision) throw new Error('resume requires --approve yes|no');
+  if (args.decision && args.responseJson) {
+    throw new Error('resume accepts either --approve or --response-json');
+  }
+  if (!args.decision && !args.responseJson) {
+    throw new Error('resume requires --approve yes|no or --response-json');
+  }
 
-  const decision = String(args.decision).toLowerCase();
-  if (!['yes', 'y', 'no', 'n'].includes(decision)) throw new Error('resume --approve must be yes or no');
+  if (args.decision) {
+    const decision = String(args.decision).toLowerCase();
+    if (!['yes', 'y', 'no', 'n'].includes(decision)) throw new Error('resume --approve must be yes or no');
+    return { token: String(args.token), approved: decision === 'yes' || decision === 'y' };
+  }
 
-  return { token: String(args.token), approved: decision === 'yes' || decision === 'y' };
+  try {
+    return { token: String(args.token), response: JSON.parse(String(args.responseJson)) };
+  } catch {
+    throw new Error('resume --response-json must be valid JSON');
+  }
 }
 
 export function decodeResumeToken(token) {

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -9,7 +9,7 @@ export type PipelineResumePayload = {
 };
 
 export function parseResumeArgs(argv) {
-  const args = { decision: null, token: null, responseJson: null };
+  const args = { decision: null, token: null, responseJson: null, cancel: false };
 
   for (let i = 0; i < argv.length; i++) {
     const tok = argv[i];
@@ -44,14 +44,39 @@ export function parseResumeArgs(argv) {
       args.responseJson = tok.slice('--response-json='.length);
       continue;
     }
+    if (tok === '--cancel') {
+      const next = argv[i + 1];
+      if (typeof next === 'string' && !next.startsWith('--')) {
+        const parsed = parseBooleanArg(next);
+        if (parsed === null) {
+          throw new Error('resume --cancel must be true or false');
+        }
+        args.cancel = parsed;
+        i++;
+        continue;
+      }
+      args.cancel = true;
+      continue;
+    }
+    if (tok.startsWith('--cancel=')) {
+      const parsed = parseBooleanArg(tok.slice('--cancel='.length));
+      if (parsed === null) throw new Error('resume --cancel must be true or false');
+      args.cancel = parsed;
+      continue;
+    }
   }
 
   if (!args.token) throw new Error('resume requires --token');
-  if (args.decision && args.responseJson) {
-    throw new Error('resume accepts either --approve or --response-json');
+  const intentCount = Number(Boolean(args.decision)) + Number(args.responseJson !== null) + Number(args.cancel);
+  if (intentCount > 1) {
+    throw new Error('resume accepts only one of --approve, --response-json, or --cancel');
   }
-  if (!args.decision && !args.responseJson) {
-    throw new Error('resume requires --approve yes|no or --response-json');
+  if (intentCount === 0) {
+    throw new Error('resume requires --approve yes|no, --response-json, or --cancel');
+  }
+
+  if (args.cancel) {
+    return { token: String(args.token), cancel: true };
   }
 
   if (args.decision) {
@@ -65,6 +90,13 @@ export function parseResumeArgs(argv) {
   } catch {
     throw new Error('resume --response-json must be valid JSON');
   }
+}
+
+function parseBooleanArg(value: string): boolean | null {
+  const raw = String(value ?? '').trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y'].includes(raw)) return true;
+  if (['0', 'false', 'no', 'n'].includes(raw)) return false;
+  return null;
 }
 
 export function decodeResumeToken(token) {

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -1,8 +1,17 @@
 import { runPipelineInternal } from './runtime.js';
 import { encodeToken, decodeToken } from './token.js';
-import { Ajv } from 'ajv';
+import { sharedAjv } from '../validation.js';
 
-const inputAjv = new Ajv({ allErrors: false, strict: false });
+type SdkResumePayload = {
+  protocolVersion: 1;
+  v: 1;
+  stageIndex?: number;
+  resumeAtIndex: number;
+  items?: unknown[];
+  prompt?: string;
+  inputSchema?: unknown;
+  inputSubject?: unknown;
+};
 
 /**
  * @typedef {Object} LobsterResult
@@ -205,17 +214,34 @@ export class Lobster {
    * @param {Object} options
    * @param {boolean} [options.approved] - Whether the approval was granted
    * @param {Object} [options.response] - Structured input response
+   * @param {boolean} [options.cancel] - Cancel a pending approval/input request
    * @returns {Promise<LobsterResult>}
    */
-  async resume(token, { approved, response }) {
-    if (typeof approved === 'boolean' && response !== undefined) {
-      throw new Error('resume accepts either approved or response, not both');
+  async resume(
+    token: string,
+    options: { approved?: boolean; response?: unknown; cancel?: boolean } = {},
+  ) {
+    const { approved, response, cancel } = options;
+    const intentCount = Number(typeof approved === 'boolean') + Number(response !== undefined) + Number(cancel === true);
+    if (intentCount > 1) {
+      throw new Error('resume accepts only one of approved, response, or cancel');
     }
-    if (approved === undefined && response === undefined) {
-      throw new Error('resume requires approved or response');
+    if (intentCount === 0) {
+      throw new Error('resume requires approved, response, or cancel');
     }
 
-    const payload = decodeToken(token);
+    const payload = decodeSdkResumePayload(token);
+
+    if (cancel === true) {
+      return {
+        ok: true,
+        status: 'cancelled',
+        output: [],
+        requiresApproval: null,
+        requiresInput: null,
+      };
+    }
+
     const expectsInput = Boolean(payload.inputSchema && typeof payload.inputSchema === 'object');
     if (expectsInput) {
       if (approved !== undefined) {
@@ -249,7 +275,7 @@ export class Lobster {
       if (!schema || typeof schema !== 'object') {
         throw new Error('resume token does not support input responses');
       }
-      const validator = inputAjv.compile(schema);
+      const validator = sharedAjv.compile(schema);
       const ok = validator(response);
       if (!ok) {
         const first = validator.errors?.[0];
@@ -358,4 +384,22 @@ export class Lobster {
     cloned.#meta = this.#meta ? { ...this.#meta } : null;
     return cloned;
   }
+}
+
+function decodeSdkResumePayload(token: string): SdkResumePayload {
+  const payload = decodeToken(token);
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid token');
+  }
+  const data = payload as Record<string, unknown>;
+  if (data.protocolVersion !== 1 || data.v !== 1) {
+    throw new Error('Invalid token');
+  }
+  if (typeof data.resumeAtIndex !== 'number' || !Number.isInteger(data.resumeAtIndex) || data.resumeAtIndex < 0) {
+    throw new Error('Invalid token');
+  }
+  if (data.items !== undefined && !Array.isArray(data.items)) {
+    throw new Error('Invalid token');
+  }
+  return data as unknown as SdkResumePayload;
 }

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -242,7 +242,7 @@ export class Lobster {
       };
     }
 
-    const expectsInput = Boolean(payload.inputSchema && typeof payload.inputSchema === 'object');
+    const expectsInput = payload.inputSchema !== undefined;
     if (expectsInput) {
       if (approved !== undefined) {
         throw new Error('resume token expects an input response, not approved');
@@ -272,10 +272,15 @@ export class Lobster {
     let resumeItems = payload.items ?? [];
     if (response !== undefined) {
       const schema = payload.inputSchema;
-      if (!schema || typeof schema !== 'object') {
+      if (schema === undefined) {
         throw new Error('resume token does not support input responses');
       }
-      const validator = sharedAjv.compile(schema);
+      let validator;
+      try {
+        validator = sharedAjv.compile(schema as any);
+      } catch {
+        throw new Error('resume token input schema is invalid');
+      }
       const ok = validator(response);
       if (!ok) {
         const first = validator.errors?.[0];

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -1,15 +1,23 @@
 import { runPipelineInternal } from './runtime.js';
 import { encodeToken, decodeToken } from './token.js';
+import { Ajv } from 'ajv';
+
+const inputAjv = new Ajv({ allErrors: false, strict: false });
 
 /**
  * @typedef {Object} LobsterResult
  * @property {boolean} ok - Whether the workflow completed successfully
- * @property {'ok' | 'needs_approval' | 'cancelled' | 'error'} status - Workflow status
+ * @property {'ok' | 'needs_approval' | 'needs_input' | 'cancelled' | 'error'} status - Workflow status
  * @property {any[]} output - Output items from the workflow
  * @property {Object|null} requiresApproval - Approval request if halted
  * @property {string} [requiresApproval.prompt] - Approval prompt
  * @property {any[]} [requiresApproval.items] - Items pending approval
  * @property {string} [requiresApproval.resumeToken] - Token to resume workflow
+ * @property {Object|null} requiresInput - Input request if halted
+ * @property {string} [requiresInput.prompt] - Input prompt
+ * @property {Object} [requiresInput.responseSchema] - JSON Schema for response
+ * @property {any} [requiresInput.subject] - Subject shown to the human
+ * @property {string} [requiresInput.resumeToken] - Token to resume workflow
  * @property {Object} [error] - Error details if failed
  */
 
@@ -139,6 +147,33 @@ export class Lobster {
             items: approval.items,
             resumeToken,
           },
+          requiresInput: null,
+        };
+      }
+
+      if (result.halted && result.items.length === 1 && result.items[0]?.type === 'input_request') {
+        const input = result.items[0];
+        const resumeToken = encodeToken({
+          protocolVersion: 1,
+          v: 1,
+          stageIndex: result.haltedAt?.index ?? -1,
+          resumeAtIndex: (result.haltedAt?.index ?? -1) + 1,
+          items: [],
+          inputSchema: input.responseSchema,
+          inputSubject: input.subject,
+        });
+        return {
+          ok: true,
+          status: 'needs_input',
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            prompt: input.prompt,
+            responseSchema: input.responseSchema,
+            defaults: input.defaults,
+            subject: input.subject,
+            resumeToken,
+          },
         };
       }
 
@@ -147,6 +182,7 @@ export class Lobster {
         status: 'ok',
         output: result.items,
         requiresApproval: null,
+        requiresInput: null,
       };
     } catch (err) {
       return {
@@ -154,6 +190,7 @@ export class Lobster {
         status: 'error',
         output: [],
         requiresApproval: null,
+        requiresInput: null,
         error: {
           type: 'runtime_error',
           message: err?.message ?? String(err),
@@ -163,25 +200,63 @@ export class Lobster {
   }
 
   /**
-   * Resume a halted workflow after approval
+   * Resume a halted workflow after approval or input response
    * @param {string} token - Resume token from previous run
    * @param {Object} options
-   * @param {boolean} options.approved - Whether the approval was granted
+   * @param {boolean} [options.approved] - Whether the approval was granted
+   * @param {Object} [options.response] - Structured input response
    * @returns {Promise<LobsterResult>}
    */
-  async resume(token, { approved }) {
-    if (!approved) {
-      return {
-        ok: true,
-        status: 'cancelled',
-        output: [],
-        requiresApproval: null,
-      };
+  async resume(token, { approved, response }) {
+    if (typeof approved === 'boolean' && response !== undefined) {
+      throw new Error('resume accepts either approved or response, not both');
+    }
+    if (approved === undefined && response === undefined) {
+      throw new Error('resume requires approved or response');
     }
 
     const payload = decodeToken(token);
+    const expectsInput = Boolean(payload.inputSchema && typeof payload.inputSchema === 'object');
+    if (expectsInput) {
+      if (approved !== undefined) {
+        throw new Error('resume token expects an input response, not approved');
+      }
+      if (response === undefined) {
+        throw new Error('resume token expects response');
+      }
+    } else {
+      if (response !== undefined) {
+        throw new Error('resume token expects approved=true|false, not response');
+      }
+      if (typeof approved !== 'boolean') {
+        throw new Error('resume token expects approved=true|false');
+      }
+      if (approved === false) {
+        return {
+          ok: true,
+          status: 'cancelled',
+          output: [],
+          requiresApproval: null,
+          requiresInput: null,
+        };
+      }
+    }
+
     const resumeIndex = payload.resumeAtIndex ?? 0;
-    const resumeItems = payload.items ?? [];
+    let resumeItems = payload.items ?? [];
+    if (response !== undefined) {
+      const schema = payload.inputSchema;
+      if (!schema || typeof schema !== 'object') {
+        throw new Error('resume token does not support input responses');
+      }
+      const validator = inputAjv.compile(schema);
+      const ok = validator(response);
+      if (!ok) {
+        const first = validator.errors?.[0];
+        throw new Error(`response does not match schema at ${first?.instancePath || '/'}: ${first?.message || 'invalid'}`);
+      }
+      resumeItems = [response];
+    }
 
     // Get remaining stages
     const remainingStages = this.#stages.slice(resumeIndex);
@@ -220,6 +295,34 @@ export class Lobster {
             items: approval.items,
             resumeToken,
           },
+          requiresInput: null,
+        };
+      }
+
+      if (result.halted && result.items.length === 1 && result.items[0]?.type === 'input_request') {
+        const input = result.items[0];
+        const resumeToken = encodeToken({
+          protocolVersion: 1,
+          v: 1,
+          stageIndex: resumeIndex + (result.haltedAt?.index ?? 0),
+          resumeAtIndex: resumeIndex + (result.haltedAt?.index ?? 0) + 1,
+          items: [],
+          inputSchema: input.responseSchema,
+          inputSubject: input.subject,
+        });
+
+        return {
+          ok: true,
+          status: 'needs_input',
+          output: [],
+          requiresApproval: null,
+          requiresInput: {
+            prompt: input.prompt,
+            responseSchema: input.responseSchema,
+            defaults: input.defaults,
+            subject: input.subject,
+            resumeToken,
+          },
         };
       }
 
@@ -228,6 +331,7 @@ export class Lobster {
         status: 'ok',
         output: result.items,
         requiresApproval: null,
+        requiresInput: null,
       };
     } catch (err) {
       return {
@@ -235,6 +339,7 @@ export class Lobster {
         status: 'error',
         output: [],
         requiresApproval: null,
+        requiresInput: null,
         error: {
           type: 'runtime_error',
           message: err?.message ?? String(err),

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,3 +1,9 @@
 import { Ajv } from 'ajv';
 
-export const sharedAjv = new Ajv({ allErrors: false, strict: false });
+export const sharedAjv = new Ajv({
+  allErrors: false,
+  strict: false,
+  // User-provided schemas may repeat `$id` across runs/resumes.
+  // Disable global schema registration to avoid duplicate-id collisions.
+  addUsedSchema: false,
+});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,3 @@
+import { Ajv } from 'ajv';
+
+export const sharedAjv = new Ajv({ allErrors: false, strict: false });

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1,6 +1,7 @@
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { Ajv } from 'ajv';
 
 import { randomUUID } from 'node:crypto';
 import { PassThrough } from 'node:stream';
@@ -30,8 +31,14 @@ export type WorkflowStep = {
   cwd?: string;
   stdin?: unknown;
   approval?: WorkflowApproval;
+  input?: WorkflowInputRequest;
   condition?: unknown;
   when?: unknown;
+  retry?: number;
+  retry_delay?: string;
+  on_error?: 'fail' | 'skip' | string;
+  next?: string;
+  max_iterations?: number;
 };
 
 export type WorkflowApproval =
@@ -44,22 +51,40 @@ export type WorkflowApproval =
     preview?: string;
   };
 
+export type WorkflowInputRequest = {
+  prompt: string;
+  responseSchema?: unknown;
+  defaults?: unknown;
+};
+
 export type WorkflowStepResult = {
   id: string;
   stdout?: string;
   json?: unknown;
   approved?: boolean;
+  subject?: unknown;
+  response?: unknown;
+  failed?: boolean;
+  error?: string;
   skipped?: boolean;
 };
 
 export type WorkflowRunResult = {
-  status: 'ok' | 'needs_approval' | 'cancelled';
+  status: 'ok' | 'needs_approval' | 'needs_input' | 'cancelled';
   output: unknown[];
   requiresApproval?: {
     type: 'approval_request';
     prompt: string;
     items: unknown[];
     preview?: string;
+    resumeToken?: string;
+  };
+  requiresInput?: {
+    type: 'input_request';
+    prompt: string;
+    responseSchema: unknown;
+    defaults?: unknown;
+    subject: unknown;
     resumeToken?: string;
   };
 };
@@ -88,6 +113,10 @@ export type WorkflowResumePayload = {
   steps?: Record<string, WorkflowStepResult>;
   args?: Record<string, unknown>;
   approvalStepId?: string;
+  inputStepId?: string;
+  inputSchema?: unknown;
+  inputSubject?: unknown;
+  iterationCounts?: Record<string, number>;
 };
 
 type WorkflowResumeState = {
@@ -96,6 +125,10 @@ type WorkflowResumeState = {
   steps: Record<string, WorkflowStepResult>;
   args: Record<string, unknown>;
   approvalStepId?: string;
+  inputStepId?: string;
+  inputSchema?: unknown;
+  inputSubject?: unknown;
+  iterationCounts?: Record<string, number>;
   createdAt: string;
 };
 
@@ -124,11 +157,17 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     const shellCommand = typeof step.run === 'string' ? step.run : step.command;
     const pipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
     const executionCount = Number(Boolean(shellCommand)) + Number(Boolean(pipeline));
-    if (executionCount === 0 && !isApprovalStep(step.approval)) {
-      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, or approval`);
+    if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input)) {
+      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, approval, or input`);
     }
     if (executionCount > 1) {
       throw new Error(`Workflow step ${step.id} can only define one of run, command, or pipeline`);
+    }
+    if (executionCount > 0 && isInputStep(step.input)) {
+      throw new Error(`Workflow step ${step.id} input steps cannot define run, command, or pipeline`);
+    }
+    if (isApprovalStep(step.approval) && isInputStep(step.input)) {
+      throw new Error(`Workflow step ${step.id} cannot define both approval and input`);
     }
     if (step.run !== undefined && typeof step.run !== 'string') {
       throw new Error(`Workflow step ${step.id} run must be a string`);
@@ -139,10 +178,58 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (step.pipeline !== undefined && typeof step.pipeline !== 'string') {
       throw new Error(`Workflow step ${step.id} pipeline must be a string`);
     }
+    if (step.input !== undefined && !isInputStep(step.input)) {
+      throw new Error(`Workflow step ${step.id} input must be an object`);
+    }
+    if (step.input && typeof step.input.prompt !== 'string') {
+      throw new Error(`Workflow step ${step.id} input.prompt must be a string`);
+    }
+    if (step.input && (!step.input.responseSchema || typeof step.input.responseSchema !== 'object')) {
+      throw new Error(`Workflow step ${step.id} input.responseSchema must be an object`);
+    }
+    if (step.retry !== undefined && (!Number.isInteger(step.retry) || step.retry < 0)) {
+      throw new Error(`Workflow step ${step.id} retry must be a non-negative integer`);
+    }
+    if (step.retry_delay !== undefined && !isValidDurationString(step.retry_delay)) {
+      throw new Error(`Workflow step ${step.id} retry_delay must be a duration like 1s or 500ms`);
+    }
+    if (step.max_iterations !== undefined && (!Number.isInteger(step.max_iterations) || step.max_iterations <= 0)) {
+      throw new Error(`Workflow step ${step.id} max_iterations must be a positive integer`);
+    }
+    if (step.on_error !== undefined && typeof step.on_error !== 'string') {
+      throw new Error(`Workflow step ${step.id} on_error must be a string`);
+    }
+    if (step.next !== undefined && typeof step.next !== 'string') {
+      throw new Error(`Workflow step ${step.id} next must be a string`);
+    }
     if (seen.has(step.id)) {
       throw new Error(`Duplicate workflow step id: ${step.id}`);
     }
     seen.add(step.id);
+  }
+
+  for (const step of steps) {
+    if (step.next) {
+      const target = step.next.trim();
+      if (!target) {
+        throw new Error(`Workflow step ${step.id} next cannot be empty`);
+      }
+      if (!seen.has(target)) {
+        throw new Error(`Workflow step ${step.id} next target not found: ${target}`);
+      }
+      if (isApprovalStep(step.approval) || isInputStep(step.input)) {
+        throw new Error(`Workflow step ${step.id} cannot use next with approval/input steps`);
+      }
+    }
+    if (typeof step.on_error === 'string') {
+      const target = step.on_error.trim();
+      if (!target) {
+        throw new Error(`Workflow step ${step.id} on_error cannot be empty`);
+      }
+      if (!['fail', 'skip'].includes(target) && !seen.has(target)) {
+        throw new Error(`Workflow step ${step.id} on_error target not found: ${target}`);
+      }
+    }
   }
 
   return parsed as WorkflowFile;
@@ -174,12 +261,14 @@ export async function runWorkflowFile({
   ctx,
   resume,
   approved,
+  response,
 }: {
   filePath?: string;
   args?: Record<string, unknown>;
   ctx: RunContext;
   resume?: WorkflowResumePayload;
   approved?: boolean;
+  response?: unknown;
 }): Promise<WorkflowRunResult> {
   const consumedResumeStateKey = resume?.stateKey && typeof resume.stateKey === 'string'
     ? resume.stateKey
@@ -194,31 +283,143 @@ export async function runWorkflowFile({
   const workflow = await loadWorkflowFile(resolvedFilePath);
   const resolvedArgs = resolveWorkflowArgs(workflow.args, args ?? resumeState?.args);
   const steps = workflow.steps;
+  const stepIndexById = new Map(steps.map((step, idx) => [step.id, idx]));
   const results: Record<string, WorkflowStepResult> = resumeState?.steps
     ? cloneResults(resumeState.steps)
     : {};
+  const iterationCounts: Record<string, number> = resumeState?.iterationCounts
+    ? { ...resumeState.iterationCounts }
+    : {};
   const startIndex = resumeState?.resumeAtIndex ?? 0;
 
-  if (resumeState?.approvalStepId && approved === false) {
-    if (consumedResumeStateKey) {
-      await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+  if (resumeState?.approvalStepId) {
+    if (typeof approved !== 'boolean') {
+      throw new Error('Workflow resume requires --approve yes|no for approval requests');
     }
-    return { status: 'cancelled', output: [] };
-  }
-
-  if (resumeState?.approvalStepId && typeof approved === 'boolean') {
+    if (approved === false) {
+      if (consumedResumeStateKey) {
+        await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+      }
+      return { status: 'cancelled', output: [] };
+    }
     const previous = results[resumeState.approvalStepId] ?? { id: resumeState.approvalStepId };
     previous.approved = approved;
     results[resumeState.approvalStepId] = previous;
   }
 
-  let lastStepId: string | null = findLastCompletedStepId(steps, results);
+  if (resumeState?.inputStepId) {
+    if (response === undefined) {
+      throw new Error('Workflow resume requires --response-json for input requests');
+    }
+    const inputStep = steps[stepIndexById.get(resumeState.inputStepId) ?? -1];
+    if (!inputStep || !isInputStep(inputStep.input)) {
+      throw new Error(`Invalid input step in resume state: ${resumeState.inputStepId}`);
+    }
+    validateInputResponse({
+      schema: resumeState.inputSchema ?? inputStep.input.responseSchema,
+      response,
+      stepId: inputStep.id,
+    });
+    const previous = results[resumeState.inputStepId] ?? { id: resumeState.inputStepId };
+    previous.subject = resumeState.inputSubject ?? null;
+    previous.response = response;
+    delete previous.skipped;
+    delete previous.failed;
+    delete previous.error;
+    results[resumeState.inputStepId] = previous;
+  }
 
-  for (let idx = startIndex; idx < steps.length; idx++) {
+  let lastStepId: string | null =
+    resumeState?.inputStepId ?? findLastCompletedStepId(steps, results);
+
+  let idx = startIndex;
+  while (idx < steps.length) {
     const step = steps[idx];
 
     if (!evaluateCondition(step.when ?? step.condition, results)) {
       results[step.id] = { id: step.id, skipped: true };
+      idx += 1;
+      continue;
+    }
+
+    const maxIterations = resolveMaxIterations(step.max_iterations);
+    const nextIteration = (iterationCounts[step.id] ?? 0) + 1;
+    iterationCounts[step.id] = nextIteration;
+    if (nextIteration > maxIterations) {
+      throw new Error(
+        `Workflow step ${step.id} exceeded max_iterations (${maxIterations}). ` +
+        `This usually indicates a loop that never exits.`,
+      );
+    }
+
+    if (isInputStep(step.input)) {
+      const subject = resolveInputSubject({
+        step,
+        args: resolvedArgs,
+        results,
+        lastStepId,
+      });
+      const inputRequest = buildNeedsInputRequest({
+        stepId: step.id,
+        prompt: step.input.prompt,
+        responseSchema: step.input.responseSchema,
+        defaults: step.input.defaults,
+        subject,
+        maxEnvelopeBytes: resolveToolEnvelopeMaxBytes(ctx.env),
+      });
+
+      if (ctx.mode === 'tool' || !isInteractive(ctx.stdin)) {
+        const stateKey = await saveWorkflowResumeState(ctx.env, {
+          filePath: resolvedFilePath,
+          resumeAtIndex: idx + 1,
+          steps: results,
+          args: resolvedArgs,
+          inputStepId: step.id,
+          inputSchema: step.input.responseSchema,
+          inputSubject: subject,
+          iterationCounts,
+          createdAt: new Date().toISOString(),
+        });
+
+        if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
+          await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+        }
+
+        const resumeToken = encodeToken({
+          protocolVersion: 1,
+          v: 1,
+          kind: 'workflow-file',
+          stateKey,
+        } satisfies WorkflowResumePayload);
+
+        return {
+          status: 'needs_input',
+          output: [],
+          requiresInput: {
+            ...inputRequest,
+            resumeToken,
+          },
+        };
+      }
+
+      ctx.stdout.write(`${step.input.prompt}\n`);
+      ctx.stdout.write('Enter JSON response: ');
+      const raw = await readLineFromStream(ctx.stdin, {
+        timeoutMs: parseApprovalTimeoutMs(ctx.env),
+      });
+      const parsed = parseResponseJson(String(raw ?? '').trim());
+      validateInputResponse({
+        schema: step.input.responseSchema,
+        response: parsed,
+        stepId: step.id,
+      });
+      results[step.id] = {
+        id: step.id,
+        subject,
+        response: parsed,
+      };
+      lastStepId = step.id;
+      idx += 1;
       continue;
     }
 
@@ -226,32 +427,68 @@ export async function runWorkflowFile({
     const cwd = resolveCwd(step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
     const execution = getStepExecution(step);
 
-    let result: WorkflowStepResult;
-    if (execution.kind === 'shell') {
-      const command = resolveTemplate(execution.value, resolvedArgs, results);
-      const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
-      const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
-      result = { id: step.id, stdout, json: parseJson(stdout) };
-    } else if (execution.kind === 'pipeline') {
-      if (!ctx.registry) {
-        throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
-      }
-      const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
-      const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
-      result = await runPipelineStep({
-        stepId: step.id,
-        pipelineText,
-        inputValue,
-        ctx,
-        env,
-        cwd,
+    let result: WorkflowStepResult | null = null;
+    let failure: unknown = null;
+    try {
+      result = await runWithRetry({
+        retries: step.retry ?? 0,
+        retryDelayMs: parseRetryDelayMs(step.retry_delay),
+        signal: ctx.signal,
+        run: async () => {
+          if (execution.kind === 'shell') {
+            const command = resolveTemplate(execution.value, resolvedArgs, results);
+            const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
+            const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
+            return { id: step.id, stdout, json: parseJson(stdout) };
+          }
+          if (execution.kind === 'pipeline') {
+            if (!ctx.registry) {
+              throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
+            }
+            const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
+            const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
+            return await runPipelineStep({
+              stepId: step.id,
+              pipelineText,
+              inputValue,
+              ctx,
+              env,
+              cwd,
+            });
+          }
+          const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
+          return createSyntheticStepResult(step.id, inputValue);
+        },
       });
-    } else {
-      const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
-      result = createSyntheticStepResult(step.id, inputValue);
+    } catch (err) {
+      failure = err;
     }
 
-    results[step.id] = result;
+    if (failure) {
+      const message = failure instanceof Error ? failure.message : String(failure);
+      results[step.id] = {
+        id: step.id,
+        failed: true,
+        error: message,
+      };
+      lastStepId = step.id;
+      const onErrorTarget = normalizeOnError(step.on_error);
+      if (onErrorTarget === 'fail') {
+        throw failure;
+      }
+      if (onErrorTarget === 'skip') {
+        idx += 1;
+        continue;
+      }
+      const jumpIndex = stepIndexById.get(onErrorTarget);
+      if (jumpIndex === undefined) {
+        throw new Error(`Workflow step ${step.id} on_error target not found: ${onErrorTarget}`);
+      }
+      idx = jumpIndex;
+      continue;
+    }
+
+    results[step.id] = result!;
     lastStepId = step.id;
 
     if (isApprovalStep(step.approval)) {
@@ -264,6 +501,7 @@ export async function runWorkflowFile({
           steps: results,
           args: resolvedArgs,
           approvalStepId: step.id,
+          iterationCounts,
           createdAt: new Date().toISOString(),
         });
 
@@ -297,6 +535,16 @@ export async function runWorkflowFile({
       }
       results[step.id].approved = true;
     }
+
+    if (step.next) {
+      const jumpIndex = stepIndexById.get(step.next.trim());
+      if (jumpIndex === undefined) {
+        throw new Error(`Workflow step ${step.id} next target not found: ${step.next}`);
+      }
+      idx = jumpIndex;
+      continue;
+    }
+    idx += 1;
   }
 
   const output = lastStepId ? toOutputItems(results[lastStepId]) : [];
@@ -428,34 +676,30 @@ function resolveArgsTemplate(input: string, args: Record<string, unknown>) {
 }
 
 function resolveStepRefs(input: string, results: Record<string, WorkflowStepResult>) {
-  return input.replace(/\$([A-Za-z0-9_-]+)\.(stdout|json|approved)/g, (match, id, field) => {
-    const step = results[id];
-    if (!step) return match;
-    if (field === 'stdout') return step.stdout ?? '';
-    if (field === 'json') return step.json !== undefined ? JSON.stringify(step.json) : '';
-    if (field === 'approved') return step.approved === true ? 'true' : 'false';
-    return match;
+  return input.replace(/\$([A-Za-z0-9_-]+)\.([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)/g, (match, id, pathValue) => {
+    const refValue = getStepRefValue({ id, path: pathValue }, results, false);
+    if (refValue === undefined) return match;
+    return renderTemplateValue(refValue);
   });
 }
 
 function parseStepRef(value: string) {
-  const match = value.match(/^\$([A-Za-z0-9_-]+)\.(stdout|json)$/);
+  const match = value.match(/^\$([A-Za-z0-9_-]+)\.([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)$/);
   if (!match) return null;
-  return { id: match[1], field: match[2] as 'stdout' | 'json' };
+  return { id: match[1], path: match[2] };
 }
 
 function getStepRefValue(
-  ref: { id: string; field: 'stdout' | 'json' },
+  ref: { id: string; path: string },
   results: Record<string, WorkflowStepResult>,
   strict: boolean,
 ) {
   const step = results[ref.id];
   if (!step) {
-    if (strict) throw new Error(`Unknown step reference: ${ref.id}.${ref.field}`);
-    return '';
+    if (strict) throw new Error(`Unknown step reference: ${ref.id}.${ref.path}`);
+    return undefined;
   }
-  if (ref.field === 'stdout') return step.stdout ?? '';
-  return step.json;
+  return getValueByPath(step, ref.path);
 }
 
 function evaluateCondition(
@@ -469,14 +713,7 @@ function evaluateCondition(
   const trimmed = condition.trim();
   if (trimmed === 'true') return true;
   if (trimmed === 'false') return false;
-
-  const match = trimmed.match(/^\$([A-Za-z0-9_-]+)\.(approved|skipped)$/);
-  if (!match) throw new Error(`Unsupported condition: ${condition}`);
-
-  const step = results[match[1]];
-  if (!step) return false;
-
-  return match[2] === 'approved' ? step.approved === true : step.skipped === true;
+  return evaluateExpression(trimmed, results);
 }
 
 function isApprovalStep(approval: WorkflowStep['approval']) {
@@ -484,6 +721,10 @@ function isApprovalStep(approval: WorkflowStep['approval']) {
   if (typeof approval === 'string' && approval.trim().length > 0) return true;
   if (approval && typeof approval === 'object' && !Array.isArray(approval)) return true;
   return false;
+}
+
+function isInputStep(input: WorkflowStep['input']) {
+  return Boolean(input && typeof input === 'object' && !Array.isArray(input));
 }
 
 function extractApprovalRequest(step: WorkflowStep, result: WorkflowStepResult) {
@@ -572,6 +813,383 @@ function parseApprovalTimeoutMs(env: Record<string, string | undefined>) {
   const value = Number(raw);
   if (!Number.isFinite(value) || value <= 0) return 0;
   return Math.floor(value);
+}
+
+const inputResponseAjv = new Ajv({ allErrors: false, strict: false });
+const DURATION_PATTERN = /^(\d+)(ms|s|m|h)$/i;
+const DEFAULT_MAX_ITERATIONS = 20;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+const MAX_NEEDS_INPUT_SUBJECT_BYTES = 192_000;
+const DEFAULT_TOOL_ENVELOPE_MAX_BYTES = 512_000;
+const RESUME_TOKEN_PLACEHOLDER = 'x'.repeat(220);
+
+function parseResponseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error('Invalid JSON passed to --response-json');
+  }
+}
+
+function validateInputResponse(params: {
+  schema: unknown;
+  response: unknown;
+  stepId: string;
+}) {
+  const validator = inputResponseAjv.compile(params.schema as object);
+  const ok = validator(params.response);
+  if (ok) return;
+  const first = validator.errors?.[0];
+  const pathValue = first?.instancePath || '/';
+  const reason = first?.message ? ` ${first.message}` : '';
+  throw new Error(
+    `Workflow input step ${params.stepId} response failed schema validation at ${pathValue}:${reason}`,
+  );
+}
+
+function resolveInputSubject(params: {
+  step: WorkflowStep;
+  args: Record<string, unknown>;
+  results: Record<string, WorkflowStepResult>;
+  lastStepId: string | null;
+}) {
+  if (params.step.stdin !== undefined) {
+    return resolveInputValue(params.step.stdin, params.args, params.results);
+  }
+  if (!params.lastStepId) return null;
+  const previous = params.results[params.lastStepId];
+  if (!previous) return null;
+  if (previous.json !== undefined) return previous.json;
+  if (previous.stdout !== undefined) return previous.stdout;
+  return null;
+}
+
+function maybeTruncateInputSubject(subject: unknown): unknown {
+  let serialized = '';
+  try {
+    serialized = JSON.stringify(subject ?? null);
+  } catch {
+    return {
+      truncated: true,
+      bytes: 0,
+      preview: '[unserializable subject]',
+    };
+  }
+  const byteLength = Buffer.byteLength(serialized, 'utf8');
+  if (byteLength <= MAX_NEEDS_INPUT_SUBJECT_BYTES) return subject;
+  const preview = serialized.slice(0, 2000);
+  return {
+    truncated: true,
+    bytes: byteLength,
+    preview,
+  };
+}
+
+function resolveToolEnvelopeMaxBytes(env: Record<string, string | undefined>) {
+  const raw = env?.LOBSTER_MAX_TOOL_ENVELOPE_BYTES;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1024) {
+    return DEFAULT_TOOL_ENVELOPE_MAX_BYTES;
+  }
+  return Math.floor(parsed);
+}
+
+function buildNeedsInputRequest(params: {
+  stepId: string;
+  prompt: string;
+  responseSchema: unknown;
+  defaults: unknown;
+  subject: unknown;
+  maxEnvelopeBytes: number;
+}) {
+  const base = {
+    type: 'input_request' as const,
+    prompt: params.prompt,
+    responseSchema: params.responseSchema,
+    ...(params.defaults !== undefined ? { defaults: params.defaults } : null),
+  };
+
+  let subject = params.subject;
+  let request = { ...base, subject };
+  if (fitsNeedsInputEnvelope(request, params.maxEnvelopeBytes)) {
+    return request;
+  }
+
+  subject = maybeTruncateInputSubject(subject);
+  request = { ...base, subject };
+  if (fitsNeedsInputEnvelope(request, params.maxEnvelopeBytes)) {
+    return request;
+  }
+
+  request = {
+    ...base,
+    subject: {
+      truncated: true,
+      bytes: estimateSerializedBytes(params.subject),
+      preview: '[subject omitted: envelope size limit]',
+    },
+  };
+  if (fitsNeedsInputEnvelope(request, params.maxEnvelopeBytes)) {
+    return request;
+  }
+
+  throw new Error(
+    `Workflow input step ${params.stepId} needs_input envelope exceeds ${params.maxEnvelopeBytes} bytes ` +
+    `even after subject truncation`,
+  );
+}
+
+function fitsNeedsInputEnvelope(
+  request: {
+    type: 'input_request';
+    prompt: string;
+    responseSchema: unknown;
+    defaults?: unknown;
+    subject: unknown;
+  },
+  maxEnvelopeBytes: number,
+) {
+  const envelope = {
+    protocolVersion: 1,
+    ok: true,
+    status: 'needs_input',
+    output: [],
+    requiresApproval: null,
+    requiresInput: {
+      ...request,
+      resumeToken: RESUME_TOKEN_PLACEHOLDER,
+    },
+  };
+  return estimateSerializedBytes(envelope) <= maxEnvelopeBytes;
+}
+
+function estimateSerializedBytes(value: unknown) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8');
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function isValidDurationString(value: string) {
+  return DURATION_PATTERN.test(value.trim());
+}
+
+function parseRetryDelayMs(value: unknown) {
+  if (value === undefined || value === null) return DEFAULT_RETRY_DELAY_MS;
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  if (typeof value !== 'string') {
+    throw new Error('retry_delay must be a duration string like 1s');
+  }
+  const trimmed = value.trim();
+  const match = trimmed.match(DURATION_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid retry_delay: ${value}`);
+  }
+  const amount = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const multiplier = unit === 'ms' ? 1 : unit === 's' ? 1000 : unit === 'm' ? 60_000 : 3_600_000;
+  return amount * multiplier;
+}
+
+async function runWithRetry<T>(params: {
+  retries: number;
+  retryDelayMs: number;
+  signal?: AbortSignal;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const retries = Number.isInteger(params.retries) && params.retries > 0 ? params.retries : 0;
+  const attempts = retries + 1;
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await params.run();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= attempts) {
+        throw err;
+      }
+      await sleepWithAbort(params.retryDelayMs, params.signal);
+    }
+  }
+  throw lastError ?? new Error('retry failed');
+}
+
+async function sleepWithAbort(ms: number, signal?: AbortSignal) {
+  const waitMs = Math.max(0, ms);
+  if (!waitMs) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, waitMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error('Workflow aborted'));
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+function normalizeOnError(value: WorkflowStep['on_error']) {
+  const raw = typeof value === 'string' ? value.trim() : 'fail';
+  if (!raw || raw === 'fail') return 'fail' as const;
+  if (raw === 'skip') return 'skip' as const;
+  return raw;
+}
+
+function resolveMaxIterations(value: WorkflowStep['max_iterations']) {
+  if (value === undefined || value === null) return DEFAULT_MAX_ITERATIONS;
+  return value;
+}
+
+function renderTemplateValue(value: unknown) {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getValueByPath(value: unknown, pathValue: string) {
+  const fields = pathValue.split('.');
+  let current: unknown = value;
+  for (const field of fields) {
+    if (current === null || current === undefined) return undefined;
+    if (Array.isArray(current)) {
+      const idx = Number(field);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= current.length) return undefined;
+      current = current[idx];
+      continue;
+    }
+    if (typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[field];
+  }
+  return current;
+}
+
+function evaluateExpression(expression: string, results: Record<string, WorkflowStepResult>) {
+  const hasAnd = containsConditionOperator(expression, '&&');
+  const hasOr = containsConditionOperator(expression, '||');
+  if (hasAnd && hasOr) {
+    throw new Error(`Unsupported condition: ${expression}`);
+  }
+  if (hasAnd) {
+    const parts = splitConditionByOperator(expression, '&&');
+    if (parts.length !== 2) throw new Error(`Unsupported condition: ${expression}`);
+    return evaluateAtom(parts[0], results) && evaluateAtom(parts[1], results);
+  }
+  if (hasOr) {
+    const parts = splitConditionByOperator(expression, '||');
+    if (parts.length !== 2) throw new Error(`Unsupported condition: ${expression}`);
+    return evaluateAtom(parts[0], results) || evaluateAtom(parts[1], results);
+  }
+  return evaluateAtom(expression, results);
+}
+
+function containsConditionOperator(input: string, op: '&&' | '||') {
+  return splitConditionByOperator(input, op).length > 1;
+}
+
+function splitConditionByOperator(input: string, op: '&&' | '||') {
+  const pieces: string[] = [];
+  let current = '';
+  let quote = false;
+  for (let idx = 0; idx < input.length; idx++) {
+    const ch = input[idx];
+    if (ch === '"' && !isEscapedQuote(input, idx)) {
+      quote = !quote;
+      current += ch;
+      continue;
+    }
+    if (!quote && input.slice(idx, idx + op.length) === op) {
+      pieces.push(current.trim());
+      current = '';
+      idx += op.length - 1;
+      continue;
+    }
+    current += ch;
+  }
+  pieces.push(current.trim());
+  return pieces.filter((piece) => piece.length > 0);
+}
+
+function isEscapedQuote(input: string, quoteIndex: number) {
+  let backslashes = 0;
+  for (let idx = quoteIndex - 1; idx >= 0 && input[idx] === '\\'; idx--) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function evaluateAtom(atomRaw: string, results: Record<string, WorkflowStepResult>): boolean {
+  const atom = atomRaw.trim();
+  if (!atom) throw new Error('Unsupported condition');
+  if (atom === 'true') return true;
+  if (atom === 'false') return false;
+  if (atom.startsWith('!')) {
+    return !evaluateAtom(atom.slice(1), results);
+  }
+
+  const comparison = parseComparison(atom);
+  if (comparison) {
+    const left = resolveConditionRef(comparison.ref, results);
+    if (left === undefined || left === null) return false;
+    const leftText = String(left);
+    return comparison.op === '==' ? leftText === comparison.literal : leftText !== comparison.literal;
+  }
+
+  const ref = parseStepRef(atom);
+  if (!ref) {
+    throw new Error(`Unsupported condition: ${atom}`);
+  }
+  const value = getStepRefValue(ref, results, false);
+  return Boolean(value);
+}
+
+function parseComparison(atom: string): { ref: { id: string; path: string }; op: '==' | '!='; literal: string } | null {
+  const match = atom.match(
+    /^(\$[A-Za-z0-9_-]+\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)\s*(==|!=)\s*(.+)$/,
+  );
+  if (!match) return null;
+  const ref = parseStepRef(match[1]);
+  if (!ref) throw new Error(`Unsupported condition: ${atom}`);
+  return {
+    ref,
+    op: match[2] as '==' | '!=',
+    literal: parseConditionLiteral(match[3].trim()),
+  };
+}
+
+function parseConditionLiteral(input: string) {
+  if (input.startsWith('"')) {
+    if (!input.endsWith('"') || input.length < 2) {
+      throw new Error(`Invalid quoted literal in condition: ${input}`);
+    }
+    const body = input.slice(1, -1);
+    return body.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  if (!/^[^\s&|"]+$/.test(input)) {
+    throw new Error(`Invalid literal in condition: ${input}`);
+  }
+  return input;
+}
+
+function resolveConditionRef(ref: { id: string; path: string }, results: Record<string, WorkflowStepResult>) {
+  return getStepRefValue(ref, results, false);
 }
 
 async function runShellCommand({

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -132,6 +132,13 @@ type WorkflowResumeState = {
   createdAt: string;
 };
 
+export class WorkflowResumeArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkflowResumeArgumentError';
+  }
+}
+
 export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> {
   const text = await fsp.readFile(filePath, 'utf8');
   const ext = path.extname(filePath).toLowerCase();
@@ -294,7 +301,7 @@ export async function runWorkflowFile({
 
   if (resumeState?.approvalStepId) {
     if (typeof approved !== 'boolean') {
-      throw new Error('Workflow resume requires --approve yes|no for approval requests');
+      throw new WorkflowResumeArgumentError('Workflow resume requires --approve yes|no for approval requests');
     }
     if (approved === false) {
       if (consumedResumeStateKey) {
@@ -309,7 +316,7 @@ export async function runWorkflowFile({
 
   if (resumeState?.inputStepId) {
     if (response === undefined) {
-      throw new Error('Workflow resume requires --response-json for input requests');
+      throw new WorkflowResumeArgumentError('Workflow resume requires --response-json for input requests');
     }
     const inputStep = steps[stepIndexById.get(resumeState.inputStepId) ?? -1];
     if (!inputStep || !isInputStep(inputStep.input)) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -678,7 +678,10 @@ function resolveArgsTemplate(input: string, args: Record<string, unknown>) {
 function resolveStepRefs(input: string, results: Record<string, WorkflowStepResult>) {
   return input.replace(/\$([A-Za-z0-9_-]+)\.([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)/g, (match, id, pathValue) => {
     const refValue = getStepRefValue({ id, path: pathValue }, results, false);
-    if (refValue === undefined) return match;
+    if (refValue === undefined) {
+      if (pathValue === 'approved' || pathValue === 'skipped') return 'false';
+      return '';
+    }
     return renderTemplateValue(refValue);
   });
 }
@@ -782,6 +785,9 @@ function toOutputItems(result: WorkflowStepResult | undefined) {
   if (!result) return [];
   if (result.json !== undefined) {
     return Array.isArray(result.json) ? result.json : [result.json];
+  }
+  if (result.response !== undefined) {
+    return Array.isArray(result.response) ? result.response : [result.response];
   }
   if (result.stdout !== undefined) {
     return result.stdout === '' ? [] : [result.stdout];

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -194,6 +194,15 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (step.input && (!step.input.responseSchema || typeof step.input.responseSchema !== 'object')) {
       throw new Error(`Workflow step ${step.id} input.responseSchema must be an object`);
     }
+    if (step.input) {
+      try {
+        sharedAjv.compile(step.input.responseSchema as any);
+      } catch (err: any) {
+        throw new Error(
+          `Workflow step ${step.id} input.responseSchema is invalid: ${err?.message ?? String(err)}`,
+        );
+      }
+    }
     if (step.retry !== undefined && (!Number.isInteger(step.retry) || step.retry < 0)) {
       throw new Error(`Workflow step ${step.id} retry must be a non-negative integer`);
     }
@@ -417,7 +426,7 @@ export async function runWorkflowFile({
           args: resolvedArgs,
           inputStepId: step.id,
           inputSchema: step.input.responseSchema,
-          inputSubject: subject,
+          inputSubject: inputRequest.subject,
           iterationCounts,
           createdAt: new Date().toISOString(),
         });

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1059,19 +1059,19 @@ async function runWithRetry<T>(params: {
 }): Promise<T> {
   const retries = Number.isInteger(params.retries) && params.retries > 0 ? params.retries : 0;
   const attempts = retries + 1;
-  let lastError: unknown = null;
-  for (let attempt = 1; attempt <= attempts; attempt++) {
+  for (let attempt = 1; ; attempt++) {
+    if (params.signal?.aborted) {
+      throw new Error('Workflow aborted');
+    }
     try {
       return await params.run();
     } catch (err) {
-      lastError = err;
       if (attempt >= attempts) {
         throw err;
       }
       await sleepWithAbort(params.retryDelayMs, params.signal);
     }
   }
-  throw lastError ?? new Error('retry failed');
 }
 
 async function sleepWithAbort(ms: number, signal?: AbortSignal) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -84,7 +84,7 @@ export type WorkflowRunResult = {
     prompt: string;
     responseSchema: unknown;
     defaults?: unknown;
-    subject: unknown;
+    subject?: unknown;
     resumeToken?: string;
   };
 };

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -206,7 +206,10 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (step.retry !== undefined && (!Number.isInteger(step.retry) || step.retry < 0)) {
       throw new Error(`Workflow step ${step.id} retry must be a non-negative integer`);
     }
-    if (step.retry_delay !== undefined && !isValidDurationString(step.retry_delay)) {
+    if (step.retry_delay !== undefined && typeof step.retry_delay !== 'string') {
+      throw new Error(`Workflow step ${step.id} retry_delay must be a duration like 1s or 500ms`);
+    }
+    if (typeof step.retry_delay === 'string' && !isValidDurationString(step.retry_delay)) {
       throw new Error(`Workflow step ${step.id} retry_delay must be a duration like 1s or 500ms`);
     }
     if (step.max_iterations !== undefined && (!Number.isInteger(step.max_iterations) || step.max_iterations <= 0)) {
@@ -225,7 +228,7 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
   }
 
   for (const step of steps) {
-    if (step.next) {
+    if (typeof step.next === 'string') {
       const target = step.next.trim();
       if (!target) {
         throw new Error(`Workflow step ${step.id} next cannot be empty`);
@@ -409,16 +412,16 @@ export async function runWorkflowFile({
         results,
         lastStepId,
       });
-      const inputRequest = buildNeedsInputRequest({
-        stepId: step.id,
-        prompt: step.input.prompt,
-        responseSchema: step.input.responseSchema,
-        defaults: step.input.defaults,
-        subject,
-        maxEnvelopeBytes: resolveToolEnvelopeMaxBytes(ctx.env),
-      });
 
       if (ctx.mode === 'tool' || !isInteractive(ctx.stdin)) {
+        const inputRequest = buildNeedsInputRequest({
+          stepId: step.id,
+          prompt: step.input.prompt,
+          responseSchema: step.input.responseSchema,
+          defaults: step.input.defaults,
+          subject,
+          maxEnvelopeBytes: resolveToolEnvelopeMaxBytes(ctx.env),
+        });
         const stateKey = await saveWorkflowResumeState(ctx.env, {
           filePath: resolvedFilePath,
           resumeAtIndex: idx + 1,

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -368,7 +368,14 @@ export async function runWorkflowFile({
     if (!evaluateCondition(step.when ?? step.condition, results)) {
       const previous = results[step.id];
       results[step.id] = previous
-        ? { ...previous, skipped: true }
+        ? {
+          id: step.id,
+          stdout: previous.stdout,
+          json: previous.json,
+          subject: previous.subject,
+          response: previous.response,
+          skipped: true,
+        }
         : { id: step.id, skipped: true };
       idx += 1;
       continue;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -293,6 +293,7 @@ export async function runWorkflowFile({
   const resolvedArgs = resolveWorkflowArgs(workflow.args, args ?? resumeState?.args);
   const steps = workflow.steps;
   const stepIndexById = new Map(steps.map((step, idx) => [step.id, idx]));
+  const jumpTargets = collectJumpTargets(steps);
   const results: Record<string, WorkflowStepResult> = resumeState?.steps
     ? cloneResults(resumeState.steps)
     : {};
@@ -373,14 +374,16 @@ export async function runWorkflowFile({
       continue;
     }
 
-    const maxIterations = resolveMaxIterations(step.max_iterations);
-    const nextIteration = (iterationCounts[step.id] ?? 0) + 1;
-    iterationCounts[step.id] = nextIteration;
-    if (nextIteration > maxIterations) {
-      throw new Error(
-        `Workflow step ${step.id} exceeded max_iterations (${maxIterations}). ` +
-        `This usually indicates a loop that never exits.`,
-      );
+    if (shouldTrackStepIterations(step, jumpTargets)) {
+      const maxIterations = resolveMaxIterations(step.max_iterations);
+      const nextIteration = (iterationCounts[step.id] ?? 0) + 1;
+      iterationCounts[step.id] = nextIteration;
+      if (nextIteration > maxIterations) {
+        throw new Error(
+          `Workflow step ${step.id} exceeded max_iterations (${maxIterations}). ` +
+          `This usually indicates a loop that never exits.`,
+        );
+      }
     }
 
     if (isInputStep(step.input)) {
@@ -616,6 +619,16 @@ async function loadWorkflowResumeState(env: Record<string, string | undefined>, 
   if (typeof data.resumeAtIndex !== 'number') throw new Error('Invalid workflow resume state');
   if (!data.steps || typeof data.steps !== 'object') throw new Error('Invalid workflow resume state');
   if (!data.args || typeof data.args !== 'object') throw new Error('Invalid workflow resume state');
+  if (data.iterationCounts !== undefined) {
+    if (!data.iterationCounts || typeof data.iterationCounts !== 'object' || Array.isArray(data.iterationCounts)) {
+      throw new Error('Invalid workflow resume state');
+    }
+    for (const value of Object.values(data.iterationCounts)) {
+      if (!Number.isInteger(value) || (value as number) < 0) {
+        throw new Error('Invalid workflow resume state');
+      }
+    }
+  }
   return data as WorkflowResumeState;
 }
 
@@ -1088,6 +1101,32 @@ function resolveMaxIterations(value: WorkflowStep['max_iterations']) {
   return value;
 }
 
+function collectJumpTargets(steps: WorkflowStep[]) {
+  const out = new Set<string>();
+  for (const step of steps) {
+    if (typeof step.next === 'string' && step.next.trim()) {
+      out.add(step.next.trim());
+    }
+    if (typeof step.on_error === 'string') {
+      const target = step.on_error.trim();
+      if (target && target !== 'fail' && target !== 'skip') {
+        out.add(target);
+      }
+    }
+  }
+  return out;
+}
+
+function shouldTrackStepIterations(step: WorkflowStep, jumpTargets: Set<string>) {
+  if (step.max_iterations !== undefined) return true;
+  if (typeof step.next === 'string' && step.next.trim()) return true;
+  if (typeof step.on_error === 'string') {
+    const target = step.on_error.trim();
+    if (target && target !== 'fail' && target !== 'skip') return true;
+  }
+  return jumpTargets.has(step.id);
+}
+
 function renderTemplateValue(value: unknown) {
   if (value === undefined || value === null) return '';
   if (typeof value === 'string') return value;
@@ -1126,13 +1165,11 @@ function evaluateExpression(expression: string, results: Record<string, Workflow
   }
   if (hasAnd) {
     const parts = splitConditionByOperator(expression, '&&');
-    if (parts.length !== 2) throw new Error(`Unsupported condition: ${expression}`);
-    return evaluateAtom(parts[0], results) && evaluateAtom(parts[1], results);
+    return parts.every((part) => evaluateAtom(part, results));
   }
   if (hasOr) {
     const parts = splitConditionByOperator(expression, '||');
-    if (parts.length !== 2) throw new Error(`Unsupported condition: ${expression}`);
-    return evaluateAtom(parts[0], results) || evaluateAtom(parts[1], results);
+    return parts.some((part) => evaluateAtom(part, results));
   }
   return evaluateAtom(expression, results);
 }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1,7 +1,6 @@
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { Ajv } from 'ajv';
 
 import { randomUUID } from 'node:crypto';
 import { PassThrough } from 'node:stream';
@@ -12,6 +11,7 @@ import { encodeToken } from '../token.js';
 import { deleteStateJson, readStateJson, writeStateJson } from '../state/store.js';
 import { readLineFromStream } from '../read_line.js';
 import { resolveInlineShellCommand } from '../shell.js';
+import { sharedAjv } from '../validation.js';
 
 export type WorkflowFile = {
   name?: string;
@@ -53,7 +53,7 @@ export type WorkflowApproval =
 
 export type WorkflowInputRequest = {
   prompt: string;
-  responseSchema?: unknown;
+  responseSchema: unknown;
   defaults?: unknown;
 };
 
@@ -269,6 +269,7 @@ export async function runWorkflowFile({
   resume,
   approved,
   response,
+  cancel,
 }: {
   filePath?: string;
   args?: Record<string, unknown>;
@@ -276,6 +277,7 @@ export async function runWorkflowFile({
   resume?: WorkflowResumePayload;
   approved?: boolean;
   response?: unknown;
+  cancel?: boolean;
 }): Promise<WorkflowRunResult> {
   const consumedResumeStateKey = resume?.stateKey && typeof resume.stateKey === 'string'
     ? resume.stateKey
@@ -298,16 +300,22 @@ export async function runWorkflowFile({
     ? { ...resumeState.iterationCounts }
     : {};
   const startIndex = resumeState?.resumeAtIndex ?? 0;
+  if (resumeState?.approvalStepId && resumeState?.inputStepId) {
+    throw new Error('Invalid workflow resume state');
+  }
 
   if (resumeState?.approvalStepId) {
-    if (typeof approved !== 'boolean') {
+    if (response !== undefined) {
       throw new WorkflowResumeArgumentError('Workflow resume requires --approve yes|no for approval requests');
     }
-    if (approved === false) {
+    if (cancel === true || approved === false) {
       if (consumedResumeStateKey) {
         await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
       }
       return { status: 'cancelled', output: [] };
+    }
+    if (typeof approved !== 'boolean') {
+      throw new WorkflowResumeArgumentError('Workflow resume requires --approve yes|no for approval requests');
     }
     const previous = results[resumeState.approvalStepId] ?? { id: resumeState.approvalStepId };
     previous.approved = approved;
@@ -315,6 +323,15 @@ export async function runWorkflowFile({
   }
 
   if (resumeState?.inputStepId) {
+    if (cancel === true) {
+      if (consumedResumeStateKey) {
+        await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+      }
+      return { status: 'cancelled', output: [] };
+    }
+    if (approved !== undefined) {
+      throw new WorkflowResumeArgumentError('Workflow resume requires --response-json for input requests');
+    }
     if (response === undefined) {
       throw new WorkflowResumeArgumentError('Workflow resume requires --response-json for input requests');
     }
@@ -322,11 +339,15 @@ export async function runWorkflowFile({
     if (!inputStep || !isInputStep(inputStep.input)) {
       throw new Error(`Invalid input step in resume state: ${resumeState.inputStepId}`);
     }
-    validateInputResponse({
-      schema: resumeState.inputSchema ?? inputStep.input.responseSchema,
-      response,
-      stepId: inputStep.id,
-    });
+    try {
+      validateInputResponse({
+        schema: resumeState.inputSchema ?? inputStep.input.responseSchema,
+        response,
+        stepId: inputStep.id,
+      });
+    } catch (err: any) {
+      throw new WorkflowResumeArgumentError(err?.message ?? String(err));
+    }
     const previous = results[resumeState.inputStepId] ?? { id: resumeState.inputStepId };
     previous.subject = resumeState.inputSubject ?? null;
     previous.response = response;
@@ -344,7 +365,10 @@ export async function runWorkflowFile({
     const step = steps[idx];
 
     if (!evaluateCondition(step.when ?? step.condition, results)) {
-      results[step.id] = { id: step.id, skipped: true };
+      const previous = results[step.id];
+      results[step.id] = previous
+        ? { ...previous, skipped: true }
+        : { id: step.id, skipped: true };
       idx += 1;
       continue;
     }
@@ -828,7 +852,6 @@ function parseApprovalTimeoutMs(env: Record<string, string | undefined>) {
   return Math.floor(value);
 }
 
-const inputResponseAjv = new Ajv({ allErrors: false, strict: false });
 const DURATION_PATTERN = /^(\d+)(ms|s|m|h)$/i;
 const DEFAULT_MAX_ITERATIONS = 20;
 const DEFAULT_RETRY_DELAY_MS = 1000;
@@ -849,7 +872,7 @@ function validateInputResponse(params: {
   response: unknown;
   stepId: string;
 }) {
-  const validator = inputResponseAjv.compile(params.schema as object);
+  const validator = sharedAjv.compile(params.schema as object);
   const ok = validator(params.response);
   if (ok) return;
   const first = validator.errors?.[0];

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -297,6 +297,29 @@ export async function runWorkflowFile({
   const resumeState = resume?.stateKey
     ? await loadWorkflowResumeState(ctx.env, resume.stateKey)
     : resume ?? null;
+  if (resumeState?.approvalStepId && resumeState?.inputStepId) {
+    throw new Error('Invalid workflow resume state');
+  }
+
+  if (resumeState?.approvalStepId) {
+    if (response !== undefined) {
+      throw new WorkflowResumeArgumentError('Workflow resume requires --approve yes|no for approval requests');
+    }
+    if (cancel === true || approved === false) {
+      if (consumedResumeStateKey) {
+        await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+      }
+      return { status: 'cancelled', output: [] };
+    }
+  }
+
+  if (resumeState?.inputStepId && cancel === true) {
+    if (consumedResumeStateKey) {
+      await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+    }
+    return { status: 'cancelled', output: [] };
+  }
+
   const resolvedFilePath = filePath ?? resumeState?.filePath;
   if (!resolvedFilePath) {
     throw new Error('Workflow file path required');
@@ -313,19 +336,9 @@ export async function runWorkflowFile({
     ? { ...resumeState.iterationCounts }
     : {};
   const startIndex = resumeState?.resumeAtIndex ?? 0;
-  if (resumeState?.approvalStepId && resumeState?.inputStepId) {
-    throw new Error('Invalid workflow resume state');
-  }
-
   if (resumeState?.approvalStepId) {
     if (response !== undefined) {
       throw new WorkflowResumeArgumentError('Workflow resume requires --approve yes|no for approval requests');
-    }
-    if (cancel === true || approved === false) {
-      if (consumedResumeStateKey) {
-        await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-      }
-      return { status: 'cancelled', output: [] };
     }
     if (typeof approved !== 'boolean') {
       throw new WorkflowResumeArgumentError('Workflow resume requires --approve yes|no for approval requests');
@@ -336,12 +349,6 @@ export async function runWorkflowFile({
   }
 
   if (resumeState?.inputStepId) {
-    if (cancel === true) {
-      if (consumedResumeStateKey) {
-        await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-      }
-      return { status: 'cancelled', output: [] };
-    }
     if (approved !== undefined) {
       throw new WorkflowResumeArgumentError('Workflow resume requires --response-json for input requests');
     }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -866,6 +866,7 @@ function resolveInputSubject(params: {
   const previous = params.results[params.lastStepId];
   if (!previous) return null;
   if (previous.json !== undefined) return previous.json;
+  if (previous.response !== undefined) return previous.response;
   if (previous.stdout !== undefined) return previous.stdout;
   return null;
 }

--- a/test/core_tool_runtime.test.ts
+++ b/test/core_tool_runtime.test.ts
@@ -275,6 +275,117 @@ test('resumeToolRequest validates pipeline input response against ask schema', a
   assert.deepEqual(good.output, ['hello']);
 });
 
+test('resumeToolRequest maps workflow input schema validation failures to parse_error', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-workflow-schema-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: path.join(tmpDir, 'state'),
+  };
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Provide title',
+              responseSchema: { type: 'string' },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const first = await runToolRequest({
+    filePath,
+    ctx: { env },
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.status, 'needs_input');
+  assert.ok(first.requiresInput?.resumeToken);
+
+  const bad = await resumeToolRequest({
+    token: first.requiresInput?.resumeToken ?? '',
+    response: { not: 'a string' },
+    ctx: { env },
+  });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.error?.type, 'parse_error');
+  assert.match(String(bad.error?.message), /schema validation/i);
+});
+
+test('resumeToolRequest supports explicit cancel for input requests', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-cancel-input-'));
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: path.join(tmpDir, 'state'),
+  };
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string' } },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const workflowFirst = await runToolRequest({
+    filePath,
+    ctx: { env },
+  });
+  assert.equal(workflowFirst.ok, true);
+  assert.equal(workflowFirst.status, 'needs_input');
+  assert.ok(workflowFirst.requiresInput?.resumeToken);
+
+  const workflowCancelled = await resumeToolRequest({
+    token: workflowFirst.requiresInput?.resumeToken ?? '',
+    cancel: true,
+    ctx: { env },
+  });
+  assert.equal(workflowCancelled.ok, true);
+  assert.equal(workflowCancelled.status, 'cancelled');
+
+  const pipelineFirst = await runToolRequest({
+    pipeline: "ask --prompt 'Decision?' --schema '{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\"}},\"required\":[\"decision\"]}'",
+    ctx: { env },
+  });
+  assert.equal(pipelineFirst.ok, true);
+  assert.equal(pipelineFirst.status, 'needs_input');
+  assert.ok(pipelineFirst.requiresInput?.resumeToken);
+
+  const pipelineCancelled = await resumeToolRequest({
+    token: pipelineFirst.requiresInput?.resumeToken ?? '',
+    cancel: true,
+    ctx: { env },
+  });
+  assert.equal(pipelineCancelled.ok, true);
+  assert.equal(pipelineCancelled.status, 'cancelled');
+});
+
 test('ask command fails fast on invalid --schema JSON', async () => {
   const envelope = await runToolRequest({
     pipeline: "ask --prompt 'Decision?' --schema '{'",

--- a/test/core_tool_runtime.test.ts
+++ b/test/core_tool_runtime.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 
 import { resumeToolRequest, runToolRequest } from '../src/core/index.js';
+import { encodeToken } from '../src/token.js';
 
 function createDirectAdapter(resultText: string) {
   const calls: Array<Record<string, unknown>> = [];
@@ -125,4 +126,205 @@ test('resumeToolRequest completes approval-gated workflow with injected llm adap
   assert.equal(resumed.status, 'ok');
   assert.equal((resumed.output![0] as any).output.data.reason, 'warm');
   assert.equal(calls.length, 1);
+});
+
+test('runToolRequest/resumeToolRequest handles needs_input workflow pauses', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-input-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'hello'}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string', enum: ['approve', 'reject'] } },
+                required: ['decision'],
+              },
+            },
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:process.env.TEXT}))\"",
+            env: { TEXT: '$review.subject.text' },
+            when: '$review.response.decision == approve',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: path.join(tmpDir, 'state'),
+  };
+
+  const first = await runToolRequest({
+    filePath,
+    ctx: { cwd: tmpDir, env },
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.status, 'needs_input');
+  assert.ok(first.requiresInput?.resumeToken);
+  assert.deepEqual(first.requiresInput?.subject, { text: 'hello' });
+
+  const resumed = await resumeToolRequest({
+    token: first.requiresInput?.resumeToken ?? '',
+    response: { decision: 'approve' },
+    ctx: { cwd: tmpDir, env },
+  });
+  assert.equal(resumed.ok, true);
+  assert.equal(resumed.status, 'ok');
+  assert.deepEqual(resumed.output, [{ text: 'hello' }]);
+});
+
+test('resumeToolRequest enforces pipeline pause type for approval/input resumes', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-pipeline-guards-'));
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: path.join(tmpDir, 'state'),
+  };
+
+  const approvalRun = await runToolRequest({
+    pipeline: 'approve --prompt "ok?"',
+    ctx: { env },
+  });
+  assert.equal(approvalRun.ok, true);
+  assert.equal(approvalRun.status, 'needs_approval');
+  assert.ok(approvalRun.requiresApproval?.resumeToken);
+
+  const wrongApprovalResume = await resumeToolRequest({
+    token: approvalRun.requiresApproval?.resumeToken ?? '',
+    response: { decision: 'approve' },
+    ctx: { env },
+  });
+  assert.equal(wrongApprovalResume.ok, false);
+  assert.equal(wrongApprovalResume.error?.type, 'parse_error');
+  assert.match(String(wrongApprovalResume.error?.message), /approval resumes require approved/i);
+
+  const inputRun = await runToolRequest({
+    pipeline: "ask --prompt 'Decision?' --schema '{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\"}},\"required\":[\"decision\"]}'",
+    ctx: { env },
+  });
+  assert.equal(inputRun.ok, true);
+  assert.equal(inputRun.status, 'needs_input');
+  assert.ok(inputRun.requiresInput?.resumeToken);
+
+  const wrongInputResume = await resumeToolRequest({
+    token: inputRun.requiresInput?.resumeToken ?? '',
+    approved: true,
+    ctx: { env },
+  });
+  assert.equal(wrongInputResume.ok, false);
+  assert.equal(wrongInputResume.error?.type, 'parse_error');
+  assert.match(String(wrongInputResume.error?.message), /input resumes require response/i);
+});
+
+test('resumeToolRequest validates pipeline input response against ask schema', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-pipeline-schema-'));
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: path.join(tmpDir, 'state'),
+  };
+
+  const first = await runToolRequest({
+    pipeline: "ask --prompt 'Value?' --schema '{\"type\":\"string\"}'",
+    ctx: { env },
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.status, 'needs_input');
+  assert.ok(first.requiresInput?.resumeToken);
+
+  const bad = await resumeToolRequest({
+    token: first.requiresInput?.resumeToken ?? '',
+    response: { not: 'a string' },
+    ctx: { env },
+  });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.error?.type, 'parse_error');
+  assert.match(String(bad.error?.message), /schema validation/i);
+
+  const good = await resumeToolRequest({
+    token: first.requiresInput?.resumeToken ?? '',
+    response: 'hello',
+    ctx: { env },
+  });
+  assert.equal(good.ok, true);
+  assert.equal(good.status, 'ok');
+  assert.deepEqual(good.output, ['hello']);
+});
+
+test('ask command fails fast on invalid --schema JSON', async () => {
+  const envelope = await runToolRequest({
+    pipeline: "ask --prompt 'Decision?' --schema '{'",
+    ctx: { env: process.env },
+  });
+
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.error?.type, 'runtime_error');
+  assert.match(String(envelope.error?.message), /ask --schema must be valid JSON/i);
+});
+
+test('resumeToolRequest legacy pipeline state without haltType requires approved flag', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-legacy-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const stateKey = 'pipeline_resume_legacy_core';
+  await fsp.mkdir(stateDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(stateDir, `${stateKey}.json`),
+    JSON.stringify(
+      {
+        pipeline: [],
+        resumeAtIndex: 0,
+        items: [{ a: 1 }],
+        prompt: 'legacy',
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const token = encodeToken({
+    protocolVersion: 1,
+    v: 1,
+    kind: 'pipeline-resume',
+    stateKey,
+  });
+
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: stateDir,
+  };
+
+  const bad = await resumeToolRequest({
+    token,
+    response: { decision: 'approve' },
+    ctx: { env },
+  });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.error?.type, 'parse_error');
+  assert.match(String(bad.error?.message), /legacy pipeline resumes require approved/i);
+
+  const good = await resumeToolRequest({
+    token,
+    approved: true,
+    ctx: { env },
+  });
+  assert.equal(good.ok, true);
+  assert.equal(good.status, 'ok');
+  assert.deepEqual(good.output, [{ a: 1 }]);
 });

--- a/test/core_tool_runtime.test.ts
+++ b/test/core_tool_runtime.test.ts
@@ -507,6 +507,17 @@ test('ask command fails fast on invalid --schema JSON', async () => {
   assert.match(String(envelope.error?.message), /ask --schema must be valid JSON/i);
 });
 
+test('ask command fails fast on invalid --schema object', async () => {
+  const envelope = await runToolRequest({
+    pipeline: "ask --prompt 'Decision?' --schema '{\"type\":\"wat\"}'",
+    ctx: { env: process.env },
+  });
+
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.error?.type, 'runtime_error');
+  assert.match(String(envelope.error?.message), /ask response schema is invalid/i);
+});
+
 test('resumeToolRequest legacy pipeline state without haltType requires approved flag', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-legacy-'));
   const stateDir = path.join(tmpDir, 'state');

--- a/test/core_tool_runtime.test.ts
+++ b/test/core_tool_runtime.test.ts
@@ -437,6 +437,65 @@ test('runToolRequest omits subject when ask does not provide one', async () => {
   assert.equal(Object.prototype.hasOwnProperty.call(envelope.requiresInput, 'subject'), false);
 });
 
+test('runToolRequest can pause on input requests with non-serializable halt items', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-input-items-'));
+  const stateDir = path.join(tmpDir, 'state');
+
+  const cyclic: any = { value: 'x' };
+  cyclic.self = cyclic;
+
+  const emitInputCommand = {
+    name: 'emit_input',
+    meta: { description: 'emit test input_request' },
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Decision?',
+            responseSchema: {
+              type: 'object',
+              properties: { decision: { type: 'string' } },
+              required: ['decision'],
+            },
+            subject: { text: 'draft' },
+            items: [cyclic],
+          };
+        })(),
+      };
+    },
+  };
+
+  const registry = {
+    get(name: string) {
+      if (name === 'emit_input') return emitInputCommand;
+      return undefined;
+    },
+    list() {
+      return ['emit_input'];
+    },
+  };
+
+  const envelope = await runToolRequest({
+    pipeline: 'emit_input',
+    ctx: {
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      registry: registry as any,
+    },
+  });
+
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.status, 'needs_input');
+  assert.ok(envelope.requiresInput?.resumeToken);
+
+  const files = await fsp.readdir(stateDir);
+  const stateFile = files.find((name) => name.startsWith('pipeline_resume_') && name.endsWith('.json'));
+  assert.ok(stateFile);
+  const persisted = JSON.parse(await fsp.readFile(path.join(stateDir, stateFile!), 'utf8'));
+  assert.deepEqual(persisted.items, []);
+});
+
 test('ask command fails fast on invalid --schema JSON', async () => {
   const envelope = await runToolRequest({
     pipeline: "ask --prompt 'Decision?' --schema '{'",

--- a/test/core_tool_runtime.test.ts
+++ b/test/core_tool_runtime.test.ts
@@ -275,6 +275,46 @@ test('resumeToolRequest validates pipeline input response against ask schema', a
   assert.deepEqual(good.output, ['hello']);
 });
 
+test('resumeToolRequest validates boolean input schemas in pipeline resume state', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-bool-schema-'));
+  const stateDir = path.join(tmpDir, 'state');
+  await fsp.mkdir(stateDir, { recursive: true });
+  const stateKey = 'pipeline_resume_boolean_schema';
+  await fsp.writeFile(
+    path.join(stateDir, `${stateKey}.json`),
+    JSON.stringify(
+      {
+        pipeline: [],
+        resumeAtIndex: 0,
+        items: [],
+        haltType: 'input_request',
+        inputSchema: false,
+        prompt: 'Denied by schema',
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const token = encodeToken({
+    protocolVersion: 1,
+    v: 1,
+    kind: 'pipeline-resume',
+    stateKey,
+  });
+
+  const bad = await resumeToolRequest({
+    token,
+    response: { decision: 'approve' },
+    ctx: { env: { ...process.env, LOBSTER_STATE_DIR: stateDir } },
+  });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.error?.type, 'parse_error');
+  assert.match(String(bad.error?.message), /schema validation/i);
+});
+
 test('resumeToolRequest maps workflow input schema validation failures to parse_error', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-core-tool-runtime-workflow-schema-'));
   const filePath = path.join(tmpDir, 'workflow.lobster');
@@ -384,6 +424,17 @@ test('resumeToolRequest supports explicit cancel for input requests', async () =
   });
   assert.equal(pipelineCancelled.ok, true);
   assert.equal(pipelineCancelled.status, 'cancelled');
+});
+
+test('runToolRequest omits subject when ask does not provide one', async () => {
+  const envelope = await runToolRequest({
+    pipeline: "ask --prompt 'Decision?' --schema '{\"type\":\"string\"}'",
+    ctx: { env: process.env },
+  });
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.status, 'needs_input');
+  assert.ok(envelope.requiresInput);
+  assert.equal(Object.prototype.hasOwnProperty.call(envelope.requiresInput, 'subject'), false);
 });
 
 test('ask command fails fast on invalid --schema JSON', async () => {

--- a/test/core_tool_runtime.test.ts
+++ b/test/core_tool_runtime.test.ts
@@ -180,6 +180,15 @@ test('runToolRequest/resumeToolRequest handles needs_input workflow pauses', asy
   assert.ok(first.requiresInput?.resumeToken);
   assert.deepEqual(first.requiresInput?.subject, { text: 'hello' });
 
+  const wrongCancel = await resumeToolRequest({
+    token: first.requiresInput?.resumeToken ?? '',
+    approved: false,
+    ctx: { cwd: tmpDir, env },
+  });
+  assert.equal(wrongCancel.ok, false);
+  assert.equal(wrongCancel.error?.type, 'parse_error');
+  assert.match(String(wrongCancel.error?.message), /response-json.*input requests/i);
+
   const resumed = await resumeToolRequest({
     token: first.requiresInput?.resumeToken ?? '',
     response: { decision: 'approve' },

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -80,3 +80,224 @@ test('resume cancellation cleans up pipeline resume state', async () => {
   const pipelineResumeFiles = files.filter((name) => name.startsWith('pipeline_resume_'));
   assert.deepEqual(pipelineResumeFiles, []);
 });
+
+test('cli resume accepts --response-json for input requests', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-input-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'hello'}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string', enum: ['approve', 'reject'] } },
+                required: ['decision'],
+              },
+            },
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:process.env.TEXT}))\"",
+            env: { TEXT: '$review.subject.text' },
+            when: '$review.response.decision == approve',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const first = runCli(['run', '--mode', 'tool', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+  assert.ok(firstJson.requiresInput?.resumeToken);
+
+  const resumed = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(resumed.status, 0);
+  const resumedJson = JSON.parse(resumed.stdout);
+  assert.equal(resumedJson.status, 'ok');
+  assert.deepEqual(resumedJson.output, [{ text: 'hello' }]);
+});
+
+test('resume rejects invalid --response-json with stable parse error', () => {
+  const resumed = runCli(
+    ['resume', '--token', 'invalid-token', '--response-json', '{'],
+    {},
+  );
+  assert.equal(resumed.status, 2);
+  const resumedJson = JSON.parse(resumed.stdout);
+  assert.equal(resumedJson.ok, false);
+  assert.equal(resumedJson.error?.type, 'parse_error');
+  assert.equal(resumedJson.error?.message, 'resume --response-json must be valid JSON');
+});
+
+test('pipeline needs_input tokens reject --approve and remain resumable with --response-json', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-pipeline-needs-input-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const pipeline =
+    "ask --prompt 'Decision?' --schema '{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\"}},\"required\":[\"decision\"]}' | pick decision";
+
+  const first = runCli(['run', '--mode', 'tool', pipeline], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+
+  const bad = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--approve', 'yes'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(bad.status, 2);
+  const badJson = JSON.parse(bad.stdout);
+  assert.equal(badJson.ok, false);
+  assert.match(String(badJson.error?.message), /require --response-json/i);
+
+  const good = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(good.status, 0);
+  const goodJson = JSON.parse(good.stdout);
+  assert.equal(goodJson.status, 'ok');
+  assert.deepEqual(goodJson.output, [{ decision: 'approve' }]);
+});
+
+test('pipeline needs_approval tokens reject --response-json and remain resumable with --approve', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-pipeline-needs-approval-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const pipeline =
+    "exec --json --shell \"node -e 'process.stdout.write(JSON.stringify([{a:1}]))'\" | approve --prompt 'ok?' | pick a";
+
+  const first = runCli(['run', '--mode', 'tool', pipeline], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_approval');
+
+  const bad = runCli(
+    ['resume', '--token', firstJson.requiresApproval.resumeToken, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(bad.status, 2);
+  const badJson = JSON.parse(bad.stdout);
+  assert.equal(badJson.ok, false);
+  assert.match(String(badJson.error?.message), /require --approve/i);
+
+  const good = runCli(
+    ['resume', '--token', firstJson.requiresApproval.resumeToken, '--approve', 'yes'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(good.status, 0);
+  const goodJson = JSON.parse(good.stdout);
+  assert.equal(goodJson.status, 'ok');
+});
+
+test('workflow input schemas can accept primitive responses', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-input-primitive-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Provide title',
+              responseSchema: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:process.env.TEXT}))\"",
+            env: { TEXT: '$review.response' },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const first = runCli(['run', '--mode', 'tool', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+
+  const resumed = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '"hello world"'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(resumed.status, 0);
+  const resumedJson = JSON.parse(resumed.stdout);
+  assert.equal(resumedJson.status, 'ok');
+  assert.deepEqual(resumedJson.output, [{ text: 'hello world' }]);
+});
+
+test('legacy pipeline resume state without haltType requires --approve', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-legacy-pipeline-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const stateKey = 'pipeline_resume_legacy_test';
+  await fsp.mkdir(stateDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(stateDir, `${stateKey}.json`),
+    JSON.stringify(
+      {
+        pipeline: [],
+        resumeAtIndex: 0,
+        items: [{ a: 1 }],
+        prompt: 'legacy',
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const token = encodeToken({
+    protocolVersion: 1,
+    v: 1,
+    kind: 'pipeline-resume',
+    stateKey,
+  });
+
+  const bad = runCli(
+    ['resume', '--token', token, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(bad.status, 2);
+  const badJson = JSON.parse(bad.stdout);
+  assert.equal(badJson.ok, false);
+  assert.match(String(badJson.error?.message), /legacy pipeline resumes require --approve/i);
+
+  const good = runCli(
+    ['resume', '--token', token, '--approve', 'yes'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(good.status, 0);
+  const goodJson = JSON.parse(good.stdout);
+  assert.equal(goodJson.ok, true);
+  assert.equal(goodJson.status, 'ok');
+  assert.deepEqual(goodJson.output, [{ a: 1 }]);
+});

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -415,6 +415,82 @@ test('pipeline needs_input tokens reject --approve and remain resumable with --r
   assert.deepEqual(goodJson.output, [{ decision: 'approve' }]);
 });
 
+test('pipeline ask --subject-from-stdin survives halt and resume round-trips', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-pipeline-subject-roundtrip-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const pipeline =
+    `exec --shell "printf 'draft v1'"` +
+    ` | ask --prompt 'First?' --subject-from-stdin --schema '{"type":"object","properties":{"decision":{"type":"string"}},"required":["decision"]}'` +
+    ` | ask --prompt 'Second?' --subject-from-stdin --schema '{"type":"object","properties":{"confirm":{"type":"string"}},"required":["confirm"]}'` +
+    ` | pick confirm`;
+
+  const first = runCli(['run', '--mode', 'tool', pipeline], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+  assert.equal(typeof firstJson.requiresInput?.subject?.text, 'string');
+  assert.match(String(firstJson.requiresInput?.subject?.text), /draft v1/i);
+
+  const second = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '{"decision":"redraft"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(second.status, 0);
+  const secondJson = JSON.parse(second.stdout);
+  assert.equal(secondJson.status, 'needs_input');
+  assert.equal(typeof secondJson.requiresInput?.subject?.text, 'string');
+  assert.match(String(secondJson.requiresInput?.subject?.text), /redraft/i);
+
+  const done = runCli(
+    ['resume', '--token', secondJson.requiresInput.resumeToken, '--response-json', '{"confirm":"yes"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(done.status, 0);
+  const doneJson = JSON.parse(done.stdout);
+  assert.equal(doneJson.status, 'ok');
+  assert.deepEqual(doneJson.output, [{ confirm: 'yes' }]);
+});
+
+test('pipeline input resumes fail fast when stored inputSchema is missing', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-pipeline-missing-input-schema-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const stateKey = 'pipeline_resume_missing_input_schema';
+  await fsp.mkdir(stateDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(stateDir, `${stateKey}.json`),
+    JSON.stringify(
+      {
+        pipeline: [],
+        resumeAtIndex: 0,
+        items: [],
+        haltType: 'input_request',
+        prompt: 'Decision?',
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const token = encodeToken({
+    protocolVersion: 1,
+    v: 1,
+    kind: 'pipeline-resume',
+    stateKey,
+  });
+
+  const bad = runCli(
+    ['resume', '--token', token, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(bad.status, 2);
+  const badJson = JSON.parse(bad.stdout);
+  assert.equal(badJson.ok, false);
+  assert.equal(badJson.error?.type, 'parse_error');
+  assert.match(String(badJson.error?.message), /schema is missing/i);
+});
+
 test('pipeline needs_approval tokens reject --response-json and remain resumable with --approve', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-pipeline-needs-approval-'));
   const stateDir = path.join(tmpDir, 'state');

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -81,6 +81,50 @@ test('resume cancellation cleans up pipeline resume state', async () => {
   assert.deepEqual(pipelineResumeFiles, []);
 });
 
+test('workflow approval resume reports cancelled status in CLI', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-workflow-cancel-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'approve_step',
+            run: "node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?',items:[{id:1}]}}))\"",
+            approval: 'required',
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+            when: '$approve_step.approved',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const first = runCli(['run', '--mode', 'tool', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_approval');
+  assert.ok(firstJson.requiresApproval?.resumeToken);
+
+  const cancelled = runCli(
+    ['resume', '--token', firstJson.requiresApproval.resumeToken, '--approve', 'no'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(cancelled.status, 0);
+  const cancelledJson = JSON.parse(cancelled.stdout);
+  assert.equal(cancelledJson.status, 'cancelled');
+  assert.deepEqual(cancelledJson.output, []);
+});
+
 test('cli resume accepts --response-json for input requests', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-input-'));
   const stateDir = path.join(tmpDir, 'state');
@@ -134,6 +178,199 @@ test('cli resume accepts --response-json for input requests', async () => {
   const resumedJson = JSON.parse(resumed.stdout);
   assert.equal(resumedJson.status, 'ok');
   assert.deepEqual(resumedJson.output, [{ text: 'hello' }]);
+});
+
+test('workflow needs_input schema mismatches return parse_error and keep token resumable', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-workflow-schema-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Provide title',
+              responseSchema: { type: 'string' },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const first = runCli(['run', '--mode', 'tool', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+
+  const bad = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '{"not":"a string"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(bad.status, 2);
+  const badJson = JSON.parse(bad.stdout);
+  assert.equal(badJson.ok, false);
+  assert.equal(badJson.error?.type, 'parse_error');
+  assert.match(String(badJson.error?.message), /schema validation/i);
+
+  const good = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '"hello"'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(good.status, 0);
+  const goodJson = JSON.parse(good.stdout);
+  assert.equal(goodJson.status, 'ok');
+  assert.deepEqual(goodJson.output, ['hello']);
+});
+
+test('workflow needs_input tokens reject --approve and remain resumable with --response-json', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-workflow-needs-input-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string', enum: ['approve', 'reject'] } },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const first = runCli(['run', '--mode', 'tool', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+
+  const bad = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--approve', 'no'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(bad.status, 2);
+  const badJson = JSON.parse(bad.stdout);
+  assert.equal(badJson.ok, false);
+  assert.equal(badJson.error?.type, 'parse_error');
+  assert.match(String(badJson.error?.message), /requires --response-json/i);
+
+  const good = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(good.status, 0);
+  const goodJson = JSON.parse(good.stdout);
+  assert.equal(goodJson.status, 'ok');
+  assert.deepEqual(goodJson.output, [{ decision: 'approve' }]);
+});
+
+test('workflow and pipeline needs_input tokens can be cancelled with --cancel', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-cancel-input-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string' } },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const workflowFirst = runCli(['run', '--mode', 'tool', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(workflowFirst.status, 0);
+  const workflowFirstJson = JSON.parse(workflowFirst.stdout);
+  assert.equal(workflowFirstJson.status, 'needs_input');
+
+  const workflowCancelled = runCli(
+    ['resume', '--token', workflowFirstJson.requiresInput.resumeToken, '--cancel'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(workflowCancelled.status, 0);
+  const workflowCancelledJson = JSON.parse(workflowCancelled.stdout);
+  assert.equal(workflowCancelledJson.status, 'cancelled');
+
+  const pipeline =
+    "ask --prompt 'Decision?' --schema '{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\"}},\"required\":[\"decision\"]}' | pick decision";
+  const pipelineFirst = runCli(['run', '--mode', 'tool', pipeline], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(pipelineFirst.status, 0);
+  const pipelineFirstJson = JSON.parse(pipelineFirst.stdout);
+  assert.equal(pipelineFirstJson.status, 'needs_input');
+
+  const pipelineCancelled = runCli(
+    ['resume', '--token', pipelineFirstJson.requiresInput.resumeToken, '--cancel'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(pipelineCancelled.status, 0);
+  const pipelineCancelledJson = JSON.parse(pipelineCancelled.stdout);
+  assert.equal(pipelineCancelledJson.status, 'cancelled');
+});
+
+test('resume --cancel false does not trigger cancellation', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-cancel-false-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const pipeline =
+    "ask --prompt 'Decision?' --schema '{\"type\":\"object\",\"properties\":{\"decision\":{\"type\":\"string\"}},\"required\":[\"decision\"]}' | pick decision";
+
+  const first = runCli(['run', '--mode', 'tool', pipeline], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(first.status, 0);
+  const firstJson = JSON.parse(first.stdout);
+  assert.equal(firstJson.status, 'needs_input');
+
+  const notCancelled = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--cancel', 'false'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(notCancelled.status, 2);
+  const notCancelledJson = JSON.parse(notCancelled.stdout);
+  assert.equal(notCancelledJson.ok, false);
+  assert.equal(notCancelledJson.error?.type, 'parse_error');
+  assert.match(String(notCancelledJson.error?.message), /requires --approve yes\|no, --response-json, or --cancel/i);
+
+  const resumed = runCli(
+    ['resume', '--token', firstJson.requiresInput.resumeToken, '--response-json', '{"decision":"approve"}'],
+    { LOBSTER_STATE_DIR: stateDir },
+  );
+  assert.equal(resumed.status, 0);
+  const resumedJson = JSON.parse(resumed.stdout);
+  assert.equal(resumedJson.status, 'ok');
+  assert.deepEqual(resumedJson.output, [{ decision: 'approve' }]);
 });
 
 test('resume rejects invalid --response-json with stable parse error', () => {

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -180,6 +180,42 @@ test('cli resume accepts --response-json for input requests', async () => {
   assert.deepEqual(resumedJson.output, [{ text: 'hello' }]);
 });
 
+test('cli run in non-interactive human mode surfaces needs_input with resume token', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-run-human-needs-input-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string', enum: ['approve', 'reject'] } },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const run = runCli(['run', filePath], { LOBSTER_STATE_DIR: stateDir });
+  assert.equal(run.status, 0);
+  const runJson = JSON.parse(run.stdout);
+  assert.equal(runJson.status, 'needs_input');
+  assert.ok(runJson.requiresInput?.resumeToken);
+});
+
 test('workflow needs_input schema mismatches return parse_error and keep token resumable', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resume-workflow-schema-'));
   const stateDir = path.join(tmpDir, 'state');

--- a/test/sdk_lobster.test.ts
+++ b/test/sdk_lobster.test.ts
@@ -142,3 +142,57 @@ test('sdk Lobster.resume rejects invalid structured input responses', async () =
     /does not match schema/i,
   );
 });
+
+test('sdk Lobster.resume treats boolean schemas as input resumes', async () => {
+  const workflow = new Lobster().pipe({
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Provide anything',
+            responseSchema: true,
+            subject: { text: 'draft v1' },
+          };
+        })(),
+      };
+    },
+  });
+
+  const first = await workflow.run();
+  assert.equal(first.status, 'needs_input');
+  const resumed = await workflow.resume(first.requiresInput!.resumeToken, {
+    response: { any: 'value' },
+  });
+  assert.equal(resumed.status, 'ok');
+  assert.deepEqual(resumed.output, [{ any: 'value' }]);
+});
+
+test('sdk Lobster.resume validates false boolean schemas as input resumes', async () => {
+  const workflow = new Lobster().pipe({
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Provide anything',
+            responseSchema: false,
+            subject: { text: 'draft v1' },
+          };
+        })(),
+      };
+    },
+  });
+
+  const first = await workflow.run();
+  assert.equal(first.status, 'needs_input');
+  await assert.rejects(
+    () =>
+      workflow.resume(first.requiresInput!.resumeToken, {
+        response: { any: 'value' },
+      }),
+    /does not match schema/i,
+  );
+});

--- a/test/sdk_lobster.test.ts
+++ b/test/sdk_lobster.test.ts
@@ -76,3 +76,69 @@ test('sdk Lobster.resume cancel still validates resume token', async () => {
     /invalid token/i,
   );
 });
+
+test('sdk Lobster.resume accepts valid structured input responses', async () => {
+  const workflow = new Lobster().pipe({
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Decision?',
+            responseSchema: {
+              type: 'object',
+              properties: { decision: { type: 'string', enum: ['approve', 'reject'] } },
+              required: ['decision'],
+            },
+            subject: { text: 'draft v1' },
+          };
+        })(),
+      };
+    },
+  });
+
+  const first = await workflow.run();
+  assert.equal(first.ok, true);
+  assert.equal(first.status, 'needs_input');
+  assert.ok(first.requiresInput?.resumeToken);
+
+  const resumed = await workflow.resume(first.requiresInput!.resumeToken, {
+    response: { decision: 'approve' },
+  });
+  assert.equal(resumed.ok, true);
+  assert.equal(resumed.status, 'ok');
+  assert.deepEqual(resumed.output, [{ decision: 'approve' }]);
+});
+
+test('sdk Lobster.resume rejects invalid structured input responses', async () => {
+  const workflow = new Lobster().pipe({
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Decision?',
+            responseSchema: {
+              type: 'object',
+              properties: { decision: { type: 'string', enum: ['approve', 'reject'] } },
+              required: ['decision'],
+            },
+            subject: { text: 'draft v1' },
+          };
+        })(),
+      };
+    },
+  });
+
+  const first = await workflow.run();
+  assert.equal(first.status, 'needs_input');
+  await assert.rejects(
+    () =>
+      workflow.resume(first.requiresInput!.resumeToken, {
+        response: { decision: 'maybe' },
+      }),
+    /does not match schema/i,
+  );
+});

--- a/test/sdk_lobster.test.ts
+++ b/test/sdk_lobster.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Lobster } from '../src/sdk/Lobster.js';
+
+test('sdk Lobster.resume supports cancel for input requests', async () => {
+  const workflow = new Lobster().pipe({
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Decision?',
+            responseSchema: {
+              type: 'object',
+              properties: { decision: { type: 'string' } },
+              required: ['decision'],
+            },
+            subject: { text: 'draft v1' },
+          };
+        })(),
+      };
+    },
+  });
+
+  const first = await workflow.run();
+  assert.equal(first.ok, true);
+  assert.equal(first.status, 'needs_input');
+  assert.ok(first.requiresInput?.resumeToken);
+
+  const cancelled = await workflow.resume(first.requiresInput!.resumeToken, { cancel: true });
+  assert.equal(cancelled.ok, true);
+  assert.equal(cancelled.status, 'cancelled');
+  assert.deepEqual(cancelled.output, []);
+});
+
+test('sdk Lobster.resume enforces a single resume intent', async () => {
+  const workflow = new Lobster().pipe({
+    async run() {
+      return {
+        halt: true,
+        output: (async function* () {
+          yield {
+            type: 'input_request',
+            prompt: 'Decision?',
+            responseSchema: { type: 'string' },
+            subject: { text: 'draft v1' },
+          };
+        })(),
+      };
+    },
+  });
+
+  const first = await workflow.run();
+  assert.equal(first.status, 'needs_input');
+  await assert.rejects(
+    () =>
+      workflow.resume(first.requiresInput!.resumeToken, {
+        cancel: true,
+        response: 'approve',
+      }),
+    /only one of approved, response, or cancel/i,
+  );
+});
+
+test('sdk Lobster.resume cancel still validates resume token', async () => {
+  const workflow = new Lobster();
+  await assert.rejects(
+    () => workflow.resume('not-a-token', { cancel: true }),
+    /invalid token/i,
+  );
+  const structurallyInvalid = Buffer.from(JSON.stringify({ protocolVersion: 1, v: 1 }), 'utf8').toString('base64url');
+  await assert.rejects(
+    () => workflow.resume(structurallyInvalid, { cancel: true }),
+    /invalid token/i,
+  );
+});

--- a/test/tool_mode.test.ts
+++ b/test/tool_mode.test.ts
@@ -156,3 +156,35 @@ test('ask keeps freeform decision UX in interactive mode for default schema', as
   for await (const it of result.output) items.push(it);
   assert.deepEqual(items, [{ decision: 'approve' }]);
 });
+
+test('ask treats quoted interactive strings like decisions for default schema', async () => {
+  const registry = createDefaultRegistry();
+  const cmd = registry.get('ask');
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  setImmediate(() => {
+    stdin.end('"approve"\n');
+  });
+
+  const result = await cmd.run({
+    input: streamOf([]),
+    args: {
+      _: [],
+      prompt: 'Decision?',
+    },
+    ctx: {
+      stdin,
+      stdout,
+      stderr: process.stderr,
+      env: process.env,
+      registry,
+      mode: 'human',
+      render: { json() {}, lines() {} },
+    },
+  });
+
+  const items = [];
+  for await (const it of result.output) items.push(it);
+  assert.deepEqual(items, [{ decision: 'approve' }]);
+});

--- a/test/tool_mode.test.ts
+++ b/test/tool_mode.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
 import { parsePipeline } from '../src/parser.js';
 import { createDefaultRegistry } from '../src/commands/registry.js';
 import { runPipeline } from '../src/runtime.js';
@@ -56,4 +57,102 @@ test('approve passes through in human interactive mode only (emit required other
   for await (const it of result.output) items.push(it);
   assert.equal(result.halt, true);
   assert.equal(items[0].type, 'approval_request');
+});
+
+test('ask validates interactive reply against string schema', async () => {
+  const registry = createDefaultRegistry();
+  const cmd = registry.get('ask');
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  setImmediate(() => {
+    stdin.end('approve\n');
+  });
+
+  const result = await cmd.run({
+    input: streamOf([]),
+    args: {
+      _: [],
+      prompt: 'Decision?',
+      schema: '{"type":"string","enum":["approve","reject"]}',
+    },
+    ctx: {
+      stdin,
+      stdout,
+      stderr: process.stderr,
+      env: process.env,
+      registry,
+      mode: 'human',
+      render: { json() {}, lines() {} },
+    },
+  });
+
+  const items = [];
+  for await (const it of result.output) items.push(it);
+  assert.deepEqual(items, ['approve']);
+});
+
+test('ask rejects invalid interactive reply when schema does not match', async () => {
+  const registry = createDefaultRegistry();
+  const cmd = registry.get('ask');
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  setImmediate(() => {
+    stdin.end('maybe\n');
+  });
+
+  await assert.rejects(
+    () =>
+      cmd.run({
+        input: streamOf([]),
+        args: {
+          _: [],
+          prompt: 'Decision?',
+          schema: '{"type":"string","enum":["approve","reject"]}',
+        },
+        ctx: {
+          stdin,
+          stdout,
+          stderr: process.stderr,
+          env: process.env,
+          registry,
+          mode: 'human',
+          render: { json() {}, lines() {} },
+        },
+      }),
+    /schema validation/i,
+  );
+});
+
+test('ask keeps freeform decision UX in interactive mode for default schema', async () => {
+  const registry = createDefaultRegistry();
+  const cmd = registry.get('ask');
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  setImmediate(() => {
+    stdin.end('approve\n');
+  });
+
+  const result = await cmd.run({
+    input: streamOf([]),
+    args: {
+      _: [],
+      prompt: 'Decision?',
+    },
+    ctx: {
+      stdin,
+      stdout,
+      stderr: process.stderr,
+      env: process.env,
+      registry,
+      mode: 'human',
+      render: { json() {}, lines() {} },
+    },
+  });
+
+  const items = [];
+  for await (const it of result.output) items.push(it);
+  assert.deepEqual(items, [{ decision: 'approve' }]);
 });

--- a/test/tool_mode.test.ts
+++ b/test/tool_mode.test.ts
@@ -125,6 +125,39 @@ test('ask rejects invalid interactive reply when schema does not match', async (
   );
 });
 
+test('ask reports invalid interactive schema with a stable error', async () => {
+  const registry = createDefaultRegistry();
+  const cmd = registry.get('ask');
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  setImmediate(() => {
+    stdin.end('approve\n');
+  });
+
+  await assert.rejects(
+    () =>
+      cmd.run({
+        input: streamOf([]),
+        args: {
+          _: [],
+          prompt: 'Decision?',
+          schema: '{"type":"wat"}',
+        },
+        ctx: {
+          stdin,
+          stdout,
+          stderr: process.stderr,
+          env: process.env,
+          registry,
+          mode: 'human',
+          render: { json() {}, lines() {} },
+        },
+      }),
+    /schema is invalid/i,
+  );
+});
+
 test('ask keeps freeform decision UX in interactive mode for default schema', async () => {
   const registry = createDefaultRegistry();
   const cmd = registry.get('ask');

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -143,6 +143,65 @@ test('workflow resume cancellation cleans up resume state', async () => {
   assert.deepEqual(resumeStateFiles, []);
 });
 
+test('workflow approval denial succeeds even when workflow file is missing', async () => {
+  const workflow = {
+    steps: [
+      {
+        id: 'approve_step',
+        command: "node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?', items:[{id:1}]}}))\"",
+        approval: 'required',
+      },
+      {
+        id: 'finish',
+        command: "node -e \"process.stdout.write(JSON.stringify({done:true}))\"",
+        condition: '$approve_step.approved',
+      },
+    ],
+  };
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-cancel-missing-file-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env,
+      mode: 'tool',
+    },
+  });
+  assert.equal(first.status, 'needs_approval');
+
+  const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+  assert.ok(payload.stateKey);
+
+  await fsp.rm(filePath);
+
+  const cancelled = await runWorkflowFile({
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env,
+      mode: 'tool',
+    },
+    resume: payload,
+    approved: false,
+  });
+
+  assert.equal(cancelled.status, 'cancelled');
+  assert.deepEqual(cancelled.output, []);
+  const files = await fsp.readdir(stateDir);
+  const resumeStateFiles = files.filter((name) => name.startsWith('workflow_resume_'));
+  assert.deepEqual(resumeStateFiles, []);
+});
+
 test('workflow files can mix shell steps, approval-only steps, and pipeline llm steps', async () => {
   const registry = createDefaultRegistry();
   const requests: any[] = [];

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -938,6 +938,45 @@ test('next loops fail fast when max_iterations is exceeded', async () => {
   );
 });
 
+test('on_error backward jumps fail fast when max_iterations is exceeded', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-on-error-backward-loop-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'start',
+            run: "node -e \"process.stdout.write('{}')\"",
+            next: 'flaky',
+          },
+          {
+            id: 'flaky',
+            run: "node -e \"process.stderr.write('boom'); process.exit(1)\"",
+            max_iterations: 2,
+            on_error: 'start',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /step flaky exceeded max_iterations/i,
+  );
+});
+
 test('workflow parser rejects invalid next declarations', async () => {
   const cases = [
     {

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -638,6 +638,63 @@ test('input step reads response from interactive TTY mode', async () => {
   assert.deepEqual(result.output, [{ decision: 'approve', text: 'hello' }]);
 });
 
+test('interactive input mode ignores tool envelope size limits', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-interactive-no-envelope-limit-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'P'.repeat(20_000),
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  setImmediate(() => {
+    stdin.end('{"decision":"approve"}\n');
+  });
+
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: stateDir,
+    LOBSTER_MAX_TOOL_ENVELOPE_BYTES: '1024',
+  } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env, {
+      stdin,
+      stdout,
+      stderr,
+      mode: 'human',
+    }),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ decision: 'approve' }]);
+});
+
 test('terminal input step emits submitted response in interactive mode', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-terminal-interactive-output-'));
   const stateDir = path.join(tmpDir, 'state');
@@ -1114,6 +1171,19 @@ test('workflow parser rejects invalid next declarations', async () => {
       pattern: /next cannot be empty/i,
     },
     {
+      name: 'next target explicit empty string',
+      workflow: {
+        steps: [
+          {
+            id: 'a',
+            run: "node -e \"process.stdout.write('{}')\"",
+            next: '',
+          },
+        ],
+      },
+      pattern: /next cannot be empty/i,
+    },
+    {
       name: 'next on input step',
       workflow: {
         steps: [
@@ -1227,6 +1297,85 @@ test('workflow parser rejects invalid input response schemas before pausing', as
         ctx: makeCtx(env),
       }),
     /input\.responseSchema is invalid/i,
+  );
+});
+
+test('workflow parser accepts repeated responseSchema $id across runs', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-shared-id-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                $id: 'urn:lobster:test:input-schema',
+                type: 'object',
+                properties: { decision: { type: 'string' } },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+
+  const second = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(second.status, 'needs_input');
+});
+
+test('workflow parser rejects non-string retry_delay with validation error', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-retry-delay-type-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'step1',
+            run: "node -e \"process.stdout.write('ok')\"",
+            retry: 1,
+            retry_delay: 100,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /retry_delay must be a duration like 1s or 500ms/i,
   );
 });
 

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -913,6 +913,59 @@ test('input resume rejects approved flag and supports explicit cancel', async ()
   assert.deepEqual(resumeStateFiles, []);
 });
 
+test('input cancel succeeds even when workflow file is missing', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-cancel-missing-file-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+  assert.ok(payload.stateKey);
+
+  await fsp.rm(filePath);
+
+  const cancelled = await runWorkflowFile({
+    ctx: makeCtx(env),
+    resume: payload as any,
+    cancel: true,
+  });
+  assert.equal(cancelled.status, 'cancelled');
+  const files = await fsp.readdir(stateDir);
+  const resumeStateFiles = files.filter((name) => name.startsWith('workflow_resume_'));
+  assert.deepEqual(resumeStateFiles, []);
+});
+
 test('workflow resume rejects invalid iterationCounts in stored state', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-invalid-iteration-counts-'));
   const stateDir = path.join(tmpDir, 'state');

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -977,6 +977,58 @@ test('on_error backward jumps fail fast when max_iterations is exceeded', async 
   );
 });
 
+test('loop revisit skip preserves data outputs but clears stale failure flags', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-loop-skip-clear-failure-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const markerPath = path.join(tmpDir, 'toggle.marker');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        env: {
+          MARKER: markerPath,
+        },
+        steps: [
+          {
+            id: 'toggle',
+            run: "node -e \"const fs=require('node:fs');const p=process.env.MARKER;const first=!fs.existsSync(p);if(first)fs.writeFileSync(p,'1');process.stdout.write(JSON.stringify({go:first}));\"",
+          },
+          {
+            id: 'flaky',
+            run: "node -e \"process.stderr.write('boom'); process.exit(1)\"",
+            when: '$toggle.json.go == true',
+            on_error: 'toggle',
+            max_iterations: 3,
+          },
+          {
+            id: 'report',
+            run: "node -e \"process.stdout.write(JSON.stringify({failed:process.env.FAILED==='true',error:process.env.ERROR||''}))\"",
+            env: {
+              FAILED: '$flaky.failed',
+              ERROR: '$flaky.error',
+            },
+            when: '$flaky.failed',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ go: false }]);
+});
+
 test('workflow parser rejects invalid next declarations', async () => {
   const cases = [
     {

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -340,6 +340,83 @@ test('next loops back to input step and subject tracks latest executed step outp
   assert.deepEqual(done.output, [{ published: 'v2' }]);
 });
 
+test('loop revisits preserve prior step output when later iteration skips the step', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-loop-skip-preserve-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'v1'}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve or redraft?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'redraft'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+          {
+            id: 'redraft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'v2'}))\"",
+            when: '$review.response.decision == redraft',
+            next: 'review',
+            max_iterations: 3,
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({picked:process.env.PICKED,decision:process.env.DECISION}))\"",
+            env: {
+              PICKED: '$redraft.json.text',
+              DECISION: '$review.response.decision',
+            },
+            when: '$review.response.decision == approve',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+
+  const first = await runWorkflowFile({ filePath, ctx: makeCtx(env) });
+  assert.equal(first.status, 'needs_input');
+  const firstPayload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(firstPayload.kind, 'workflow-file');
+
+  const second = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: firstPayload as any,
+    response: { decision: 'redraft' },
+  });
+  assert.equal(second.status, 'needs_input');
+  const secondPayload = decodeResumeToken(second.requiresInput?.resumeToken ?? '');
+  assert.equal(secondPayload.kind, 'workflow-file');
+
+  const done = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: secondPayload as any,
+    response: { decision: 'approve' },
+  });
+  assert.equal(done.status, 'ok');
+  assert.deepEqual(done.output, [{ picked: 'v2', decision: 'approve' }]);
+});
+
 test('retry and on_error jump mark step as failed and continue at target step', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-retry-'));
   const stateDir = path.join(tmpDir, 'state');
@@ -658,6 +735,69 @@ test('input resume requires response payload', async () => {
       }),
     /requires --response-json/i,
   );
+});
+
+test('input resume rejects approved flag and supports explicit cancel', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-approve-reject-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+  assert.ok(payload.stateKey);
+
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+        resume: payload as any,
+        approved: true,
+      }),
+    /requires --response-json/i,
+  );
+
+  const cancelled = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: payload as any,
+    cancel: true,
+  });
+  assert.equal(cancelled.status, 'cancelled');
+  const files = await fsp.readdir(stateDir);
+  const resumeStateFiles = files.filter((name) => name.startsWith('workflow_resume_'));
+  assert.deepEqual(resumeStateFiles, []);
 });
 
 test('needs_input fails when envelope exceeds max bytes even after subject truncation', async () => {

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -191,6 +191,76 @@ test('input resume rejects response that does not match schema', async () => {
   );
 });
 
+test('input to input chaining derives subject from previous input response', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-chain-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'first',
+            input: {
+              prompt: 'First value?',
+              responseSchema: { type: 'string' },
+            },
+          },
+          {
+            id: 'second',
+            input: {
+              prompt: 'Second value?',
+              responseSchema: { type: 'string' },
+            },
+          },
+          {
+            id: 'done',
+            run: "node -e \"process.stdout.write(JSON.stringify({subject:process.env.SUBJECT,response:process.env.RESPONSE}))\"",
+            env: {
+              SUBJECT: '$second.subject',
+              RESPONSE: '$second.response',
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+
+  const firstPayload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(firstPayload.kind, 'workflow-file');
+  const second = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: firstPayload as any,
+    response: 'alpha',
+  });
+  assert.equal(second.status, 'needs_input');
+  assert.equal(second.requiresInput?.subject, 'alpha');
+
+  const secondPayload = decodeResumeToken(second.requiresInput?.resumeToken ?? '');
+  assert.equal(secondPayload.kind, 'workflow-file');
+  const done = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: secondPayload as any,
+    response: 'omega',
+  });
+  assert.equal(done.status, 'ok');
+  assert.deepEqual(done.output, [{ subject: 'alpha', response: 'omega' }]);
+});
+
 test('next loops back to input step and subject tracks latest executed step output', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-loop-'));
   const stateDir = path.join(tmpDir, 'state');

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -1529,3 +1529,46 @@ test('retry delay wait is abortable via workflow signal', async () => {
     /Workflow aborted/i,
   );
 });
+
+test('workflow abort signal stops execution before first retry attempt', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-retry-pre-abort-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'pipeline_step',
+            pipeline: 'json',
+            stdin: {
+              ok: true,
+            },
+            retry: 2,
+            retry_delay: '10ms',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const abort = new AbortController();
+  abort.abort();
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env, {
+          signal: abort.signal,
+        }),
+      }),
+    /Workflow aborted/i,
+  );
+});

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -800,6 +800,64 @@ test('input resume rejects approved flag and supports explicit cancel', async ()
   assert.deepEqual(resumeStateFiles, []);
 });
 
+test('workflow resume rejects invalid iterationCounts in stored state', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-invalid-iteration-counts-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+  const stateKey = (payload as any).stateKey;
+  assert.equal(typeof stateKey, 'string');
+
+  const statePath = path.join(stateDir, `${stateKey}.json`);
+  const parsed = JSON.parse(await fsp.readFile(statePath, 'utf8'));
+  parsed.iterationCounts = 'invalid';
+  await fsp.writeFile(statePath, JSON.stringify(parsed, null, 2), 'utf8');
+
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+        resume: payload as any,
+        response: { decision: 'approve' },
+      }),
+    /Invalid workflow resume state/i,
+  );
+});
+
 test('needs_input fails when envelope exceeds max bytes even after subject truncation', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-envelope-hard-limit-'));
   const stateDir = path.join(tmpDir, 'state');
@@ -1064,6 +1122,65 @@ test('condition parser supports &&, ||, !, !=, and quoted string literals', asyn
 
   assert.equal(result.status, 'ok');
   assert.deepEqual(result.output, ['and', 'or', 'neq', 'quoted', 'not']);
+});
+
+test('condition parser supports more than two operands for && and ||', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-conditions-nary-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const markerPath = path.join(tmpDir, 'markers.txt');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  const append = (label: string) =>
+    `node -e "require('node:fs').appendFileSync(process.env.OUT,'${label}\\\\n')"`;
+  const readMarkers =
+    "node -e \"const fs=require('node:fs');const p=process.env.OUT;const t=fs.existsSync(p)?fs.readFileSync(p,'utf8').trim():'';process.stdout.write(JSON.stringify(t?t.split('\\\\n'):[]));\"";
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        env: {
+          OUT: markerPath,
+        },
+        steps: [
+          {
+            id: 'seed',
+            run: "node -e \"process.stdout.write(JSON.stringify({target:'prod',ok:true}))\"",
+          },
+          {
+            id: 'allow',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+          },
+          {
+            id: 'and_nary',
+            run: append('and_nary'),
+            when: '$seed.json.target == prod && $allow.json.ok == true && $seed.json.ok == true',
+          },
+          {
+            id: 'or_nary',
+            run: append('or_nary'),
+            when: '$seed.json.target == staging || $allow.json.ok == true || $seed.json.ok == true',
+          },
+          {
+            id: 'read',
+            run: readMarkers,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['and_nary', 'or_nary']);
 });
 
 test('resolveStepRefs does not leak raw placeholders for missing fields', async () => {

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -516,6 +516,62 @@ test('needs_input subject truncation is envelope-aware against tool output limit
   assert.equal((first.requiresInput?.subject as any)?.truncated, true);
 });
 
+test('needs_input persists sanitized subject in resume state', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-sanitized-subject-state-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'x'.repeat(30000)}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: stateDir,
+    LOBSTER_MAX_TOOL_ENVELOPE_BYTES: '4096',
+  } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(first.status, 'needs_input');
+  assert.equal(typeof first.requiresInput?.subject, 'object');
+  assert.equal((first.requiresInput?.subject as any)?.truncated, true);
+  assert.ok(first.requiresInput?.resumeToken);
+
+  const tokenPayload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(tokenPayload.kind, 'workflow-file');
+  const statePath = path.join(stateDir, `${(tokenPayload as any).stateKey}.json`);
+  const state = JSON.parse(await fsp.readFile(statePath, 'utf8'));
+  assert.equal((state.inputSubject as any)?.truncated, true);
+});
+
 test('input step reads response from interactive TTY mode', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-interactive-'));
   const stateDir = path.join(tmpDir, 'state');
@@ -1133,6 +1189,44 @@ test('workflow parser rejects input steps without prompt', async () => {
         ctx: makeCtx(env),
       }),
     /input\.prompt must be a string/i,
+  );
+});
+
+test('workflow parser rejects invalid input response schemas before pausing', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-invalid-schema-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'wat',
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /input\.responseSchema is invalid/i,
   );
 });
 

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -1,0 +1,969 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { runWorkflowFile } from '../src/workflows/file.js';
+import { decodeResumeToken } from '../src/resume.js';
+
+function makeCtx(
+  env: Record<string, string>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    env,
+    mode: 'tool' as const,
+    ...overrides,
+  };
+}
+
+test('input step pauses with needs_input and resumes with structured response', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'hello'}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({decision:process.env.DECISION,text:process.env.TEXT}))\"",
+            env: {
+              DECISION: '$review.response.decision',
+              TEXT: '$review.subject.text',
+            },
+            when: '$review.response.decision == approve',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(first.status, 'needs_input');
+  assert.equal(first.requiresInput?.prompt, 'Approve?');
+  assert.deepEqual(first.requiresInput?.subject, { text: 'hello' });
+  assert.ok(first.requiresInput?.resumeToken);
+
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+
+  const resumed = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: payload as any,
+    response: { decision: 'approve' },
+  });
+
+  assert.equal(resumed.status, 'ok');
+  assert.deepEqual(resumed.output, [{ decision: 'approve', text: 'hello' }]);
+});
+
+test('input resume rejects response that does not match schema', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-schema-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Pick',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+        resume: payload as any,
+        response: { decision: 'invalid' },
+      }),
+    /schema validation/i,
+  );
+});
+
+test('next loops back to input step and subject tracks latest executed step output', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-loop-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'v1'}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve or redraft?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'redraft'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+          {
+            id: 'redraft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'v2'}))\"",
+            when: '$review.response.decision == redraft',
+            next: 'review',
+            max_iterations: 3,
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({published:process.env.TEXT}))\"",
+            env: {
+              TEXT: '$review.subject.text',
+            },
+            when: '$review.response.decision == approve',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({ filePath, ctx: makeCtx(env) });
+  assert.equal(first.status, 'needs_input');
+  assert.deepEqual(first.requiresInput?.subject, { text: 'v1' });
+
+  const firstToken = first.requiresInput?.resumeToken ?? '';
+  const firstPayload = decodeResumeToken(firstToken);
+  assert.equal(firstPayload.kind, 'workflow-file');
+  const second = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: firstPayload as any,
+    response: { decision: 'redraft' },
+  });
+  assert.equal(second.status, 'needs_input');
+  assert.deepEqual(second.requiresInput?.subject, { text: 'v2' });
+
+  const secondToken = second.requiresInput?.resumeToken ?? '';
+  const secondPayload = decodeResumeToken(secondToken);
+  assert.equal(secondPayload.kind, 'workflow-file');
+  const done = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: secondPayload as any,
+    response: { decision: 'approve' },
+  });
+  assert.equal(done.status, 'ok');
+  assert.deepEqual(done.output, [{ published: 'v2' }]);
+});
+
+test('retry and on_error jump mark step as failed and continue at target step', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-retry-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'flaky',
+            run: "node -e \"process.stderr.write('boom'); process.exit(1)\"",
+            retry: 1,
+            retry_delay: '1ms',
+            on_error: 'alert',
+          },
+          {
+            id: 'never_runs',
+            run: "node -e \"process.stdout.write(JSON.stringify({wrong:true}))\"",
+          },
+          {
+            id: 'alert',
+            run: "node -e \"process.stdout.write(JSON.stringify({failed:process.env.FAILED==='true',error:process.env.ERR}))\"",
+            env: {
+              FAILED: '$flaky.failed',
+              ERR: '$flaky.error',
+            },
+            when: '$flaky.failed',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.output.length, 1);
+  assert.equal((result.output[0] as any).failed, true);
+  assert.match(String((result.output[0] as any).error), /boom|failed/i);
+});
+
+test('needs_input subject truncation is envelope-aware against tool output limit', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-envelope-limit-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'x'.repeat(30000)}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: stateDir,
+    LOBSTER_MAX_TOOL_ENVELOPE_BYTES: '4096',
+  } as Record<string, string>;
+
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(first.status, 'needs_input');
+  assert.equal(typeof first.requiresInput?.subject, 'object');
+  assert.equal((first.requiresInput?.subject as any)?.truncated, true);
+});
+
+test('input step reads response from interactive TTY mode', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-interactive-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'draft',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:'hello'}))\"",
+          },
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({decision:process.env.DECISION,text:process.env.TEXT}))\"",
+            env: {
+              DECISION: '$review.response.decision',
+              TEXT: '$review.subject.text',
+            },
+            when: '$review.response.decision == approve',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  setImmediate(() => {
+    stdin.end('{"decision":"approve"}\n');
+  });
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env, {
+      stdin,
+      stdout,
+      stderr,
+      mode: 'human',
+    }),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ decision: 'approve', text: 'hello' }]);
+});
+
+test('input step accepts primitive JSON response when schema allows it', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-primitive-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Provide title',
+              responseSchema: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            id: 'publish',
+            run: "node -e \"process.stdout.write(JSON.stringify({text:process.env.TEXT}))\"",
+            env: {
+              TEXT: '$review.response',
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+
+  const resumed = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: payload as any,
+    response: 'hello world',
+  });
+  assert.equal(resumed.status, 'ok');
+  assert.deepEqual(resumed.output, [{ text: 'hello world' }]);
+});
+
+test('input resume requires response payload', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-missing-response-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+        resume: payload as any,
+      }),
+    /requires --response-json/i,
+  );
+});
+
+test('needs_input fails when envelope exceeds max bytes even after subject truncation', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-envelope-hard-limit-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'x'.repeat(20_000),
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string' },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = {
+    ...process.env,
+    LOBSTER_STATE_DIR: stateDir,
+    LOBSTER_MAX_TOOL_ENVELOPE_BYTES: '1024',
+  } as Record<string, string>;
+
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /needs_input envelope exceeds/i,
+  );
+});
+
+test('next loops fail fast when max_iterations is exceeded', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-loop-max-iterations-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'loop',
+            run: "node -e \"process.stdout.write('{}')\"",
+            next: 'loop',
+            max_iterations: 2,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /exceeded max_iterations/i,
+  );
+});
+
+test('workflow parser rejects invalid next declarations', async () => {
+  const cases = [
+    {
+      name: 'next target missing',
+      workflow: {
+        steps: [
+          {
+            id: 'a',
+            run: "node -e \"process.stdout.write('{}')\"",
+            next: 'missing',
+          },
+        ],
+      },
+      pattern: /next target not found/i,
+    },
+    {
+      name: 'next target empty',
+      workflow: {
+        steps: [
+          {
+            id: 'a',
+            run: "node -e \"process.stdout.write('{}')\"",
+            next: '   ',
+          },
+        ],
+      },
+      pattern: /next cannot be empty/i,
+    },
+    {
+      name: 'next on input step',
+      workflow: {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string' } },
+                required: ['decision'],
+              },
+            },
+            next: 'review',
+          },
+        ],
+      },
+      pattern: /cannot use next with approval\/input steps/i,
+    },
+  ] as const;
+
+  for (const tc of cases) {
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), `lobster-workflow-next-guard-${tc.name.replace(/\s+/g, '-')}-`));
+    const stateDir = path.join(tmpDir, 'state');
+    const filePath = path.join(tmpDir, 'workflow.lobster');
+    await fsp.writeFile(filePath, JSON.stringify(tc.workflow, null, 2), 'utf8');
+
+    const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+    await assert.rejects(
+      () =>
+        runWorkflowFile({
+          filePath,
+          ctx: makeCtx(env),
+        }),
+      tc.pattern,
+    );
+  }
+});
+
+test('workflow parser rejects input steps without prompt', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-missing-prompt-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              responseSchema: {
+                type: 'object',
+                properties: { decision: { type: 'string' } },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /input\.prompt must be a string/i,
+  );
+});
+
+test('condition parser supports &&, ||, !, !=, and quoted string literals', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-conditions-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const markerPath = path.join(tmpDir, 'markers.txt');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  const append = (label: string) =>
+    `node -e "require('node:fs').appendFileSync(process.env.OUT,'${label}\\\\n')"`;
+  const readMarkers =
+    "node -e \"const fs=require('node:fs');const p=process.env.OUT;const t=fs.existsSync(p)?fs.readFileSync(p,'utf8').trim():'';process.stdout.write(JSON.stringify(t?t.split('\\\\n'):[]));\"";
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        env: {
+          OUT: markerPath,
+        },
+        steps: [
+          {
+            id: 'seed',
+            run: "node -e \"process.stdout.write(JSON.stringify({target:'prod',note:'not ready yet',ok:true}))\"",
+          },
+          {
+            id: 'allow',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+          },
+          {
+            id: 'and_step',
+            run: append('and'),
+            when: '$seed.json.target == prod && $allow.json.ok == true',
+          },
+          {
+            id: 'or_step',
+            run: append('or'),
+            when: '$seed.json.target == staging || $allow.json.ok == true',
+          },
+          {
+            id: 'neq_step',
+            run: append('neq'),
+            when: '$seed.json.target != staging',
+          },
+          {
+            id: 'quoted_step',
+            run: append('quoted'),
+            when: '$seed.json.note == "not ready yet"',
+          },
+          {
+            id: 'skip',
+            run: append('skip'),
+            when: '$seed.json.target == staging',
+          },
+          {
+            id: 'not_step',
+            run: append('not'),
+            when: '!$skip.failed',
+          },
+          {
+            id: 'read',
+            run: readMarkers,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['and', 'or', 'neq', 'quoted', 'not']);
+});
+
+test('condition parser handles quoted literals ending with backslash before &&', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-conditions-backslash-quote-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const markerPath = path.join(tmpDir, 'markers.txt');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  const append = (label: string) =>
+    `node -e "require('node:fs').appendFileSync(process.env.OUT,'${label}\\\\n')"`;
+  const readMarkers =
+    "node -e \"const fs=require('node:fs');const p=process.env.OUT;const t=fs.existsSync(p)?fs.readFileSync(p,'utf8').trim():'';process.stdout.write(JSON.stringify(t?t.split('\\\\n'):[]));\"";
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        env: {
+          OUT: markerPath,
+        },
+        steps: [
+          {
+            id: 'seed',
+            run: "node -e \"process.stdout.write(JSON.stringify({path:'C:\\\\\\\\temp\\\\\\\\',ok:true}))\"",
+          },
+          {
+            id: 'allow',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+          },
+          {
+            id: 'gated',
+            run: append('gated'),
+            when: '$seed.json.path == "C:\\\\temp\\\\" && $allow.json.ok == true',
+          },
+          {
+            id: 'read',
+            run: readMarkers,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['gated']);
+});
+
+test('condition parser rejects mixed && and || in one expression', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-conditions-mixed-op-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'seed',
+            run: "node -e \"process.stdout.write(JSON.stringify({target:'prod',ok:true}))\"",
+          },
+          {
+            id: 'allow',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+          },
+          {
+            id: 'bad',
+            run: "node -e \"process.stdout.write('{}')\"",
+            when: '$seed.json.target == prod && $allow.json.ok == true || $seed.json.ok == true',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /Unsupported condition/i,
+  );
+});
+
+test('on_error skip continues workflow and exposes failed/error fields', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-on-error-skip-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'flaky',
+            run: "node -e \"process.stderr.write('boom'); process.exit(1)\"",
+            on_error: 'skip',
+          },
+          {
+            id: 'report',
+            run: "node -e \"process.stdout.write(JSON.stringify({failed:process.env.FAILED==='true',error:process.env.ERR}))\"",
+            env: {
+              FAILED: '$flaky.failed',
+              ERR: '$flaky.error',
+            },
+            when: '$flaky.failed',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ failed: true, error: 'workflow command failed (1): boom' }]);
+});
+
+test('default on_error fail preserves failure behavior', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-on-error-fail-default-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'flaky',
+            run: "node -e \"process.stderr.write('boom'); process.exit(1)\"",
+          },
+          {
+            id: 'never_runs',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env),
+      }),
+    /boom/i,
+  );
+});
+
+test('retry delay wait is abortable via workflow signal', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-retry-abort-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'flaky',
+            run: "node -e \"process.stderr.write('boom'); process.exit(1)\"",
+            retry: 5,
+            retry_delay: '50ms',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const abort = new AbortController();
+  setTimeout(() => abort.abort(), 10);
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  await assert.rejects(
+    () =>
+      runWorkflowFile({
+        filePath,
+        ctx: makeCtx(env, {
+          signal: abort.signal,
+        }),
+      }),
+    /Workflow aborted/i,
+  );
+});

--- a/test/workflow_input_request.test.ts
+++ b/test/workflow_input_request.test.ts
@@ -90,6 +90,56 @@ test('input step pauses with needs_input and resumes with structured response', 
   assert.deepEqual(resumed.output, [{ decision: 'approve', text: 'hello' }]);
 });
 
+test('terminal input step emits submitted response as final output after resume', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-terminal-output-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const first = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+  assert.equal(first.status, 'needs_input');
+  const payload = decodeResumeToken(first.requiresInput?.resumeToken ?? '');
+  assert.equal(payload.kind, 'workflow-file');
+
+  const resumed = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+    resume: payload as any,
+    response: { decision: 'approve' },
+  });
+
+  assert.equal(resumed.status, 'ok');
+  assert.deepEqual(resumed.output, [{ decision: 'approve' }]);
+});
+
 test('input resume rejects response that does not match schema', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-schema-'));
   const stateDir = path.join(tmpDir, 'state');
@@ -383,6 +433,59 @@ test('input step reads response from interactive TTY mode', async () => {
 
   assert.equal(result.status, 'ok');
   assert.deepEqual(result.output, [{ decision: 'approve', text: 'hello' }]);
+});
+
+test('terminal input step emits submitted response in interactive mode', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-input-terminal-interactive-output-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'review',
+            input: {
+              prompt: 'Approve?',
+              responseSchema: {
+                type: 'object',
+                properties: {
+                  decision: { type: 'string', enum: ['approve', 'reject'] },
+                },
+                required: ['decision'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = true;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  setImmediate(() => {
+    stdin.end('{"decision":"approve"}\n');
+  });
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env, {
+      stdin,
+      stdout,
+      stderr,
+      mode: 'human',
+    }),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ decision: 'approve' }]);
 });
 
 test('input step accepts primitive JSON response when schema allows it', async () => {
@@ -751,6 +854,47 @@ test('condition parser supports &&, ||, !, !=, and quoted string literals', asyn
 
   assert.equal(result.status, 'ok');
   assert.deepEqual(result.output, ['and', 'or', 'neq', 'quoted', 'not']);
+});
+
+test('resolveStepRefs does not leak raw placeholders for missing fields', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-workflow-template-missing-refs-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+
+  await fsp.writeFile(
+    filePath,
+    JSON.stringify(
+      {
+        steps: [
+          {
+            id: 'seed',
+            run: "node -e \"process.stdout.write(JSON.stringify({ok:true}))\"",
+          },
+          {
+            id: 'render',
+            run: "node -e \"process.stdout.write(JSON.stringify({approved:process.env.APPROVED,missing:process.env.MISSING,unknown:process.env.UNKNOWN}))\"",
+            env: {
+              APPROVED: '$seed.approved',
+              MISSING: 'prefix-$seed.nope-suffix',
+              UNKNOWN: '$missing.stdout',
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir } as Record<string, string>;
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: makeCtx(env),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ approved: 'false', missing: 'prefix--suffix', unknown: '' }]);
 });
 
 test('condition parser handles quoted literals ending with backslash before &&', async () => {


### PR DESCRIPTION
Implements #38

This PR adds the Lobster-side changes from the design doc:

•⁠  ⁠⁠ input: ⁠ step type with ⁠ needs_input ⁠ pause/resume and schema validation
•⁠  ⁠⁠ $step.response ⁠ / ⁠ $step.subject ⁠ deep field access
•⁠  ⁠Extended ⁠ when ⁠ conditions: comparisons, negation, AND/OR
•⁠  ⁠⁠ next: ⁠ step flow control with ⁠ max_iterations ⁠ loop guard
•⁠  ⁠⁠ retry ⁠, ⁠ retry_delay ⁠, ⁠ on_error ⁠ for step-level error recovery
•⁠  ⁠SDK updated to recognize ⁠ input_request ⁠ halts and ⁠ resume({ response }) ⁠

All changes are additive. Existing workflows, tokens, and conditionals are unchanged.

