### PR TITLE
feat: template filters (upper, length, join, etc.)

### DIFF
--- a/src/commands/stdlib/template.ts
+++ b/src/commands/stdlib/template.ts
@@ -12,11 +12,50 @@ function getByPath(obj: any, path: string): any {
   return cur;
 }
 
+/**
+ * Split a template expression on `|` but only outside of quotes.
+ * e.g. `line | split "|" | first` → [`line`, `split "|"`, `first`]
+ */
+function splitFilterChain(expr: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let i = 0;
+  while (i < expr.length) {
+    const ch = expr[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      current += ch;
+      i++;
+      while (i < expr.length && expr[i] !== quote) {
+        if (expr[i] === '\\' && i + 1 < expr.length) {
+          current += expr[i] + expr[i + 1];
+          i += 2;
+        } else {
+          current += expr[i];
+          i++;
+        }
+      }
+      if (i < expr.length) {
+        current += expr[i]; // closing quote
+        i++;
+      }
+    } else if (ch === '|') {
+      parts.push(current.trim());
+      current = '';
+      i++;
+    } else {
+      current += ch;
+      i++;
+    }
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
 function renderTemplate(tpl: string, ctx: any): string {
   return tpl.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_m, expr) => {
     const raw = String(expr ?? '').trim();
-    // Split on | to separate path from filters, but only at top level
-    const parts = raw.split('|').map((s) => s.trim());
+    const parts = splitFilterChain(raw);
     const key = parts[0];
     let val: unknown = getByPath(ctx, key);
     if (parts.length > 1) {

--- a/src/commands/stdlib/template.ts
+++ b/src/commands/stdlib/template.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import { applyFilters } from '../../core/filters.js';
 
 function getByPath(obj: any, path: string): any {
   if (path === '.' || path === 'this') return obj;
@@ -13,10 +14,17 @@ function getByPath(obj: any, path: string): any {
 
 function renderTemplate(tpl: string, ctx: any): string {
   return tpl.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_m, expr) => {
-    const key = String(expr ?? '').trim();
-    const val = getByPath(ctx, key);
+    const raw = String(expr ?? '').trim();
+    // Split on | to separate path from filters, but only at top level
+    const parts = raw.split('|').map((s) => s.trim());
+    const key = parts[0];
+    let val: unknown = getByPath(ctx, key);
+    if (parts.length > 1) {
+      val = applyFilters(val, parts.slice(1));
+    }
     if (val === undefined || val === null) return '';
     if (typeof val === 'string') return val;
+    if (typeof val === 'number' || typeof val === 'boolean') return String(val);
     return JSON.stringify(val);
   });
 }
@@ -28,7 +36,7 @@ export const templateCommand = {
     argsSchema: {
       type: 'object',
       properties: {
-        text: { type: 'string', description: 'Template text (supports {{path}}; {{.}} for the whole item)' },
+        text: { type: 'string', description: 'Template text (supports {{path}}, {{path | filter}}, {{.}} for the whole item)' },
         file: { type: 'string', description: 'Template file path' },
         _: { type: 'array', items: { type: 'string' } },
       },
@@ -45,7 +53,12 @@ export const templateCommand = {
       `Template syntax:\n` +
       `  - {{field}} or {{nested.field}}\n` +
       `  - {{.}} for the whole item\n` +
-      `  - Missing values render as empty string\n`
+      `  - {{field | filter}} pipe-based filters\n` +
+      `  - Missing values render as empty string\n\n` +
+      `Filters:\n` +
+      `  upper, lower, trim, truncate N, replace "from" "to", split sep\n` +
+      `  first, last, length, join sep\n` +
+      `  json, string, default val, round N, date fmt\n`
     );
   },
   async run({ input, args }: any) {

--- a/src/core/filters.ts
+++ b/src/core/filters.ts
@@ -35,12 +35,12 @@ FILTERS.set('date', (v, fmt) => {
   if (isNaN(d.getTime())) return String(v);
   if (!fmt) return d.toISOString();
   return fmt
-    .replace('YYYY', String(d.getFullYear()))
-    .replace('MM', String(d.getMonth() + 1).padStart(2, '0'))
-    .replace('DD', String(d.getDate()).padStart(2, '0'))
-    .replace('HH', String(d.getHours()).padStart(2, '0'))
-    .replace('mm', String(d.getMinutes()).padStart(2, '0'))
-    .replace('ss', String(d.getSeconds()).padStart(2, '0'));
+    .replace('YYYY', String(d.getUTCFullYear()))
+    .replace('MM', String(d.getUTCMonth() + 1).padStart(2, '0'))
+    .replace('DD', String(d.getUTCDate()).padStart(2, '0'))
+    .replace('HH', String(d.getUTCHours()).padStart(2, '0'))
+    .replace('mm', String(d.getUTCMinutes()).padStart(2, '0'))
+    .replace('ss', String(d.getUTCSeconds()).padStart(2, '0'));
 });
 
 export function getFilter(name: string): FilterFn | undefined {

--- a/src/core/filters.ts
+++ b/src/core/filters.ts
@@ -29,7 +29,9 @@ FILTERS.set('round', (v, n) => {
   return isNaN(num) ? v : Number(num.toFixed(dec));
 });
 FILTERS.set('date', (v, fmt) => {
-  const d = new Date(String(v));
+  const d = typeof v === 'number' || (typeof v === 'string' && /^\d+$/.test(v.trim()))
+    ? new Date(Number(v))
+    : new Date(String(v));
   if (isNaN(d.getTime())) return String(v);
   if (!fmt) return d.toISOString();
   return fmt

--- a/src/core/filters.ts
+++ b/src/core/filters.ts
@@ -7,7 +7,8 @@ FILTERS.set('lower', (v) => String(v ?? '').toLowerCase());
 FILTERS.set('trim', (v) => String(v ?? '').trim());
 FILTERS.set('truncate', (v, n) => {
   const s = String(v ?? '');
-  const len = parseInt(n) || 80;
+  const parsed = parseInt(n);
+  const len = Number.isNaN(parsed) ? 80 : parsed;
   return s.length > len ? s.slice(0, len) + '...' : s;
 });
 FILTERS.set('replace', (v, from, to) => String(v ?? '').replaceAll(from ?? '', to ?? ''));

--- a/src/core/filters.ts
+++ b/src/core/filters.ts
@@ -1,0 +1,106 @@
+export type FilterFn = (value: unknown, ...args: string[]) => unknown;
+
+const FILTERS = new Map<string, FilterFn>();
+
+FILTERS.set('upper', (v) => String(v ?? '').toUpperCase());
+FILTERS.set('lower', (v) => String(v ?? '').toLowerCase());
+FILTERS.set('trim', (v) => String(v ?? '').trim());
+FILTERS.set('truncate', (v, n) => {
+  const s = String(v ?? '');
+  const len = parseInt(n) || 80;
+  return s.length > len ? s.slice(0, len) + '...' : s;
+});
+FILTERS.set('replace', (v, from, to) => String(v ?? '').replaceAll(from ?? '', to ?? ''));
+FILTERS.set('split', (v, sep) => String(v ?? '').split(sep ?? ','));
+FILTERS.set('first', (v) => (Array.isArray(v) ? v[0] : v));
+FILTERS.set('last', (v) => (Array.isArray(v) ? v[v.length - 1] : v));
+FILTERS.set('length', (v) => {
+  if (Array.isArray(v)) return v.length;
+  if (typeof v === 'string') return v.length;
+  return 0;
+});
+FILTERS.set('join', (v, sep) => (Array.isArray(v) ? v.join(sep ?? ', ') : String(v ?? '')));
+FILTERS.set('json', (v) => JSON.stringify(v, null, 2));
+FILTERS.set('string', (v) => String(v ?? ''));
+FILTERS.set('default', (v, def) => (v == null || v === '' ? def : v));
+FILTERS.set('round', (v, n) => {
+  const num = Number(v);
+  const dec = parseInt(n) || 0;
+  return isNaN(num) ? v : Number(num.toFixed(dec));
+});
+FILTERS.set('date', (v, fmt) => {
+  const d = new Date(String(v));
+  if (isNaN(d.getTime())) return String(v);
+  if (!fmt) return d.toISOString();
+  return fmt
+    .replace('YYYY', String(d.getFullYear()))
+    .replace('MM', String(d.getMonth() + 1).padStart(2, '0'))
+    .replace('DD', String(d.getDate()).padStart(2, '0'))
+    .replace('HH', String(d.getHours()).padStart(2, '0'))
+    .replace('mm', String(d.getMinutes()).padStart(2, '0'))
+    .replace('ss', String(d.getSeconds()).padStart(2, '0'));
+});
+
+export function getFilter(name: string): FilterFn | undefined {
+  return FILTERS.get(name);
+}
+
+/**
+ * Parse a single filter expression like `truncate 80` or `replace "-" "_"`.
+ * Returns [filterName, ...args].
+ */
+export function parseFilterExpression(expr: string): [string, ...string[]] {
+  const trimmed = expr.trim();
+  const parts: string[] = [];
+  let i = 0;
+
+  while (i < trimmed.length) {
+    // skip whitespace
+    while (i < trimmed.length && trimmed[i] === ' ') i++;
+    if (i >= trimmed.length) break;
+
+    if (trimmed[i] === '"' || trimmed[i] === "'") {
+      const quote = trimmed[i];
+      i++;
+      let arg = '';
+      while (i < trimmed.length && trimmed[i] !== quote) {
+        if (trimmed[i] === '\\' && i + 1 < trimmed.length) {
+          arg += trimmed[i + 1];
+          i += 2;
+        } else {
+          arg += trimmed[i];
+          i++;
+        }
+      }
+      if (i < trimmed.length) i++; // skip closing quote
+      parts.push(arg);
+    } else {
+      let arg = '';
+      while (i < trimmed.length && trimmed[i] !== ' ') {
+        arg += trimmed[i];
+        i++;
+      }
+      parts.push(arg);
+    }
+  }
+
+  if (parts.length === 0) {
+    return [trimmed];
+  }
+  return parts as [string, ...string[]];
+}
+
+/**
+ * Apply a chain of filters to a value.
+ * Each filter string is like "upper" or "truncate 80" or "replace '-' '_'".
+ */
+export function applyFilters(value: unknown, filterChain: string[]): unknown {
+  let result = value;
+  for (const filterExpr of filterChain) {
+    const [name, ...args] = parseFilterExpression(filterExpr);
+    const fn = FILTERS.get(name);
+    if (!fn) throw new Error(`Unknown template filter: ${name}`);
+    result = fn(result, ...args);
+  }
+  return result;
+}

--- a/test/template_filters.test.ts
+++ b/test/template_filters.test.ts
@@ -108,6 +108,17 @@ test('applyFilters unknown filter throws', () => {
   assert.throws(() => applyFilters('x', ['nonexistent']), /Unknown template filter/);
 });
 
+test('applyFilters date with numeric epoch timestamp', () => {
+  // 2024-03-09T16:00:00.000Z
+  const result = applyFilters(1710000000000, ['date "YYYY-MM-DD"']);
+  assert.equal(result, '2024-03-09');
+});
+
+test('applyFilters date with numeric string epoch', () => {
+  const result = applyFilters('1710000000000', ['date "YYYY-MM-DD"']);
+  assert.equal(result, '2024-03-09');
+});
+
 // --- Template integration tests ---
 
 test('template with upper filter', async () => {
@@ -138,4 +149,10 @@ test('template without filters still works', async () => {
 test('template with join filter', async () => {
   const out = await run("template --text '{{tags | join \", \"}}'", [{ tags: ['a', 'b', 'c'] }]);
   assert.deepEqual(out, ['a, b, c']);
+});
+
+test('template with quoted pipe in filter arg does not break splitting', async () => {
+  // The split filter argument contains a literal pipe character
+  const out = await run(`template --text '{{line | split "|" | first}}'`, [{ line: 'a|b|c' }]);
+  assert.deepEqual(out, ['a']);
 });

--- a/test/template_filters.test.ts
+++ b/test/template_filters.test.ts
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runPipeline } from '../src/runtime.js';
+import { createDefaultRegistry } from '../src/commands/registry.js';
+import { parsePipeline } from '../src/parser.js';
+import { applyFilters, parseFilterExpression } from '../src/core/filters.js';
+
+async function run(pipelineText: string, input: any[]) {
+  const pipeline = parsePipeline(pipelineText);
+  const registry = createDefaultRegistry();
+  const res = await runPipeline({
+    pipeline,
+    registry,
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    env: process.env,
+    mode: 'tool',
+    input: (async function* () { for (const x of input) yield x; })(),
+  });
+  return res.items;
+}
+
+// --- Filter unit tests ---
+
+test('parseFilterExpression parses simple filter', () => {
+  assert.deepEqual(parseFilterExpression('upper'), ['upper']);
+});
+
+test('parseFilterExpression parses filter with arg', () => {
+  assert.deepEqual(parseFilterExpression('truncate 80'), ['truncate', '80']);
+});
+
+test('parseFilterExpression parses filter with quoted args', () => {
+  assert.deepEqual(parseFilterExpression('replace "-" "_"'), ['replace', '-', '_']);
+});
+
+test('applyFilters upper', () => {
+  assert.equal(applyFilters('hello', ['upper']), 'HELLO');
+});
+
+test('applyFilters lower', () => {
+  assert.equal(applyFilters('HELLO', ['lower']), 'hello');
+});
+
+test('applyFilters trim', () => {
+  assert.equal(applyFilters('  hi  ', ['trim']), 'hi');
+});
+
+test('applyFilters truncate', () => {
+  assert.equal(applyFilters('hello world', ['truncate 5']), 'hello...');
+});
+
+test('applyFilters truncate no-op when short', () => {
+  assert.equal(applyFilters('hi', ['truncate 5']), 'hi');
+});
+
+test('applyFilters replace', () => {
+  assert.equal(applyFilters('a-b-c', ['replace "-" "_"']), 'a_b_c');
+});
+
+test('applyFilters split', () => {
+  assert.deepEqual(applyFilters('a,b,c', ['split ","']), ['a', 'b', 'c']);
+});
+
+test('applyFilters first', () => {
+  assert.equal(applyFilters([1, 2, 3], ['first']), 1);
+});
+
+test('applyFilters last', () => {
+  assert.equal(applyFilters([1, 2, 3], ['last']), 3);
+});
+
+test('applyFilters length on array', () => {
+  assert.equal(applyFilters([1, 2, 3], ['length']), 3);
+});
+
+test('applyFilters length on string', () => {
+  assert.equal(applyFilters('hello', ['length']), 5);
+});
+
+test('applyFilters join', () => {
+  assert.equal(applyFilters(['a', 'b', 'c'], ['join ", "']), 'a, b, c');
+});
+
+test('applyFilters json', () => {
+  assert.equal(applyFilters({ a: 1 }, ['json']), JSON.stringify({ a: 1 }, null, 2));
+});
+
+test('applyFilters default with null', () => {
+  assert.equal(applyFilters(null, ['default "N/A"']), 'N/A');
+});
+
+test('applyFilters default with value', () => {
+  assert.equal(applyFilters('ok', ['default "N/A"']), 'ok');
+});
+
+test('applyFilters round', () => {
+  assert.equal(applyFilters(3.14159, ['round 2']), 3.14);
+});
+
+test('applyFilters chain', () => {
+  assert.equal(applyFilters('  Hello World  ', ['trim', 'upper']), 'HELLO WORLD');
+});
+
+test('applyFilters unknown filter throws', () => {
+  assert.throws(() => applyFilters('x', ['nonexistent']), /Unknown template filter/);
+});
+
+// --- Template integration tests ---
+
+test('template with upper filter', async () => {
+  const out = await run("template --text '{{name | upper}}'", [{ name: 'alice' }]);
+  assert.deepEqual(out, ['ALICE']);
+});
+
+test('template with length filter', async () => {
+  const out = await run("template --text '{{items | length}}'", [{ items: [1, 2, 3] }]);
+  assert.deepEqual(out, ['3']);
+});
+
+test('template with default filter', async () => {
+  const out = await run("template --text '{{missing | default \"N/A\"}}'", [{ other: 1 }]);
+  assert.deepEqual(out, ['N/A']);
+});
+
+test('template with chained filters', async () => {
+  const out = await run("template --text '{{name | trim | upper}}'", [{ name: '  bob  ' }]);
+  assert.deepEqual(out, ['BOB']);
+});
+
+test('template without filters still works', async () => {
+  const out = await run("template --text 'hi {{name}}'", [{ name: 'v' }]);
+  assert.deepEqual(out, ['hi v']);
+});
+
+test('template with join filter', async () => {
+  const out = await run("template --text '{{tags | join \", \"}}'", [{ tags: ['a', 'b', 'c'] }]);
+  assert.deepEqual(out, ['a, b, c']);
+});

--- a/test/template_filters.test.ts
+++ b/test/template_filters.test.ts
@@ -52,6 +52,10 @@ test('applyFilters truncate', () => {
   assert.equal(applyFilters('hello world', ['truncate 5']), 'hello...');
 });
 
+test('applyFilters truncate 0 returns empty with ellipsis', () => {
+  assert.equal(applyFilters('hello', ['truncate 0']), '...');
+});
+
 test('applyFilters truncate no-op when short', () => {
   assert.equal(applyFilters('hi', ['truncate 5']), 'hi');
 });


### PR DESCRIPTION
## Summary
- Adds pipe-based filter syntax to the template engine: `{{field | upper}}`, `{{items | length}}`
- 15 built-in filters: `upper`, `lower`, `trim`, `truncate`, `replace`, `split`, `first`, `last`, `length`, `join`, `json`, `string`, `default`, `round`, `date`
- Filter chaining: `{{name | trim | upper}}`
- Zero new dependencies — all filters are pure JS functions
- Fully backward compatible — templates without `|` work exactly as before

## Changes
- New `src/core/filters.ts` — filter registry, expression parser, and all filter implementations
- Updated `src/commands/stdlib/template.ts` — `renderTemplate` now splits on `|` and applies filters
- New `test/template_filters.test.ts` — 31 tests (unit + integration)

## Test plan
- [x] All 31 new tests pass
- [x] Existing template tests still pass (4/4)
- [x] Build succeeds with no type errors