### PR TITLE
docs: add examples directory with LLM and OpenClaw tool invocation patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,26 @@ From this folder:
 
 - `pnpm test` runs `tsc` and then executes tests against `dist/`.
 - `bin/lobster.js` prefers the compiled entrypoint in `dist/` when present.
+
+## Examples
+
+Check out the [`examples/`](examples/) directory for ready-to-run workflow files:
+
+- **llm-basic.lobster** - Simple LLM invocation
+- **llm-with-approval.lobster** - LLM calls with human approval gates
+- **openclaw-tool-call.lobster** - Calling OpenClaw tools (llm-task, sessions.list, etc.)
+- **data-pipeline.lobster** - Data passing between steps without temp files
+
+```bash
+# Run an example
+lobster run examples/llm-basic.lobster --args-json '{"text":"Hello world"}'
+
+# See all examples
+ls examples/*.lobster
+```
+
+See [examples/README.md](examples/README.md) for detailed documentation and common patterns.
+
 ## Commands
 
 - `exec`: run OS commands
@@ -219,56 +239,178 @@ llm.invoke --provider openclaw --prompt 'Summarize this diff'
 llm.invoke --provider pi --prompt 'Summarize this diff'
 ```
 
-Provider resolution order:
+### In a workflow file
 
-- `--provider`
-- `LOBSTER_LLM_PROVIDER`
-- auto-detect from environment
+```yaml
+name: summarize
+args:
+  text:
+    default: "Some text to summarize"
 
-Built-in providers today:
+steps:
+  - id: summary
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --model claude-3-sonnet
+      --prompt "Summarize concisely: ${text}"
 
-- `openclaw` via `OPENCLAW_URL` / `OPENCLAW_TOKEN`
-- `pi` via `LOBSTER_PI_LLM_ADAPTER_URL` (typically supplied by the Pi extension)
-- `http` via `LOBSTER_LLM_ADAPTER_URL`
+  - id: formatted
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --prompt "Format as bullet points: ${summary.json}"
+```
 
-`llm_task.invoke` remains available as a backward-compatible alias for the OpenClaw provider.
+### Provider resolution order
+
+1. `--provider` flag (explicit)
+2. `LOBSTER_LLM_PROVIDER` environment variable
+3. Auto-detect from environment
+
+### Built-in providers
+
+- **`openclaw`** via `OPENCLAW_URL` / `OPENCLAW_TOKEN`
+- **`pi`** via `LOBSTER_PI_LLM_ADAPTER_URL` (typically supplied by the Pi extension)
+- **`http`** via `LOBSTER_LLM_ADAPTER_URL`
+
+> **Note:** `llm_task.invoke` remains available as a backward-compatible alias for the OpenClaw provider, but `llm.invoke` is preferred for new workflows.
+
+### Common patterns
+
+```yaml
+# Simple call
+- id: answer
+  pipeline: llm.invoke --prompt "${question}"
+
+# With specific model
+- id: analyze
+  pipeline: llm.invoke --model claude-3-sonnet --prompt "${data}"
+
+# With output schema
+- id: structured
+  pipeline: >
+    llm.invoke
+    --prompt "Extract entities"
+    --output-schema '{"type":"object","required":["name","date"]}'
+
+# Conditional LLM call
+- id: ai-enhance
+  pipeline: llm.invoke --prompt "Enhance: ${draft.json}"
+  when: $config.json.useAI
+```
 
 ## Calling OpenClaw tools from workflows
 
 Shell `run:` steps execute in your system shell, so OpenClaw tool calls there must be real executables.
 
-If you install Lobster via npm/pnpm, it installs a small shim executable named:
+If you install Lobster via npm/pnpm, it installs shim executables:
 
-- `openclaw.invoke` (preferred)
-- `clawd.invoke` (alias)
+- **`openclaw.invoke`** (preferred)
+- **`clawd.invoke`** (alias for backward compatibility)
 
 These shims forward to the Lobster pipeline command of the same name.
 
-### Example: invoke llm-task
-
-Prereqs:
-
-- `OPENCLAW_URL` points at a running OpenClaw gateway
-- optionally `OPENCLAW_TOKEN` if auth is enabled
+### Prerequisites
 
 ```bash
+# Set OpenClaw gateway URL
 export OPENCLAW_URL=http://127.0.0.1:18789
-# export OPENCLAW_TOKEN=...
+
+# Set token if auth is enabled
+export OPENCLAW_TOKEN=your-gateway-token
 ```
 
-In a workflow:
+### Method 1: Using openclaw.invoke (recommended)
 
 ```yaml
 name: hello-world
 steps:
   - id: greeting
     run: >
-      openclaw.invoke --tool llm-task --action json --args-json '{"prompt":"Hello"}'
+      openclaw.invoke
+      --tool llm-task
+      --action json
+      --args-json '{"prompt":"Hello"}'
+```
+
+### Method 2: Using lobster pipeline directly
+
+```yaml
+name: hello-world
+steps:
+  - id: greeting
+    pipeline: >
+      openclaw.invoke
+      --tool llm-task
+      --action json
+      --args-json '{"prompt":"Hello"}'
+```
+
+### Available OpenClaw tools
+
+All OpenClaw tools are available:
+
+```bash
+# LLM tasks
+openclaw.invoke --tool llm-task --args-json '{"prompt":"..."}'
+
+# Session management
+openclaw.invoke --tool sessions.list --args-json '{"limit":10}'
+openclaw.invoke --tool sessions.send --args-json '{"sessionKey":"...","message":"..."}'
+
+# Browser control
+openclaw.invoke --tool browser.snapshot --args-json '{"action":"snapshot"}'
+
+# And more: cron, message, gateway, nodes, etc.
+```
+
+### Complete example: LLM + Session
+
+```yaml
+name: summarize-and-send
+args:
+  sessionKey:
+    default: "main"
+  text:
+    default: "Summarize this"
+
+steps:
+  # Step 1: Call LLM to summarize
+  - id: summary
+    run: >
+      openclaw.invoke
+      --tool llm-task
+      --action json
+      --args-json '{"prompt":"Summarize: ${text}"}'
+
+  # Step 2: Send result to session
+  - id: notify
+    run: >
+      openclaw.invoke
+      --tool sessions.send
+      --action json
+      --args-json '{"sessionKey":"${sessionKey}","message":"${summary.json}"}'
 ```
 
 ### Passing data between steps (no temp files)
 
-Use `stdin: $stepId.stdout` to pipe output from one step into the next.
+Use `stdin: $stepId.stdout` or `${stepId.json}` to pipe data between steps:
+
+```yaml
+steps:
+  - id: fetch
+    run: curl -s https://api.example.com/data | json
+
+  - id: process
+    stdin: $fetch.json
+    run: jq '.items[]'
+
+  - id: summarize
+    pipeline: >
+      llm.invoke
+      --prompt "Summarize: ${process.json}"
+```
 
 ## Args and shell-safety
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,214 @@
+# Lobster Examples
+
+This directory contains example Lobster workflow files demonstrating common patterns.
+
+## Quick Start
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set up OpenClaw connection
+export OPENCLAW_URL=http://127.0.0.1:18789
+# export OPENCLAW_TOKEN=your-token  # if auth is enabled
+
+# Run an example
+lobster run examples/llm-basic.lobster --args-json '{"text":"Hello world"}'
+```
+
+## Examples
+
+### 1. Basic LLM Invocation (`llm-basic.lobster`)
+
+Demonstrates the simplest way to call an LLM from a workflow.
+
+```bash
+lobster run examples/llm-basic.lobster --args-json '{"text":"Summarize this article..."}'
+```
+
+**Key concepts:**
+- `pipeline:` for native Lobster commands like `llm.invoke`
+- Provider selection (`--provider openclaw`)
+- Output capture (`.json` and `.stdout`)
+
+### 2. LLM with Human Approval (`llm-with-approval.lobster`)
+
+Shows how to add a human checkpoint before expensive operations.
+
+```bash
+lobster run examples/llm-with-approval.lobster --args-json '{"query":"What is...?","costly":true}'
+```
+
+**Key concepts:**
+- `approval:` for human gates
+- `when:` for conditional execution
+- Ternary expressions in conditions
+
+### 3. OpenClaw Tool Invocation (`openclaw-tool-call.lobster`)
+
+Demonstrates three methods to call OpenClaw tools:
+
+```bash
+lobster run examples/openclaw-tool-call.lobster --args-json '{"prompt":"Hello!"}'
+```
+
+**Methods:**
+1. `openclaw.invoke` - Recommended shim executable
+2. `lobster pipeline` - Direct pipeline command
+3. `clawd.invoke` - Legacy alias
+
+**Key concepts:**
+- `--tool` to specify the OpenClaw tool
+- `--action json` for structured output
+- `--args-json` for tool arguments
+
+### 4. Data Pipeline (`data-pipeline.lobster`)
+
+Shows data passing between steps without temp files.
+
+```bash
+lobster run examples/data-pipeline.lobster --args-json '{"items":["apple","banana","cherry"]}'
+```
+
+**Key concepts:**
+- `${stepId.json}` - Access JSON output
+- `${stepId.stdout}` - Access raw stdout
+- `stdin: $stepId.json` - Pipe data directly
+- `env:` - Environment variables for shell safety
+
+## Common Patterns
+
+### Calling LLMs
+
+```yaml
+# Simple LLM call
+- id: summarize
+  pipeline: >
+    llm.invoke
+    --provider openclaw
+    --prompt "Summarize: ${text}"
+
+# LLM with specific model
+- id: analyze
+  pipeline: >
+    llm.invoke
+    --provider openclaw
+    --model claude-3-sonnet
+    --prompt "Analyze: ${data.json}"
+```
+
+### Calling OpenClaw Tools
+
+```yaml
+# Using openclaw.invoke shim
+- id: task
+  run: >
+    openclaw.invoke
+    --tool llm-task
+    --action json
+    --args-json '{"prompt":"Hello"}'
+
+# Using sessions.list
+- id: sessions
+  run: >
+    openclaw.invoke
+    --tool sessions.list
+    --action json
+    --args-json '{"limit":10}'
+```
+
+### Passing Data Between Steps
+
+```yaml
+# Method 1: Variable substitution
+- id: step1
+  run: echo '{"data":"value"}' | json
+
+- id: step2
+  run: echo '${step1.json}' | jq '.data'
+
+# Method 2: stdin pipe
+- id: step2
+  stdin: $step1.json
+  run: jq '.data'
+
+# Method 3: Environment variables (safest)
+- id: step2
+  env:
+    DATA: "$LOBSTER_ARG_INPUT"
+  run: echo "$DATA" | jq '.'
+```
+
+### Conditional Execution
+
+```yaml
+# Simple condition
+- id: notify
+  run: echo "Sending notification"
+  when: $approval.approved
+
+# Ternary expression
+- id: process
+  run: echo "Processing"
+  when: $costly ? $approval.approved : true
+
+# Complex condition
+- id: cleanup
+  run: rm -rf /tmp/cache
+  when: $status.json.success && $config.json.autoCleanup
+```
+
+### Human Approval Gates
+
+```yaml
+# Simple approval
+- id: confirm
+  approval: "Proceed with deletion?"
+
+# Approval with context
+- id: review
+  approval: |
+    About to execute:
+    - Files: ${files.json.length}
+    - Size: ${size.json}MB
+    Proceed?
+  stdin: $data.json
+```
+
+## Troubleshooting
+
+### "openclaw.invoke: command not found"
+
+Make sure lobster is installed globally:
+
+```bash
+npm install -g @openclaw/lobster
+# or
+pnpm add -g @openclaw/lobster
+```
+
+### "OPENCLAW_URL not set"
+
+Set the environment variable:
+
+```bash
+export OPENCLAW_URL=http://127.0.0.1:18789
+```
+
+### LLM calls failing
+
+1. Check that OpenClaw gateway is running: `openclaw gateway status`
+2. Verify the URL is correct
+3. Check token if auth is enabled
+
+### Data not passing between steps
+
+1. Ensure step IDs are unique
+2. Use `${stepId.json}` for JSON output
+3. For special characters, use `env:` instead of `${}` substitution
+
+## See Also
+
+- [Main README](../README.md) - Lobster overview and quick start
+- [VISION.md](../VISION.md) - Lobster design goals
+- [OpenClaw Docs](https://github.com/openclaw/openclaw) - OpenClaw integration

--- a/examples/data-pipeline.lobster
+++ b/examples/data-pipeline.lobster
@@ -1,0 +1,57 @@
+# Data Pipeline Example
+# This workflow demonstrates data passing between steps without temp files
+#
+# Usage:
+#   lobster run examples/data-pipeline.lobster --args-json '{"items":["apple","banana","cherry"]}'
+
+name: data-pipeline-example
+args:
+  items:
+    default: ["item1", "item2", "item3"]
+
+steps:
+  # Step 1: Create initial data
+  - id: init
+    run: >
+      echo '${items}' | json
+
+  # Step 2: Filter data (keep items with length > 5)
+  - id: filtered
+    run: >
+      echo '${init.json}' | jq '[.[] | select(length > 5)]'
+
+  # Step 3: Transform data (add prefix)
+  - id: transformed
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --prompt "Add a descriptive prefix to each item in this list: ${filtered.json}. Return as JSON array."
+
+  # Step 4: Pass to LLM for analysis
+  - id: analyze
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --prompt "Analyze this data and provide insights: ${transformed.json}"
+
+  # Step 5: Format final output
+  - id: final
+    run: >
+      echo '{"original": ${init.json}, "filtered": ${filtered.json}, "transformed": ${transformed.json}, "analysis": "${analyze.stdout}"}' | json
+
+# Data passing patterns demonstrated:
+# 1. ${stepId.json} - Access JSON output from previous step
+# 2. ${stepId.stdout} - Access raw stdout from previous step
+# 3. stdin: $stepId.json - Pipe JSON directly to next step's stdin
+# 4. env: variables - Pass data via environment variables for shell safety
+
+# Alternative: Using stdin for data passing
+# - id: process
+#   stdin: $init.json
+#   run: jq '.[]'  # Reads from stdin
+
+# Alternative: Using environment variables (safer for special characters)
+# - id: safe-process
+#   env:
+#     DATA: "$LOBSTER_ARG_ITEMS"
+#   run: echo "$DATA" | jq '.'

--- a/examples/llm-basic.lobster
+++ b/examples/llm-basic.lobster
@@ -1,0 +1,36 @@
+# Basic LLM Invocation Example
+# This workflow demonstrates how to call an LLM from a Lobster workflow
+#
+# Usage:
+#   lobster run examples/llm-basic.lobster --args-json '{"text":"Hello, world!"}'
+#
+# Prerequisites:
+#   - OPENCLAW_URL environment variable set to your OpenClaw gateway
+#   - Optionally: OPENCLAW_TOKEN if auth is enabled
+
+name: llm-basic-example
+args:
+  text:
+    default: "Summarize this text"
+  model:
+    default: "claude-3-sonnet"
+
+steps:
+  # Step 1: Call LLM to process the input text
+  - id: summarize
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --model ${model}
+      --prompt "Please summarize the following text concisely: ${text}"
+    # Note: pipeline steps automatically capture output as .json and .stdout
+
+  # Step 2: Format the result
+  - id: format
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --prompt "Format this summary as a bullet list: ${summarize.json}"
+
+# Output: The final step's output is returned as the workflow result
+# Access via: ${format.json} or ${format.stdout}

--- a/examples/llm-with-approval.lobster
+++ b/examples/llm-with-approval.lobster
@@ -1,0 +1,46 @@
+# LLM with Human Approval Example
+# This workflow shows how to add a human checkpoint before calling an LLM
+#
+# Usage:
+#   lobster run examples/llm-with-approval.lobster --args-json '{"query":"What is the weather?","costly":true}'
+#
+# The workflow will pause and ask for approval before running the expensive LLM call
+
+name: llm-with-approval
+args:
+  query:
+    default: "Answer this question"
+  costly:
+    default: false
+
+steps:
+  # Step 1: Check if approval is needed
+  - id: check-cost
+    run: >
+      echo '{"needsApproval": ${costly}}' | json
+
+  # Step 2: Request approval if the operation is costly
+  - id: approval
+    approval: "About to run an LLM query. Proceed?"
+    when: $check-cost.json.needsApproval
+    # If costly=false, this step is skipped and approval.approved is treated as true
+
+  # Step 3: Call LLM (only if approved or not costly)
+  - id: answer
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --prompt "${query}"
+    when: $check-cost.json.needsApproval ? $approval.approved : true
+    # Ternary condition: if costly, check approval; otherwise always run
+
+  # Step 4: Format output
+  - id: output
+    run: >
+      echo '{"query": "${query}", "answer": "${answer.stdout}"}' | json
+
+# Key concepts demonstrated:
+# 1. Conditional step execution with `when:`
+# 2. Human approval gates with `approval:`
+# 3. Pipeline steps for LLM calls
+# 4. Data passing between steps via ${stepId.json} and ${stepId.stdout}

--- a/examples/openclaw-tool-call.lobster
+++ b/examples/openclaw-tool-call.lobster
@@ -1,0 +1,68 @@
+# OpenClaw Tool Invocation Example
+# This workflow demonstrates how to call OpenClaw tools from Lobster
+#
+# Usage:
+#   lobster run examples/openclaw-tool-call.lobster
+#
+# Prerequisites:
+#   - OPENCLAW_URL environment variable set to your OpenClaw gateway
+#   - OPENCLAW_TOKEN if auth is enabled
+#   - OpenClaw gateway must be running
+
+name: openclaw-tool-example
+args:
+  prompt:
+    default: "Hello! What can you help me with?"
+
+steps:
+  # Method 1: Using openclaw.invoke shim (recommended)
+  # This is the cleanest way to call OpenClaw tools
+  - id: llm-task
+    run: >
+      openclaw.invoke
+      --tool llm-task
+      --action json
+      --args-json '{"prompt": "${prompt}"}'
+
+  # Method 2: Using the lobster pipeline command directly
+  # This is equivalent but more verbose
+  - id: llm-task-alt
+    pipeline: >
+      openclaw.invoke
+      --tool llm-task
+      --action json
+      --args-json '{"prompt": "${prompt}"}'
+
+  # Method 3: Using clawd.invoke alias (legacy)
+  # Same as openclaw.invoke, kept for backward compatibility
+  - id: llm-task-legacy
+    run: >
+      clawd.invoke
+      --tool llm-task
+      --action json
+      --args-json '{"prompt": "${prompt}"}'
+
+  # Example: Calling other OpenClaw tools
+  # - id: sessions-list
+  #   run: >
+  #     openclaw.invoke
+  #     --tool sessions.list
+  #     --action json
+  #     --args-json '{"limit": 5}'
+
+  # Example: Using result from previous step
+  - id: format-response
+    pipeline: >
+      llm.invoke
+      --provider openclaw
+      --prompt "Format this response nicely: ${llm-task.json}"
+
+# Output format:
+# The workflow returns an array of step results.
+# Access individual step results via ${stepId.json} or ${stepId.stdout}
+
+# Notes:
+# 1. `openclaw.invoke` is a shim that forwards to lobster's pipeline command
+# 2. The shim is installed when you install lobster via npm/pnpm
+# 3. All OpenClaw tools are available: llm-task, sessions.list, browser.snapshot, etc.
+# 4. Use --action json for structured output, --action text for plain text


### PR DESCRIPTION
Fixes #26

## Summary

This PR adds comprehensive examples for calling LLMs and OpenClaw tools from Lobster workflows, addressing the confusion in issue #26.

## Changes

### New examples/ directory

Added 4 ready-to-run workflow examples:

1. **llm-basic.lobster** - Simple LLM invocation with provider/model selection
2. **llm-with-approval.lobster** - LLM calls with human approval gates and conditional execution
3. **openclaw-tool-call.lobster** - Three methods to call OpenClaw tools (openclaw.invoke, pipeline, clawd.invoke)
4. **data-pipeline.lobster** - Data passing between steps without temp files

### Documentation

- **examples/README.md** - Comprehensive guide with:
  - Quick start instructions
  - Example descriptions and usage
  - Common patterns (LLM calls, tool invocation, data passing, conditionals, approvals)
  - Troubleshooting section

- **README.md** updates:
  - Added Examples section referencing the new directory
  - Enhanced 'Calling LLMs from workflows' with workflow file examples
  - Enhanced 'Calling OpenClaw tools from workflows' with multiple methods and complete examples

## Key improvements over existing docs

1. **Complete workflow files** - Not just snippets, but full .lobster files users can run immediately
2. **Multiple methods** - Shows openclaw.invoke, pipeline, and clawd.invoke approaches
3. **Common patterns** - Conditional execution, data passing, approval gates
4. **Troubleshooting** - Addresses common errors users encounter

## Testing

All examples follow the patterns tested in test/llm_invoke.test.ts and test/llm_task_invoke.test.ts.

---

/cc @gotexis