### PR TITLE
feat(workflows): add flow directives and lobster.run sub-workflows

### DIFF
--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -7,7 +7,7 @@ import { PassThrough } from 'node:stream';
 
 import { parsePipeline } from '../parser.js';
 import { runPipeline } from '../runtime.js';
-import { encodeToken } from '../token.js';
+import { encodeToken, decodeToken } from '../token.js';
 import { deleteStateJson, readStateJson, writeStateJson } from '../state/store.js';
 import { readLineFromStream } from '../read_line.js';
 import { resolveInlineShellCommand } from '../shell.js';
@@ -21,6 +21,10 @@ export type WorkflowFile = {
   steps: WorkflowStep[];
 };
 
+export type FlowRule =
+  | { when: string; goto: string }
+  | { default: string };
+
 export type WorkflowStep = {
   id: string;
   command?: string;
@@ -32,6 +36,8 @@ export type WorkflowStep = {
   approval?: WorkflowApproval;
   condition?: unknown;
   when?: unknown;
+  flow?: FlowRule[];
+  max_iterations?: number;
 };
 
 export type WorkflowApproval =
@@ -88,6 +94,8 @@ export type WorkflowResumePayload = {
   steps?: Record<string, WorkflowStepResult>;
   args?: Record<string, unknown>;
   approvalStepId?: string;
+  visitCounts?: Record<string, number>;
+  flowPending?: boolean;
 };
 
 type WorkflowResumeState = {
@@ -97,6 +105,10 @@ type WorkflowResumeState = {
   args: Record<string, unknown>;
   approvalStepId?: string;
   createdAt: string;
+  visitCounts?: Record<string, number>;
+  flowPending?: boolean;
+  childStateKey?: string;
+  childFilePath?: string;
 };
 
 export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> {
@@ -113,6 +125,7 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     throw new Error('Workflow file requires a non-empty steps array');
   }
 
+  // First pass: collect step IDs for flow target validation
   const seen = new Set<string>();
   for (const step of steps) {
     if (!step || typeof step !== 'object') {
@@ -145,6 +158,41 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     seen.add(step.id);
   }
 
+  // Second pass: validate flow rules and max_iterations
+  for (const step of steps) {
+    if (step.flow !== undefined) {
+      if (!Array.isArray(step.flow)) {
+        throw new Error(`Step ${step.id}: flow must be an array`);
+      }
+      for (let i = 0; i < step.flow.length; i++) {
+        const rule = step.flow[i];
+        if ('default' in rule) {
+          if (i !== step.flow.length - 1) {
+            throw new Error(`Step ${step.id}: default must be the last flow rule`);
+          }
+          if (!seen.has(rule.default)) {
+            throw new Error(`Step ${step.id}: goto target '${rule.default}' not found`);
+          }
+        } else if ('when' in rule && 'goto' in rule) {
+          if (!seen.has(rule.goto)) {
+            throw new Error(`Step ${step.id}: goto target '${rule.goto}' not found`);
+          }
+        } else {
+          throw new Error(`Step ${step.id}: invalid flow rule at index ${i}`);
+        }
+      }
+    }
+    if (step.max_iterations !== undefined) {
+      if (
+        typeof step.max_iterations !== 'number' ||
+        step.max_iterations < 1 ||
+        !Number.isInteger(step.max_iterations)
+      ) {
+        throw new Error(`Step ${step.id}: max_iterations must be a positive integer`);
+      }
+    }
+  }
+
   return parsed as WorkflowFile;
 }
 
@@ -174,12 +222,14 @@ export async function runWorkflowFile({
   ctx,
   resume,
   approved,
+  _depth = 0,
 }: {
   filePath?: string;
   args?: Record<string, unknown>;
   ctx: RunContext;
   resume?: WorkflowResumePayload;
   approved?: boolean;
+  _depth?: number;
 }): Promise<WorkflowRunResult> {
   const consumedResumeStateKey = resume?.stateKey && typeof resume.stateKey === 'string'
     ? resume.stateKey
@@ -199,29 +249,72 @@ export async function runWorkflowFile({
     : {};
   const startIndex = resumeState?.resumeAtIndex ?? 0;
 
-  if (resumeState?.approvalStepId && approved === false) {
+  if (resumeState?.approvalStepId && approved === false && !resumeState.flowPending) {
     if (consumedResumeStateKey) {
       await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
     }
     return { status: 'cancelled', output: [] };
   }
 
-  if (resumeState?.approvalStepId && typeof approved === 'boolean') {
+  if (resumeState?.approvalStepId && typeof approved === 'boolean' && !resumeState.flowPending) {
     const previous = results[resumeState.approvalStepId] ?? { id: resumeState.approvalStepId };
     previous.approved = approved;
     results[resumeState.approvalStepId] = previous;
   }
 
-  let lastStepId: string | null = findLastCompletedStepId(steps, results);
+  // Build step index map for flow jump resolution
+  const stepIndexMap = new Map<string, number>();
+  for (let i = 0; i < steps.length; i++) {
+    stepIndexMap.set(steps[i].id, i);
+  }
 
-  for (let idx = startIndex; idx < steps.length; idx++) {
+  // Restore visit counts from resume state (for halt/resume across loops)
+  const visitCounts = new Map<string, number>(
+    Object.entries(resumeState?.visitCounts ?? {}),
+  );
+
+  let lastStepId: string | null = findLastCompletedStepId(steps, results);
+  let idx = startIndex;
+
+  while (idx >= 0 && idx < steps.length) {
     const step = steps[idx];
 
-    if (!evaluateCondition(step.when ?? step.condition, results)) {
-      results[step.id] = { id: step.id, skipped: true };
+    // Handle flowPending resume: skip re-execution, just set approval and evaluate flow
+    // (Only when no childStateKey — child resume takes precedence)
+    const hasChildResume = !!(resumeState as WorkflowResumeState | null)?.childStateKey;
+    if (resumeState?.flowPending && idx === startIndex && !hasChildResume) {
+      if (resumeState.approvalStepId === step.id && typeof approved === 'boolean') {
+        results[step.id] = { ...(results[step.id] ?? { id: step.id }), approved };
+      }
+      lastStepId = step.id;
+      const flowTarget = evaluateFlowRules(step.flow, results);
+      if (flowTarget !== null) {
+        idx = stepIndexMap.get(flowTarget)!;
+      } else {
+        idx++;
+      }
+      // flowPending only applies to the first step on resume
+      (resumeState as WorkflowResumeState).flowPending = false;
       continue;
     }
 
+    if (!evaluateCondition(step.when ?? step.condition, results)) {
+      results[step.id] = { id: step.id, skipped: true };
+      idx++;
+      continue;
+    }
+
+    const childResumeKey = (resumeState as WorkflowResumeState | null)?.childStateKey;
+
+    // Resuming a halted child continues the current parent visit instead of starting a new one.
+    const visits = childResumeKey && idx === startIndex
+      ? (visitCounts.get(step.id) ?? 1)
+      : (visitCounts.get(step.id) ?? 0) + 1;
+    const maxIter = step.max_iterations ?? 10;
+    if (visits > maxIter) {
+      throw new Error(`Step '${step.id}' exceeded max_iterations (${maxIter})`);
+    }
+    visitCounts.set(step.id, visits);
     const env = mergeEnv(ctx.env, workflow.env, step.env, resolvedArgs, results);
     const cwd = resolveCwd(step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
     const execution = getStepExecution(step);
@@ -229,9 +322,68 @@ export async function runWorkflowFile({
     let result: WorkflowStepResult;
     if (execution.kind === 'shell') {
       const command = resolveTemplate(execution.value, resolvedArgs, results);
-      const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
-      const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
-      result = { id: step.id, stdout, json: parseJson(stdout) };
+      const lobsterRun = parseLobsterRunCommand(command);
+      const childResumeFilePath = (resumeState as WorkflowResumeState | null)?.childFilePath;
+
+      if (lobsterRun || childResumeKey) {
+        const childResult = await executeChildWorkflow(
+          lobsterRun ?? { file: childResumeFilePath },
+          {
+            parentFilePath: resolvedFilePath,
+            env,
+            cwd,
+            ctx,
+            depth: _depth + 1,
+            resumeChildStateKey: childResumeKey,
+            resumeApproved: approved,
+          },
+        );
+
+        // Once we've used the child resume key, clear it so we don't re-use it.
+        if (resumeState) (resumeState as WorkflowResumeState).childStateKey = undefined;
+
+        if (childResult.halted) {
+          const hasFlow = step.flow && step.flow.length > 0;
+          const stateKey = await saveWorkflowResumeState(ctx.env, {
+            filePath: resolvedFilePath,
+            resumeAtIndex: idx,
+            steps: results,
+            args: resolvedArgs,
+            approvalStepId: childResult.approvalStepId,
+            createdAt: new Date().toISOString(),
+            visitCounts: Object.fromEntries(visitCounts),
+            childStateKey: childResult.childStateKey,
+            childFilePath: childResult.childFilePath,
+            flowPending: hasFlow ? true : undefined,
+          });
+
+          if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
+            await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+          }
+
+          const resumeToken = encodeToken({
+            protocolVersion: 1,
+            v: 1,
+            kind: 'workflow-file',
+            stateKey,
+          } satisfies WorkflowResumePayload);
+
+          return {
+            status: 'needs_approval',
+            output: [],
+            requiresApproval: {
+              ...(childResult.requiresApproval!),
+              resumeToken,
+            },
+          };
+        }
+
+        result = { ...childResult.stepResult!, id: step.id };
+      } else {
+        const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
+        const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
+        result = { id: step.id, stdout, json: parseJson(stdout) };
+      }
     } else if (execution.kind === 'pipeline') {
       if (!ctx.registry) {
         throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
@@ -258,13 +410,17 @@ export async function runWorkflowFile({
       const approval = extractApprovalRequest(step, results[step.id]);
 
       if (ctx.mode === 'tool' || !isInteractive(ctx.stdin)) {
+        // If step has flow, resume at same index with flowPending so flow evaluates on resume
+        const hasFlow = step.flow && step.flow.length > 0;
         const stateKey = await saveWorkflowResumeState(ctx.env, {
           filePath: resolvedFilePath,
-          resumeAtIndex: idx + 1,
+          resumeAtIndex: hasFlow ? idx : idx + 1,
           steps: results,
           args: resolvedArgs,
           approvalStepId: step.id,
           createdAt: new Date().toISOString(),
+          visitCounts: Object.fromEntries(visitCounts),
+          flowPending: hasFlow ? true : undefined,
         });
 
         if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
@@ -296,6 +452,14 @@ export async function runWorkflowFile({
         throw new Error('Not approved');
       }
       results[step.id].approved = true;
+    }
+
+    // Evaluate flow rules after execution (and approval if interactive)
+    const flowTarget = evaluateFlowRules(step.flow, results);
+    if (flowTarget !== null) {
+      idx = stepIndexMap.get(flowTarget)!;
+    } else {
+      idx++;
     }
   }
 
@@ -458,10 +622,10 @@ function getStepRefValue(
   return step.json;
 }
 
-function evaluateCondition(
+export function evaluateCondition(
   condition: unknown,
   results: Record<string, WorkflowStepResult>,
-) {
+): boolean {
   if (condition === undefined || condition === null) return true;
   if (typeof condition === 'boolean') return condition;
   if (typeof condition !== 'string') throw new Error('Unsupported condition type');
@@ -470,13 +634,263 @@ function evaluateCondition(
   if (trimmed === 'true') return true;
   if (trimmed === 'false') return false;
 
-  const match = trimmed.match(/^\$([A-Za-z0-9_-]+)\.(approved|skipped)$/);
-  if (!match) throw new Error(`Unsupported condition: ${condition}`);
+  const parsed = parseConditionExpression(trimmed);
+  const resolvedValue = resolveDeepRef(parsed.ref, results);
 
-  const step = results[match[1]];
-  if (!step) return false;
+  if (parsed.op === null) {
+    return isTruthy(resolvedValue);
+  }
 
-  return match[2] === 'approved' ? step.approved === true : step.skipped === true;
+  return compareValues(resolvedValue, parsed.op, parsed.literal);
+}
+
+function parseConditionExpression(input: string): { ref: string; op: string | null; literal: unknown } {
+  // Try comparison: <ref> <op> <literal>
+  const compMatch = input.match(/^(\$[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+)\s*(==|!=|>=?|<=?)\s*(.+)$/);
+  if (compMatch) {
+    return { ref: compMatch[1], op: compMatch[2], literal: parseLiteral(compMatch[3].trim()) };
+  }
+  // Try bare ref
+  const refMatch = input.match(/^(\$[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+)$/);
+  if (refMatch) {
+    return { ref: refMatch[1], op: null, literal: null };
+  }
+  throw new Error(`Unsupported condition: ${input}`);
+}
+
+function parseLiteral(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw === 'null') return null;
+  if (raw.startsWith('"') && raw.endsWith('"')) return raw.slice(1, -1);
+  const num = Number(raw);
+  if (!Number.isNaN(num)) return num;
+  throw new Error(`Cannot parse literal: ${raw}`);
+}
+
+export function resolveDeepRef(
+  ref: string,
+  results: Record<string, WorkflowStepResult>,
+): unknown {
+  const match = ref.match(/^\$([A-Za-z0-9_-]+)\.(.+)$/);
+  if (!match) throw new Error(`Invalid ref: ${ref}`);
+
+  const [, stepId, path] = match;
+  const step = results[stepId];
+  if (!step) return undefined;
+
+  const segments = path.split('.');
+  let current: unknown = step;
+
+  for (const seg of segments) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[seg];
+  }
+
+  return current;
+}
+
+export function evaluateFlowRules(
+  flow: FlowRule[] | undefined,
+  results: Record<string, WorkflowStepResult>,
+): string | null {
+  if (!flow) return null;
+  for (const rule of flow) {
+    if ('default' in rule) return rule.default;
+    if (evaluateCondition(rule.when, results)) return rule.goto;
+  }
+  return null;
+}
+
+function isTruthy(value: unknown): boolean {
+  if (value === null || value === undefined || value === false || value === 0 || value === '') return false;
+  return true;
+}
+
+function compareValues(left: unknown, op: string, right: unknown): boolean {
+  switch (op) {
+    case '==': return left === right;
+    case '!=': return left !== right;
+    case '>':  return typeof left === 'number' && typeof right === 'number' && left > right;
+    case '<':  return typeof left === 'number' && typeof right === 'number' && left < right;
+    case '>=': return typeof left === 'number' && typeof right === 'number' && left >= right;
+    case '<=': return typeof left === 'number' && typeof right === 'number' && left <= right;
+    default: throw new Error(`Unknown operator: ${op}`);
+  }
+}
+
+type ChildExecutionResult =
+  | { halted: false; stepResult: WorkflowStepResult }
+  | {
+      halted: true;
+      childStateKey: string;
+      childFilePath: string;
+      approvalStepId?: string;
+      requiresApproval: WorkflowRunResult['requiresApproval'];
+      stepResult?: never;
+    };
+
+async function executeChildWorkflow(
+  parsed: { name?: string; file?: string; argsJson?: string },
+  context: {
+    parentFilePath: string;
+    env: Record<string, string | undefined>;
+    cwd?: string;
+    ctx: RunContext;
+    depth: number;
+    resumeChildStateKey?: string;
+    resumeApproved?: boolean;
+  },
+): Promise<ChildExecutionResult> {
+  const maxDepth = parseInt((context.env.LOBSTER_MAX_WORKFLOW_DEPTH as string | undefined) ?? '10', 10);
+  if (context.depth > maxDepth) {
+    throw new Error(`Workflow nesting depth exceeded (max: ${maxDepth})`);
+  }
+
+  let childPath: string;
+  if (context.resumeChildStateKey) {
+    // Resuming a halted child — path comes from resumeChildFilePath
+    childPath = parsed.file!;
+  } else if (parsed.file) {
+    childPath = path.resolve(context.cwd ?? '.', parsed.file);
+  } else {
+    childPath = await resolveWorkflowByName(
+      parsed.name!,
+      context.parentFilePath,
+      context.env.LOBSTER_WORKFLOW_PATH as string | undefined,
+      context.cwd,
+    );
+  }
+
+  const childArgs = parsed.argsJson ? JSON.parse(parsed.argsJson) : {};
+
+  // Build resume payload for child if we have a child state key
+  let childResume: WorkflowResumePayload | undefined;
+  if (context.resumeChildStateKey) {
+    childResume = {
+      protocolVersion: 1,
+      v: 1,
+      kind: 'workflow-file',
+      stateKey: context.resumeChildStateKey,
+    };
+  }
+
+  const childCtx: RunContext = {
+    ...context.ctx,
+    env: context.env as Record<string, string | undefined>,
+  };
+
+  const childResult = await runWorkflowFile({
+    filePath: childPath,
+    args: childArgs,
+    ctx: childCtx,
+    resume: childResume,
+    approved: context.resumeApproved,
+    _depth: context.depth,
+  });
+
+  if (childResult.status === 'needs_approval') {
+    // Child halted — extract the child state key from the resume token
+    const childPayload = childResult.requiresApproval?.resumeToken
+      ? decodeResumeTokenInternal(childResult.requiresApproval.resumeToken)
+      : null;
+
+    return {
+      halted: true,
+      childStateKey: childPayload?.stateKey ?? '',
+      childFilePath: childPath,
+      approvalStepId: childPayload?.approvalStepId,
+      requiresApproval: childResult.requiresApproval,
+    };
+  }
+
+  // Child completed — map output to step result
+  return { halted: false, stepResult: childOutputToStepResult(childPath, childResult) };
+}
+
+function childOutputToStepResult(stepId: string, childResult: WorkflowRunResult): WorkflowStepResult {
+  const output = childResult.output;
+  if (output.length === 0) {
+    return { id: stepId, stdout: '', json: undefined };
+  }
+  const value = output.length === 1 ? output[0] : output;
+  return {
+    id: stepId,
+    stdout: JSON.stringify(value),
+    json: value,
+  };
+}
+
+function decodeResumeTokenInternal(token: string): WorkflowResumePayload | null {
+  try {
+    return decodeToken(token) as WorkflowResumePayload | null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseLobsterRunCommand(command: string): {
+  name?: string;
+  file?: string;
+  argsJson?: string;
+} | null {
+  const trimmed = command.trim();
+  if (!trimmed.startsWith('lobster.run')) return null;
+  // Must be followed by end-of-string or whitespace
+  if (trimmed.length > 'lobster.run'.length && !/\s/.test(trimmed['lobster.run'.length])) return null;
+
+  const rest = trimmed.slice('lobster.run'.length).trim();
+
+  let name: string | undefined;
+  let file: string | undefined;
+  let argsJson: string | undefined;
+
+  // Parse --name <value>
+  const nameMatch = rest.match(/(?:^|\s)--name\s+([^\s]+)/);
+  if (nameMatch) name = nameMatch[1];
+
+  // Parse --file <value>
+  const fileMatch = rest.match(/(?:^|\s)--file\s+([^\s]+)/);
+  if (fileMatch) file = fileMatch[1];
+
+  // Parse --args-json '<json>' or --args-json <json>
+  const argsJsonMatch = rest.match(/(?:^|\s)--args-json\s+'([^']*)'/) ?? rest.match(/(?:^|\s)--args-json\s+(\S+)/);
+  if (argsJsonMatch) argsJson = argsJsonMatch[1];
+
+  if (name && file) {
+    throw new Error('lobster.run: --name and --file are mutually exclusive');
+  }
+  if (!name && !file) {
+    throw new Error('lobster.run: one of --name or --file is required');
+  }
+
+  return { name, file, argsJson };
+}
+
+export async function resolveWorkflowByName(
+  name: string,
+  parentFilePath: string,
+  workflowPath: string | undefined,
+  cwd: string | undefined,
+): Promise<string> {
+  const extensions = ['.lobster', '.yaml', '.yml', '.json'];
+  const dirs = [
+    path.dirname(parentFilePath),
+    ...(workflowPath ? workflowPath.split(':') : []),
+    ...(cwd ? [cwd] : []),
+  ];
+
+  for (const dir of dirs) {
+    for (const ext of extensions) {
+      const candidate = path.join(dir, name + ext);
+      try {
+        await fsp.access(candidate);
+        return candidate;
+      } catch { /* continue */ }
+    }
+  }
+  throw new Error(`Workflow not found: ${name}`);
 }
 
 function isApprovalStep(approval: WorkflowStep['approval']) {

--- a/test/condition-evaluator.test.ts
+++ b/test/condition-evaluator.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateCondition } from '../src/workflows/file.js';
+import type { WorkflowStepResult } from '../src/workflows/file.js';
+
+// Deep property access — truthiness
+test('evaluateCondition: deep property access truthiness', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    check: { id: 'check', stdout: '', json: { nested: { flag: true } } },
+  };
+  assert.equal(evaluateCondition('$check.json.nested.flag', results), true);
+});
+
+test('evaluateCondition: deep property missing returns falsy', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    check: { id: 'check', stdout: '', json: { nested: {} } },
+  };
+  assert.equal(evaluateCondition('$check.json.nested.missing', results), false);
+});
+
+// Comparison operators
+test('evaluateCondition: string equality', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: { status: 'ready' } },
+  };
+  assert.equal(evaluateCondition('$step.json.status == "ready"', results), true);
+  assert.equal(evaluateCondition('$step.json.status == "pending"', results), false);
+});
+
+test('evaluateCondition: numeric comparison', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: { count: 5 } },
+  };
+  assert.equal(evaluateCondition('$step.json.count > 0', results), true);
+  assert.equal(evaluateCondition('$step.json.count < 3', results), false);
+  assert.equal(evaluateCondition('$step.json.count >= 5', results), true);
+  assert.equal(evaluateCondition('$step.json.count <= 4', results), false);
+  assert.equal(evaluateCondition('$step.json.count != 5', results), false);
+});
+
+test('evaluateCondition: boolean comparison', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: { done: true } },
+  };
+  assert.equal(evaluateCondition('$step.json.done == true', results), true);
+  assert.equal(evaluateCondition('$step.json.done == false', results), false);
+});
+
+test('evaluateCondition: null comparison', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: { val: null } },
+  };
+  assert.equal(evaluateCondition('$step.json.val == null', results), true);
+});
+
+// Backward compat
+test('evaluateCondition: existing patterns still work', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: undefined, approved: true, skipped: false },
+  };
+  assert.equal(evaluateCondition('$step.approved', results), true);
+  assert.equal(evaluateCondition('$step.skipped', results), false);
+  assert.equal(evaluateCondition(true, results), true);
+  assert.equal(evaluateCondition(undefined, results), true);
+});
+
+test('evaluateCondition: false literal', () => {
+  assert.equal(evaluateCondition(false, {}), false);
+  assert.equal(evaluateCondition('false', {}), false);
+});
+
+test('evaluateCondition: step not in results returns falsy for bare ref', () => {
+  assert.equal(evaluateCondition('$missing.json.field', {}), false);
+});
+
+test('evaluateCondition: null json field returns falsy', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: { flag: null } },
+  };
+  assert.equal(evaluateCondition('$step.json.flag', results), false);
+});
+
+test('evaluateCondition: inequality', () => {
+  const results: Record<string, WorkflowStepResult> = {
+    step: { id: 'step', stdout: '', json: { status: 'ready' } },
+  };
+  assert.equal(evaluateCondition('$step.json.status != "other"', results), true);
+  assert.equal(evaluateCondition('$step.json.status != "ready"', results), false);
+});

--- a/test/workflow-flow-validation.test.ts
+++ b/test/workflow-flow-validation.test.ts
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { loadWorkflowFile } from '../src/workflows/file.js';
+
+async function writeTmpWorkflow(name: string, content: object): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-flow-test-'));
+  const file = path.join(dir, `${name}.lobster`);
+  await fsp.writeFile(file, JSON.stringify(content), 'utf8');
+  return file;
+}
+
+test('loadWorkflowFile: validates flow goto targets exist', async () => {
+  const file = await writeTmpWorkflow('bad-goto', {
+    steps: [
+      { id: 'a', command: 'echo hi', flow: [{ when: '$a.json.x == true', goto: 'nonexistent' }] },
+      { id: 'b', command: 'echo bye' },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /goto target.*nonexistent/i);
+});
+
+test('loadWorkflowFile: validates default goto target exists', async () => {
+  const file = await writeTmpWorkflow('bad-default-target', {
+    steps: [
+      { id: 'a', command: 'echo hi', flow: [{ default: 'nonexistent' }] },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /goto target.*nonexistent/i);
+});
+
+test('loadWorkflowFile: validates default is last rule', async () => {
+  const file = await writeTmpWorkflow('bad-default-order', {
+    steps: [
+      {
+        id: 'a',
+        command: 'echo hi',
+        flow: [
+          { default: 'b' },
+          { when: '$a.json.x == true', goto: 'b' },
+        ],
+      },
+      { id: 'b', command: 'echo bye' },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /default.*last/i);
+});
+
+test('loadWorkflowFile: accepts valid flow rules', async () => {
+  const file = await writeTmpWorkflow('good-flow', {
+    steps: [
+      {
+        id: 'a',
+        command: 'echo hi',
+        flow: [
+          { when: '$a.json.done == true', goto: 'b' },
+          { default: 'a' },
+        ],
+      },
+      { id: 'b', command: 'echo bye' },
+    ],
+  });
+  const wf = await loadWorkflowFile(file);
+  assert.equal(wf.steps[0].flow?.length, 2);
+});
+
+test('loadWorkflowFile: validates max_iterations is positive integer', async () => {
+  const file = await writeTmpWorkflow('bad-max-iter', {
+    steps: [
+      { id: 'a', command: 'echo hi', max_iterations: 0 },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /max_iterations/i);
+});
+
+test('loadWorkflowFile: validates max_iterations is integer not float', async () => {
+  const file = await writeTmpWorkflow('bad-max-iter-float', {
+    steps: [
+      { id: 'a', command: 'echo hi', max_iterations: 1.5 },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /max_iterations/i);
+});
+
+test('loadWorkflowFile: accepts valid max_iterations', async () => {
+  const file = await writeTmpWorkflow('good-max-iter', {
+    steps: [
+      { id: 'a', command: 'echo hi', max_iterations: 5 },
+    ],
+  });
+  const wf = await loadWorkflowFile(file);
+  assert.equal(wf.steps[0].max_iterations, 5);
+});
+
+test('loadWorkflowFile: flow must be array', async () => {
+  const file = await writeTmpWorkflow('bad-flow-type', {
+    steps: [
+      { id: 'a', command: 'echo hi', flow: 'not-an-array' },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /flow must be an array/i);
+});
+
+test('loadWorkflowFile: flow rule must be valid shape', async () => {
+  const file = await writeTmpWorkflow('bad-flow-rule', {
+    steps: [
+      { id: 'a', command: 'echo hi', flow: [{ invalid: 'rule' }] },
+    ],
+  });
+  await assert.rejects(loadWorkflowFile(file), /invalid flow rule/i);
+});

--- a/test/workflow-flow.test.ts
+++ b/test/workflow-flow.test.ts
@@ -1,0 +1,227 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile } from '../src/workflows/file.js';
+import { decodeResumeToken } from '../src/resume.js';
+import type { WorkflowResumePayload } from '../src/workflows/file.js';
+
+const testCtx = {
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr,
+  mode: 'tool' as const,
+};
+
+async function writeTmpWorkflow(
+  name: string,
+  contentFn: (dir: string) => object,
+): Promise<{ filePath: string; env: Record<string, string | undefined>; dir: string }> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-flow-'));
+  const stateDir = path.join(dir, 'state');
+  const filePath = path.join(dir, `${name}.lobster`);
+  const content = contentFn(dir);
+  await fsp.writeFile(filePath, JSON.stringify(content), 'utf8');
+  return { filePath, env: { ...process.env, LOBSTER_STATE_DIR: stateDir }, dir };
+}
+
+function decodeWorkflowResumeToken(token: string): WorkflowResumePayload {
+  const payload = decodeResumeToken(token);
+  if (payload.kind !== 'workflow-file') {
+    throw new Error(`Expected workflow resume token, got ${payload.kind}`);
+  }
+  return payload;
+}
+
+test('flow: forward jump skips intermediate steps', async () => {
+  const { filePath, env } = await writeTmpWorkflow('forward-jump', () => ({
+    steps: [
+      {
+        id: 'a',
+        command: 'node -e "process.stdout.write(JSON.stringify({jump:true}))"',
+        flow: [{ when: '$a.json.jump == true', goto: 'c' }],
+      },
+      {
+        id: 'b',
+        command: 'node -e "process.stdout.write(JSON.stringify({ran:true}))"',
+      },
+      {
+        id: 'c',
+        command: 'node -e "process.stdout.write(JSON.stringify({done:true}))"',
+      },
+    ],
+  }));
+
+  const result = await runWorkflowFile({ filePath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ done: true }]);
+});
+
+test('flow: backward jump creates a loop', async () => {
+  const { filePath, env } = await writeTmpWorkflow('loop', (d) => {
+    const cntFile = path.join(d, 'cnt.txt');
+    return {
+      steps: [
+        {
+          id: 'counter',
+          command: `node -e "const fs=require('fs'); const f='${cntFile}'; const c=(fs.existsSync(f)?parseInt(fs.readFileSync(f,'utf8')):0)+1; fs.writeFileSync(f,String(c)); process.stdout.write(JSON.stringify({count:c}))"`,
+          flow: [
+            { when: '$counter.json.count >= 3', goto: 'done' },
+            { default: 'counter' },
+          ],
+          max_iterations: 10,
+        },
+        {
+          id: 'done',
+          command: 'node -e "process.stdout.write(JSON.stringify({finished:true}))"',
+        },
+      ],
+    };
+  });
+
+  const result = await runWorkflowFile({ filePath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ finished: true }]);
+});
+
+test('flow: default fallback when condition is false', async () => {
+  const { filePath, env } = await writeTmpWorkflow('default-fallback', () => ({
+    steps: [
+      {
+        id: 'a',
+        command: 'node -e "process.stdout.write(JSON.stringify({skip:true}))"',
+        flow: [
+          { when: '$a.json.skip == false', goto: 'b' },
+          { default: 'b' },
+        ],
+      },
+      {
+        id: 'b',
+        command: 'node -e "process.stdout.write(JSON.stringify({done:true}))"',
+      },
+    ],
+  }));
+
+  const result = await runWorkflowFile({ filePath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ done: true }]);
+});
+
+test('flow: no match advances normally', async () => {
+  const { filePath, env } = await writeTmpWorkflow('no-match', () => ({
+    steps: [
+      {
+        id: 'a',
+        command: 'node -e "process.stdout.write(JSON.stringify({x:1}))"',
+        flow: [{ when: '$a.json.x == 99', goto: 'a' }],
+      },
+      {
+        id: 'b',
+        command: 'node -e "process.stdout.write(JSON.stringify({next:true}))"',
+      },
+    ],
+  }));
+
+  const result = await runWorkflowFile({ filePath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ next: true }]);
+});
+
+test('flow: max_iterations hard error', async () => {
+  const { filePath, env } = await writeTmpWorkflow('max-iter', () => ({
+    steps: [
+      {
+        id: 'loop',
+        command: 'node -e "process.stdout.write(JSON.stringify({going:true}))"',
+        max_iterations: 3,
+        flow: [{ default: 'loop' }],
+      },
+    ],
+  }));
+
+  await assert.rejects(
+    () => runWorkflowFile({ filePath, ctx: { ...testCtx, env } }),
+    /max_iterations|exceeded/i,
+  );
+});
+
+test('flow: skipped steps do not evaluate flow', async () => {
+  // A is skipped (when=false). Its flow [default:'c'] should NOT fire.
+  // If flow fires: jump to C, B is invisible → B marker file NOT written
+  // If flow doesn't fire: B runs → B marker file written, then C runs
+  const { filePath, env, dir } = await writeTmpWorkflow('skip-flow', (d) => {
+    const markerFile = path.join(d, 'b_ran');
+    return {
+      steps: [
+        {
+          id: 'a',
+          command: 'node -e "process.stdout.write(JSON.stringify({x:1}))"',
+          when: false,
+          flow: [{ default: 'c' }],
+        },
+        {
+          id: 'b',
+          command: `node -e "require('fs').writeFileSync('${markerFile}','1'); process.stdout.write(JSON.stringify({ran:true}))"`,
+        },
+        {
+          id: 'c',
+          command: 'node -e "process.stdout.write(JSON.stringify({jumped:true}))"',
+        },
+      ],
+    };
+  });
+
+  const result = await runWorkflowFile({ filePath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  // C is last step (runs after B in correct case)
+  assert.deepEqual(result.output, [{ jumped: true }]);
+  // Verify B actually ran (proves flow on A was NOT evaluated)
+  const bRan = await fsp.access(path.join(dir, 'b_ran')).then(() => true, () => false);
+  assert.equal(bRan, true, 'Step B should have run (A was skipped, its flow not evaluated)');
+});
+
+test('flow: visit counters persist across halt/resume', async () => {
+  const { filePath, env } = await writeTmpWorkflow('visit-persist', () => ({
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(JSON.stringify({requiresApproval:{prompt:\'Approve?\',items:[]}}))"',
+        approval: 'required',
+        max_iterations: 5,
+        flow: [{ default: 'check' }],
+      },
+    ],
+  }));
+
+  // First run — halts for approval (visit 1)
+  const first = await runWorkflowFile({ filePath, ctx: { ...testCtx, env } });
+  assert.equal(first.status, 'needs_approval');
+  const payload1 = decodeWorkflowResumeToken(first.requiresApproval?.resumeToken ?? '');
+
+  // Resume — flow loops back to check, so command runs again (visit 2)
+  const second = await runWorkflowFile({ filePath, ctx: { ...testCtx, env }, resume: payload1, approved: true });
+  assert.equal(second.status, 'needs_approval'); // visit 2, halts again
+
+  const payload2 = decodeWorkflowResumeToken(second.requiresApproval?.resumeToken ?? '');
+
+  // Continue resuming until max_iterations
+  let current = payload2;
+  let hitLimit = false;
+  for (let i = 0; i < 5; i++) {
+    try {
+      const r = await runWorkflowFile({ filePath, ctx: { ...testCtx, env }, resume: current, approved: true });
+      if (r.status === 'needs_approval') {
+        current = decodeWorkflowResumeToken(r.requiresApproval?.resumeToken ?? '');
+      }
+    } catch (e: unknown) {
+      if (e instanceof Error && /max_iterations|exceeded/i.test(e.message)) {
+        hitLimit = true;
+        break;
+      }
+      throw e;
+    }
+  }
+  assert.equal(hitLimit, true);
+});

--- a/test/workflow-integration.test.ts
+++ b/test/workflow-integration.test.ts
@@ -1,0 +1,248 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile } from '../src/workflows/file.js';
+import { decodeResumeToken } from '../src/resume.js';
+import type { WorkflowResumePayload } from '../src/workflows/file.js';
+
+async function makeTestEnv() {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-integ-'));
+  const stateDir = path.join(dir, 'state');
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+  return { dir, env };
+}
+
+const testCtx = {
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr,
+  mode: 'tool' as const,
+};
+
+async function writeWorkflow(dir: string, name: string, content: object): Promise<string> {
+  const filePath = path.join(dir, `${name}.lobster`);
+  await fsp.writeFile(filePath, JSON.stringify(content), 'utf8');
+  return filePath;
+}
+
+function decodeWorkflowResumeToken(token: string): WorkflowResumePayload {
+  const payload = decodeResumeToken(token);
+  if (payload.kind !== 'workflow-file') {
+    throw new Error(`Expected workflow resume token, got ${payload.kind}`);
+  }
+  return payload;
+}
+
+test('integration: sub-workflow in a flow loop — 3 iterations then done', async () => {
+  const { dir, env } = await makeTestEnv();
+  const countFile = path.join(dir, 'count.txt');
+  await fsp.writeFile(countFile, '0', 'utf8');
+  const envWithCount = { ...env, COUNT_FILE: countFile };
+
+  // Child: reads count, increments, returns {done: true} when count >= 3
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      {
+        id: 'step',
+        command: `node -e "const fs=require('fs'),f=process.env.COUNT_FILE;const c=parseInt(fs.readFileSync(f,'utf8'))+1;fs.writeFileSync(f,String(c));process.stdout.write(JSON.stringify({count:c,done:c>=3}))"`,
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      {
+        id: 'loop',
+        command: 'lobster.run --name child',
+        max_iterations: 10,
+        flow: [
+          { when: '$loop.json.done == true', goto: 'finish' },
+          { default: 'loop' },
+        ],
+      },
+      {
+        id: 'finish',
+        command: 'node -e "process.stdout.write(JSON.stringify({all_done:true}))"',
+      },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env: envWithCount } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ all_done: true }]);
+  assert.equal(parseInt(await fsp.readFile(countFile, 'utf8')), 3);
+});
+
+test('integration: three-level nesting — grandparent → parent → child', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      { id: 'out', command: "node -e \"process.stdout.write(JSON.stringify({level:'child'}))\"" },
+    ],
+  });
+
+  await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run-child', command: 'lobster.run --name child' },
+      {
+        id: 'wrap',
+        command: "node -e \"process.stdout.write(JSON.stringify({level:'parent',child:true}))\"",
+      },
+    ],
+  });
+
+  const grandparentPath = await writeWorkflow(dir, 'grandparent', {
+    steps: [
+      { id: 'run-parent', command: 'lobster.run --name parent' },
+      {
+        id: 'final',
+        command: "node -e \"process.stdout.write(JSON.stringify({level:'grandparent',done:true}))\"",
+      },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: grandparentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ level: 'grandparent', done: true }]);
+});
+
+test('integration: nested halt inside a loop with resume', async () => {
+  const { dir, env } = await makeTestEnv();
+  const countFile = path.join(dir, 'count.txt');
+  await fsp.writeFile(countFile, '0', 'utf8');
+  const envWithCount = { ...env, COUNT_FILE: countFile };
+
+  // Child requires approval on each call
+  await writeWorkflow(dir, 'approvable-child', {
+    steps: [
+      {
+        id: 'gate',
+        command: `node -e "const fs=require('fs'),f=process.env.COUNT_FILE;const c=parseInt(fs.readFileSync(f,'utf8'))+1;fs.writeFileSync(f,String(c));process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Approve iteration '+c+'?',items:[]},count:c}))"`,
+        approval: 'required',
+      },
+      {
+        id: 'result',
+        command: `node -e "const fs=require('fs'),f=process.env.COUNT_FILE;const c=parseInt(fs.readFileSync(f,'utf8'));process.stdout.write(JSON.stringify({done:c>=2}))"`,
+        condition: '$gate.approved',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      {
+        id: 'loop',
+        command: 'lobster.run --name approvable-child',
+        max_iterations: 5,
+        flow: [
+          { when: '$loop.json.done == true', goto: 'finish' },
+          { default: 'loop' },
+        ],
+      },
+      {
+        id: 'finish',
+        command: 'node -e "process.stdout.write(JSON.stringify({completed:true}))"',
+      },
+    ],
+  });
+
+  // First run — halts at child's approval gate
+  const first = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env: envWithCount } });
+  assert.equal(first.status, 'needs_approval');
+  assert.ok(first.requiresApproval?.prompt?.includes('Approve iteration 1'));
+
+  const payload1 = decodeWorkflowResumeToken(first.requiresApproval?.resumeToken ?? '');
+  // Resume iteration 1 — child completes (done: false), flow loops back, child halts again
+  const second = await runWorkflowFile({
+    filePath: parentPath,
+    ctx: { ...testCtx, env: envWithCount },
+    resume: payload1,
+    approved: true,
+  });
+  assert.equal(second.status, 'needs_approval');
+  assert.ok(second.requiresApproval?.prompt?.includes('Approve iteration 2'));
+
+  const payload2 = decodeWorkflowResumeToken(second.requiresApproval?.resumeToken ?? '');
+  // Resume iteration 2 — child completes (done: true), flow goes to finish
+  const third = await runWorkflowFile({
+    filePath: parentPath,
+    ctx: { ...testCtx, env: envWithCount },
+    resume: payload2,
+    approved: true,
+  });
+  assert.equal(third.status, 'ok');
+  assert.deepEqual(third.output, [{ completed: true }]);
+});
+
+test('integration: flow routes to correct branch based on condition', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  // score=85: >= 90 is false → default to grade-normal.
+  // Each branch flows to 'done' (when: false) so lastStepId stays on the grade step.
+  const parentPath = await writeWorkflow(dir, 'flow-cond', {
+    steps: [
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(JSON.stringify({score:85}))"',
+        flow: [
+          { when: '$check.json.score >= 90', goto: 'grade-high' },
+          { default: 'grade-normal' },
+        ],
+      },
+      { id: 'grade-high', command: "node -e \"process.stdout.write(JSON.stringify({grade:'A'}))\"", flow: [{ default: 'done' }] },
+      { id: 'grade-normal', command: "node -e \"process.stdout.write(JSON.stringify({grade:'B'}))\"", flow: [{ default: 'done' }] },
+      { id: 'done', when: false, command: 'echo noop' },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ grade: 'B' }]);
+});
+
+test('integration: flow + approval + lobster.run combined', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'analyzer', {
+    steps: [
+      { id: 'analyze', command: 'node -e "process.stdout.write(JSON.stringify({confidence:0.95}))"' },
+    ],
+  });
+
+  // Both branches flow to 'done' (when: false sentinel) so lastStepId stays on the branch step
+  const parentPath = await writeWorkflow(dir, 'combined', {
+    steps: [
+      {
+        id: 'run',
+        command: 'lobster.run --name analyzer',
+        approval: 'required',
+        flow: [
+          { when: '$run.json.confidence > 0.9', goto: 'auto-approve' },
+          { default: 'manual-review' },
+        ],
+      },
+      { id: 'auto-approve', command: "node -e \"process.stdout.write(JSON.stringify({path:'auto'}))\"", flow: [{ default: 'done' }] },
+      { id: 'manual-review', command: "node -e \"process.stdout.write(JSON.stringify({path:'manual'}))\"", flow: [{ default: 'done' }] },
+      { id: 'done', when: false, command: 'echo noop' },
+    ],
+  });
+
+  // First run — child runs, then approval gate halts
+  const first = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(first.status, 'needs_approval');
+
+  const payload = decodeWorkflowResumeToken(first.requiresApproval?.resumeToken ?? '');
+  // Resume with approval — flow evaluates $run.json.confidence > 0.9 → true → auto-approve
+  const second = await runWorkflowFile({
+    filePath: parentPath,
+    ctx: { ...testCtx, env },
+    resume: payload,
+    approved: true,
+  });
+  assert.equal(second.status, 'ok');
+  assert.deepEqual(second.output, [{ path: 'auto' }]);
+});

--- a/test/workflow-subworkflow-parsing.test.ts
+++ b/test/workflow-subworkflow-parsing.test.ts
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { parseLobsterRunCommand, resolveWorkflowByName } from '../src/workflows/file.js';
+
+// parseLobsterRunCommand tests
+
+test('parseLobsterRunCommand: parses --name', () => {
+  const result = parseLobsterRunCommand('lobster.run --name my-workflow');
+  assert.deepEqual(result, { name: 'my-workflow', file: undefined, argsJson: undefined });
+});
+
+test('parseLobsterRunCommand: parses --file and --args-json', () => {
+  const result = parseLobsterRunCommand("lobster.run --file ./path.lobster --args-json '{\"a\":1}'");
+  assert.deepEqual(result, { name: undefined, file: './path.lobster', argsJson: '{"a":1}' });
+});
+
+test('parseLobsterRunCommand: parses --name with --args-json', () => {
+  const result = parseLobsterRunCommand("lobster.run --name child --args-json '{\"x\":42}'");
+  assert.deepEqual(result, { name: 'child', file: undefined, argsJson: '{"x":42}' });
+});
+
+test('parseLobsterRunCommand: returns null for non-lobster commands', () => {
+  assert.equal(parseLobsterRunCommand('exec --shell "echo hi"'), null);
+  assert.equal(parseLobsterRunCommand('echo lobster.run'), null);
+  assert.equal(parseLobsterRunCommand(''), null);
+});
+
+test('parseLobsterRunCommand: errors on both --name and --file', () => {
+  assert.throws(() => parseLobsterRunCommand('lobster.run --name x --file y.lobster'));
+});
+
+test('parseLobsterRunCommand: errors on neither --name nor --file', () => {
+  assert.throws(() => parseLobsterRunCommand("lobster.run --args-json '{\"a\":1}'"));
+});
+
+test('parseLobsterRunCommand: handles args-json without quotes', () => {
+  const result = parseLobsterRunCommand('lobster.run --name child --args-json {"a":1}');
+  assert.equal(result?.name, 'child');
+  assert.equal(result?.argsJson, '{"a":1}');
+});
+
+// resolveWorkflowByName tests
+
+test('resolveWorkflowByName: finds .lobster in parent dir', async () => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resolve-'));
+  const wfFile = path.join(dir, 'my-workflow.lobster');
+  await fsp.writeFile(wfFile, '{}', 'utf8');
+
+  const parentFilePath = path.join(dir, 'parent.lobster');
+  const result = await resolveWorkflowByName('my-workflow', parentFilePath, undefined, undefined);
+  assert.equal(result, wfFile);
+});
+
+test('resolveWorkflowByName: finds .yaml extension', async () => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-resolve-'));
+  const wfFile = path.join(dir, 'my-workflow.yaml');
+  await fsp.writeFile(wfFile, '{}', 'utf8');
+
+  const parentFilePath = path.join(dir, 'parent.lobster');
+  const result = await resolveWorkflowByName('my-workflow', parentFilePath, undefined, undefined);
+  assert.equal(result, wfFile);
+});
+
+test('resolveWorkflowByName: falls back to LOBSTER_WORKFLOW_PATH', async () => {
+  const parentDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-parent-'));
+  const searchDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-search-'));
+  const wfFile = path.join(searchDir, 'my-workflow.lobster');
+  await fsp.writeFile(wfFile, '{}', 'utf8');
+
+  const parentFilePath = path.join(parentDir, 'parent.lobster');
+  const result = await resolveWorkflowByName('my-workflow', parentFilePath, searchDir, undefined);
+  assert.equal(result, wfFile);
+});
+
+test('resolveWorkflowByName: falls back to cwd', async () => {
+  const parentDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-parent-'));
+  const cwdDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-cwd-'));
+  const wfFile = path.join(cwdDir, 'my-workflow.lobster');
+  await fsp.writeFile(wfFile, '{}', 'utf8');
+
+  const parentFilePath = path.join(parentDir, 'parent.lobster');
+  const result = await resolveWorkflowByName('my-workflow', parentFilePath, undefined, cwdDir);
+  assert.equal(result, wfFile);
+});
+
+test('resolveWorkflowByName: parent dir takes priority over LOBSTER_WORKFLOW_PATH', async () => {
+  const parentDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-parent-'));
+  const searchDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-search-'));
+  const wfInParent = path.join(parentDir, 'my-workflow.lobster');
+  const wfInSearch = path.join(searchDir, 'my-workflow.lobster');
+  await fsp.writeFile(wfInParent, '{}', 'utf8');
+  await fsp.writeFile(wfInSearch, '{}', 'utf8');
+
+  const parentFilePath = path.join(parentDir, 'parent.lobster');
+  const result = await resolveWorkflowByName('my-workflow', parentFilePath, searchDir, undefined);
+  assert.equal(result, wfInParent);
+});
+
+test('resolveWorkflowByName: throws when not found', async () => {
+  await assert.rejects(
+    resolveWorkflowByName('nonexistent', '/tmp/parent.lobster', undefined, undefined),
+    /not found/i,
+  );
+});
+
+test('resolveWorkflowByName: colon-separated LOBSTER_WORKFLOW_PATH', async () => {
+  const dir1 = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-d1-'));
+  const dir2 = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-d2-'));
+  const wfFile = path.join(dir2, 'my-workflow.lobster');
+  await fsp.writeFile(wfFile, '{}', 'utf8');
+
+  const parentFilePath = path.join(os.tmpdir(), 'parent.lobster');
+  const result = await resolveWorkflowByName('my-workflow', parentFilePath, `${dir1}:${dir2}`, undefined);
+  assert.equal(result, wfFile);
+});

--- a/test/workflow-subworkflow.test.ts
+++ b/test/workflow-subworkflow.test.ts
@@ -1,0 +1,283 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile } from '../src/workflows/file.js';
+import { decodeResumeToken } from '../src/resume.js';
+import type { WorkflowResumePayload } from '../src/workflows/file.js';
+
+async function makeTestEnv() {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-sw-'));
+  const stateDir = path.join(dir, 'state');
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+  return { dir, env };
+}
+
+const testCtx = {
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr,
+  mode: 'tool' as const,
+};
+
+async function writeWorkflow(dir: string, name: string, content: object): Promise<string> {
+  const filePath = path.join(dir, `${name}.lobster`);
+  await fsp.writeFile(filePath, JSON.stringify(content), 'utf8');
+  return filePath;
+}
+
+function decodeWorkflowResumeToken(token: string): WorkflowResumePayload {
+  const payload = decodeResumeToken(token);
+  if (payload.kind !== 'workflow-file') {
+    throw new Error(`Expected workflow resume token, got ${payload.kind}`);
+  }
+  return payload;
+}
+
+test('lobster.run: basic child execution with args', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    args: { x: { default: 0 } },
+    steps: [
+      {
+        id: 'result',
+        command: 'node -e "process.stdout.write(JSON.stringify({value: parseInt(process.env.X||0)}))"',
+        env: { X: '${x}' },
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      {
+        id: 'run-child',
+        command: `lobster.run --name child --args-json '{"x": 42}'`,
+      },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ value: 42 }]);
+});
+
+test('lobster.run: child output as parent step result — single item unwrapped', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      {
+        id: 'out',
+        command: 'node -e "process.stdout.write(JSON.stringify({done:true}))"',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run', command: 'lobster.run --name child' },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ done: true }]);
+});
+
+test('lobster.run: child halt bubbles to parent', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      {
+        id: 'approve',
+        command: "node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Approve child?',items:[]}}))\"",
+        approval: 'required',
+      },
+      {
+        id: 'after',
+        command: 'node -e "process.stdout.write(JSON.stringify({done:true}))"',
+        condition: '$approve.approved',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run', command: 'lobster.run --name child' },
+      { id: 'done', command: 'node -e "process.stdout.write(JSON.stringify({parent:true}))"' },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'needs_approval');
+  assert.equal(result.requiresApproval?.prompt, 'Approve child?');
+  assert.ok(result.requiresApproval?.resumeToken);
+});
+
+test('lobster.run: resume after child halt', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      {
+        id: 'approve',
+        command: "node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Approve?',items:[]}}))\"",
+        approval: 'required',
+      },
+      {
+        id: 'result',
+        command: 'node -e "process.stdout.write(JSON.stringify({childDone:true}))"',
+        condition: '$approve.approved',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run', command: 'lobster.run --name child' },
+      { id: 'finish', command: 'node -e "process.stdout.write(JSON.stringify({parentDone:true}))"' },
+    ],
+  });
+
+  const first = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(first.status, 'needs_approval');
+
+  const payload = decodeWorkflowResumeToken(first.requiresApproval?.resumeToken ?? '');
+  const second = await runWorkflowFile({
+    filePath: parentPath,
+    ctx: { ...testCtx, env },
+    resume: payload,
+    approved: true,
+  });
+
+  assert.equal(second.status, 'ok');
+  assert.deepEqual(second.output, [{ parentDone: true }]);
+});
+
+test('lobster.run: resuming halted child does not consume another parent iteration', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      {
+        id: 'approve',
+        command: "node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Approve?',items:[]}}))\"",
+        approval: 'required',
+      },
+      {
+        id: 'result',
+        command: 'node -e "process.stdout.write(JSON.stringify({childDone:true}))"',
+        condition: '$approve.approved',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run', command: 'lobster.run --name child', max_iterations: 1 },
+      { id: 'finish', command: 'node -e "process.stdout.write(JSON.stringify({parentDone:true}))"' },
+    ],
+  });
+
+  const first = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(first.status, 'needs_approval');
+
+  const payload = decodeWorkflowResumeToken(first.requiresApproval?.resumeToken ?? '');
+  const second = await runWorkflowFile({
+    filePath: parentPath,
+    ctx: { ...testCtx, env },
+    resume: payload,
+    approved: true,
+  });
+
+  assert.equal(second.status, 'ok');
+  assert.deepEqual(second.output, [{ parentDone: true }]);
+});
+
+test('lobster.run: --file flag with explicit path', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  const childPath = await writeWorkflow(dir, 'explicit-child', {
+    steps: [
+      { id: 'out', command: 'node -e "process.stdout.write(JSON.stringify({explicit:true}))"' },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent-file', {
+    steps: [
+      { id: 'run', command: `lobster.run --file ${childPath}` },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ explicit: true }]);
+});
+
+test('lobster.run: depth limit', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  // A workflow that calls itself recursively
+  const selfPath = path.join(dir, 'self.lobster');
+  await fsp.writeFile(selfPath, JSON.stringify({
+    steps: [
+      { id: 'recurse', command: `lobster.run --file ${selfPath}` },
+    ],
+  }), 'utf8');
+
+  await assert.rejects(
+    () => runWorkflowFile({ filePath: selfPath, ctx: { ...testCtx, env } }),
+    /depth exceeded|nesting depth/i,
+  );
+});
+
+test('lobster.run: env inheritance — child sees parent step env', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    steps: [
+      {
+        id: 'out',
+        command: 'node -e "process.stdout.write(JSON.stringify({val:process.env.PARENT_VAR}))"',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run', command: 'lobster.run --name child', env: { PARENT_VAR: 'hello' } },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ val: 'hello' }]);
+});
+
+test('lobster.run: child env overrides parent env', async () => {
+  const { dir, env } = await makeTestEnv();
+
+  await writeWorkflow(dir, 'child', {
+    env: { MY_VAR: 'from-child-workflow' },
+    steps: [
+      {
+        id: 'out',
+        command: 'node -e "process.stdout.write(JSON.stringify({val:process.env.MY_VAR}))"',
+      },
+    ],
+  });
+
+  const parentPath = await writeWorkflow(dir, 'parent', {
+    steps: [
+      { id: 'run', command: 'lobster.run --name child', env: { MY_VAR: 'from-parent-step' } },
+    ],
+  });
+
+  const result = await runWorkflowFile({ filePath: parentPath, ctx: { ...testCtx, env } });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, [{ val: 'from-child-workflow' }]);
+});


### PR DESCRIPTION
Replacement for #33 with clean history off current main.

## Summary
- add workflow flow directives with branching, loops, and validation
- add lobster.run sub-workflow invocation with halt propagation and resume support
- add coverage for deep conditions, flow control, and sub-workflow integration

## Test Plan
- pnpm test