### PR TITLE
feat: for_each step type with batching

### DIFF
--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -776,8 +776,11 @@ function dryRunWorkflow({
       lines.push(`     sub-steps: ${step.steps.length}`);
       // Inject loop variable placeholders so sub-step ref validation accepts $item/$index
       const loopScopedResults = { ...results };
-      loopScopedResults[dryItemVar] = { id: dryItemVar };
-      loopScopedResults[dryIndexVar] = { id: dryIndexVar };
+      // Seed loop vars with json placeholders so conditions like
+      // $item.json.field or $index.json == 0 evaluate truthy in dry-run
+      // rather than always being false due to missing json field.
+      loopScopedResults[dryItemVar] = { id: dryItemVar, json: { _placeholder: true } };
+      loopScopedResults[dryIndexVar] = { id: dryIndexVar, json: 0 };
       for (let si = 0; si < step.steps.length; si++) {
         const sub = step.steps[si];
         // Skip validation for conditional sub-steps (they may reference

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -746,7 +746,17 @@ function dryRunWorkflow({
 
     if (typeof step.for_each === 'string' && Array.isArray(step.steps)) {
       lines.push(`  ${num}. ${step.id}  [for_each]`);
-      lines.push(`     for_each: ${step.for_each}`);
+      const forEachRef = step.for_each;
+      const forEachNote = dryRunTemplateNote(forEachRef);
+      lines.push(`     for_each: ${forEachRef}${forEachNote ? `  ${forEachNote}` : ''}`);
+      // Validate the for_each source ref if it points to a known step
+      if (forEachRef.trim().startsWith('$')) {
+        try {
+          resolveInputValue(forEachRef, resolvedArgs, results);
+        } catch (err: any) {
+          throw new Error(`Workflow step ${step.id} for_each: ${err?.message ?? String(err)}`);
+        }
+      }
       lines.push(`     item_var: ${step.item_var ?? 'item'}, index_var: ${step.index_var ?? 'index'}`);
       if (step.batch_size) lines.push(`     batch_size: ${step.batch_size}`);
       lines.push(`     sub-steps: ${step.steps.length}`);
@@ -758,6 +768,19 @@ function dryRunWorkflow({
           lines.push(`       ${si + 1}. ${sub.id}  [shell] run: ${cmd}`);
         } else if (subExec.kind === 'pipeline') {
           const pl = resolveDryRunTemplate(subExec.value, resolvedArgs, results);
+          if (ctx.registry) {
+            try {
+              const stages = parsePipeline(pl);
+              for (const stage of stages) {
+                if (hasDeferredDryRunStageName(stage.name)) continue;
+                if (!ctx.registry.get(stage.name)) {
+                  throw new Error(`unknown command: ${stage.name}`);
+                }
+              }
+            } catch (err: any) {
+              throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} pipeline: ${err?.message ?? String(err)}`);
+            }
+          }
           lines.push(`       ${si + 1}. ${sub.id}  [pipeline] pipeline: ${pl}`);
         }
       }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -183,6 +183,12 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (forEachShell || forEachPipeline) {
         throw new Error(`Workflow step ${step.id} for_each cannot also define run, command, or pipeline`);
       }
+      if (step.item_var !== undefined && typeof step.item_var !== 'string') {
+        throw new Error(`Workflow step ${step.id} item_var must be a string`);
+      }
+      if (step.index_var !== undefined && typeof step.index_var !== 'string') {
+        throw new Error(`Workflow step ${step.id} index_var must be a string`);
+      }
       const loopItemVar = step.item_var ?? 'item';
       const loopIndexVar = step.index_var ?? 'index';
       if (loopItemVar === loopIndexVar) {
@@ -757,15 +763,21 @@ function dryRunWorkflow({
           throw new Error(`Workflow step ${step.id} for_each: ${err?.message ?? String(err)}`);
         }
       }
-      lines.push(`     item_var: ${step.item_var ?? 'item'}, index_var: ${step.index_var ?? 'index'}`);
+      const dryItemVar = step.item_var ?? 'item';
+      const dryIndexVar = step.index_var ?? 'index';
+      lines.push(`     item_var: ${dryItemVar}, index_var: ${dryIndexVar}`);
       if (step.batch_size) lines.push(`     batch_size: ${step.batch_size}`);
       lines.push(`     sub-steps: ${step.steps.length}`);
+      // Inject loop variable placeholders so sub-step ref validation accepts $item/$index
+      const loopScopedResults = { ...results };
+      loopScopedResults[dryItemVar] = { id: dryItemVar };
+      loopScopedResults[dryIndexVar] = { id: dryIndexVar };
       for (let si = 0; si < step.steps.length; si++) {
         const sub = step.steps[si];
-        // Validate sub-step stdin refs
+        // Validate sub-step stdin refs against loop-scoped results
         if (sub.stdin !== undefined && sub.stdin !== null) {
           try {
-            resolveInputValue(sub.stdin, resolvedArgs, results);
+            resolveInputValue(sub.stdin, resolvedArgs, loopScopedResults);
           } catch (err: any) {
             throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} stdin: ${err?.message ?? String(err)}`);
           }
@@ -792,6 +804,8 @@ function dryRunWorkflow({
           }
           lines.push(`       ${si + 1}. ${sub.id}  [pipeline] pipeline: ${pl}`);
         }
+        // Add sub-step placeholder so later sub-steps can reference it
+        loopScopedResults[sub.id] = { id: sub.id };
       }
       results[step.id] = { id: step.id };
       continue;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -161,6 +161,9 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (!step.id || typeof step.id !== 'string') {
       throw new Error('Workflow step requires an id');
     }
+    if (step.for_each !== undefined && typeof step.for_each !== 'string') {
+      throw new Error(`Workflow step ${step.id} for_each must be a string (step reference expression)`);
+    }
     const isForEach = typeof step.for_each === 'string';
     if (isForEach) {
       if (!Array.isArray(step.steps) || step.steps.length === 0) {
@@ -777,6 +780,13 @@ function dryRunWorkflow({
       loopScopedResults[dryIndexVar] = { id: dryIndexVar };
       for (let si = 0; si < step.steps.length; si++) {
         const sub = step.steps[si];
+        // Skip validation for conditional sub-steps (they may reference
+        // variables that only exist in certain runtime conditions)
+        if (!evaluateCondition(sub.when ?? sub.condition, loopScopedResults)) {
+          lines.push(`       ${si + 1}. ${sub.id}  [skipped — condition: false]`);
+          loopScopedResults[sub.id] = { id: sub.id, skipped: true };
+          continue;
+        }
         // Validate sub-step stdin refs against loop-scoped results
         if (sub.stdin !== undefined && sub.stdin !== null) {
           try {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -183,10 +183,18 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (forEachShell || forEachPipeline) {
         throw new Error(`Workflow step ${step.id} for_each cannot also define run, command, or pipeline`);
       }
+      const loopItemVar = step.item_var ?? 'item';
+      const loopIndexVar = step.index_var ?? 'index';
+      if (loopItemVar === loopIndexVar) {
+        throw new Error(`Workflow step ${step.id} item_var and index_var cannot be the same`);
+      }
       const subStepIds = new Set<string>();
       for (const sub of step.steps) {
         if (!sub || typeof sub !== 'object' || !sub.id || typeof sub.id !== 'string') {
           throw new Error(`Workflow step ${step.id} for_each sub-step requires an id`);
+        }
+        if (sub.id === loopItemVar || sub.id === loopIndexVar) {
+          throw new Error(`Workflow step ${step.id} for_each sub-step id '${sub.id}' conflicts with loop variable`);
         }
         if (subStepIds.has(sub.id)) {
           throw new Error(`Workflow step ${step.id} duplicate for_each sub-step id: ${sub.id}`);
@@ -734,6 +742,27 @@ function dryRunWorkflow({
       } catch (err: any) {
         throw new Error(`Workflow step ${step.id} stdin: ${err?.message ?? String(err)}`);
       }
+    }
+
+    if (typeof step.for_each === 'string' && Array.isArray(step.steps)) {
+      lines.push(`  ${num}. ${step.id}  [for_each]`);
+      lines.push(`     for_each: ${step.for_each}`);
+      lines.push(`     item_var: ${step.item_var ?? 'item'}, index_var: ${step.index_var ?? 'index'}`);
+      if (step.batch_size) lines.push(`     batch_size: ${step.batch_size}`);
+      lines.push(`     sub-steps: ${step.steps.length}`);
+      for (let si = 0; si < step.steps.length; si++) {
+        const sub = step.steps[si];
+        const subExec = getStepExecution(sub as WorkflowStep);
+        if (subExec.kind === 'shell') {
+          const cmd = resolveDryRunTemplate(subExec.value, resolvedArgs, results);
+          lines.push(`       ${si + 1}. ${sub.id}  [shell] run: ${cmd}`);
+        } else if (subExec.kind === 'pipeline') {
+          const pl = resolveDryRunTemplate(subExec.value, resolvedArgs, results);
+          lines.push(`       ${si + 1}. ${sub.id}  [pipeline] pipeline: ${pl}`);
+        }
+      }
+      results[step.id] = { id: step.id };
+      continue;
     }
 
     const execution = getStepExecution(step);

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -183,10 +183,15 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (forEachShell || forEachPipeline) {
         throw new Error(`Workflow step ${step.id} for_each cannot also define run, command, or pipeline`);
       }
+      const subStepIds = new Set<string>();
       for (const sub of step.steps) {
         if (!sub || typeof sub !== 'object' || !sub.id || typeof sub.id !== 'string') {
           throw new Error(`Workflow step ${step.id} for_each sub-step requires an id`);
         }
+        if (subStepIds.has(sub.id)) {
+          throw new Error(`Workflow step ${step.id} duplicate for_each sub-step id: ${sub.id}`);
+        }
+        subStepIds.add(sub.id);
         if (isApprovalStep(sub.approval) || isInputStep(sub.input)) {
           throw new Error(`Workflow step ${step.id} for_each sub-steps cannot contain approval or input steps`);
         }
@@ -199,8 +204,8 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
         if (sub.pipeline !== undefined && typeof sub.pipeline !== 'string') {
           throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} pipeline must be a string`);
         }
-        const subShell = typeof sub.run === 'string' ? sub.run : (typeof sub.command === 'string' ? sub.command : undefined);
-        const subPipeline = typeof sub.pipeline === 'string' ? sub.pipeline : undefined;
+        const subShell = typeof sub.run === 'string' && sub.run.trim() ? sub.run : (typeof sub.command === 'string' && sub.command.trim() ? sub.command : undefined);
+        const subPipeline = typeof sub.pipeline === 'string' && sub.pipeline.trim() ? sub.pipeline : undefined;
         if (!subShell && !subPipeline) {
           throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} requires run, command, or pipeline`);
         }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -166,7 +166,7 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (!Array.isArray(step.steps) || step.steps.length === 0) {
         throw new Error(`Workflow step ${step.id} for_each requires a non-empty steps array`);
       }
-      if (step.batch_size !== undefined && (typeof step.batch_size !== 'number' || step.batch_size < 1)) {
+      if (step.batch_size !== undefined && (typeof step.batch_size !== 'number' || !Number.isInteger(step.batch_size) || step.batch_size < 1)) {
         throw new Error(`Workflow step ${step.id} batch_size must be a positive integer`);
       }
       if (step.pause_ms !== undefined && (typeof step.pause_ms !== 'number' || step.pause_ms < 0)) {
@@ -190,7 +190,16 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
         if (isApprovalStep(sub.approval) || isInputStep(sub.input)) {
           throw new Error(`Workflow step ${step.id} for_each sub-steps cannot contain approval or input steps`);
         }
-        const subShell = typeof sub.run === 'string' ? sub.run : sub.command;
+        if (sub.run !== undefined && typeof sub.run !== 'string') {
+          throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} run must be a string`);
+        }
+        if (sub.command !== undefined && typeof sub.command !== 'string') {
+          throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} command must be a string`);
+        }
+        if (sub.pipeline !== undefined && typeof sub.pipeline !== 'string') {
+          throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} pipeline must be a string`);
+        }
+        const subShell = typeof sub.run === 'string' ? sub.run : (typeof sub.command === 'string' ? sub.command : undefined);
         const subPipeline = typeof sub.pipeline === 'string' ? sub.pipeline : undefined;
         if (!subShell && !subPipeline) {
           throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} requires run, command, or pipeline`);

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -762,24 +762,33 @@ function dryRunWorkflow({
       lines.push(`     sub-steps: ${step.steps.length}`);
       for (let si = 0; si < step.steps.length; si++) {
         const sub = step.steps[si];
+        // Validate sub-step stdin refs
+        if (sub.stdin !== undefined && sub.stdin !== null) {
+          try {
+            resolveInputValue(sub.stdin, resolvedArgs, results);
+          } catch (err: any) {
+            throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} stdin: ${err?.message ?? String(err)}`);
+          }
+        }
         const subExec = getStepExecution(sub as WorkflowStep);
         if (subExec.kind === 'shell') {
           const cmd = resolveDryRunTemplate(subExec.value, resolvedArgs, results);
           lines.push(`       ${si + 1}. ${sub.id}  [shell] run: ${cmd}`);
         } else if (subExec.kind === 'pipeline') {
+          if (!ctx.registry) {
+            throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} requires a command registry for pipeline execution`);
+          }
           const pl = resolveDryRunTemplate(subExec.value, resolvedArgs, results);
-          if (ctx.registry) {
-            try {
-              const stages = parsePipeline(pl);
-              for (const stage of stages) {
-                if (hasDeferredDryRunStageName(stage.name)) continue;
-                if (!ctx.registry.get(stage.name)) {
-                  throw new Error(`unknown command: ${stage.name}`);
-                }
+          try {
+            const stages = parsePipeline(pl);
+            for (const stage of stages) {
+              if (hasDeferredDryRunStageName(stage.name)) continue;
+              if (!ctx.registry.get(stage.name)) {
+                throw new Error(`unknown command: ${stage.name}`);
               }
-            } catch (err: any) {
-              throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} pipeline: ${err?.message ?? String(err)}`);
             }
+          } catch (err: any) {
+            throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} pipeline: ${err?.message ?? String(err)}`);
           }
           lines.push(`       ${si + 1}. ${sub.id}  [pipeline] pipeline: ${pl}`);
         }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -172,9 +172,20 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (step.pause_ms !== undefined && (typeof step.pause_ms !== 'number' || step.pause_ms < 0)) {
         throw new Error(`Workflow step ${step.id} pause_ms must be a non-negative number`);
       }
+      if (isApprovalStep(step.approval)) {
+        throw new Error(`Workflow step ${step.id} for_each steps cannot define approval (use a separate step after the loop)`);
+      }
       for (const sub of step.steps) {
+        if (!sub || typeof sub !== 'object' || !sub.id || typeof sub.id !== 'string') {
+          throw new Error(`Workflow step ${step.id} for_each sub-step requires an id`);
+        }
         if (isApprovalStep(sub.approval) || isInputStep(sub.input)) {
           throw new Error(`Workflow step ${step.id} for_each sub-steps cannot contain approval or input steps`);
+        }
+        const subShell = typeof sub.run === 'string' ? sub.run : sub.command;
+        const subPipeline = typeof sub.pipeline === 'string' ? sub.pipeline : undefined;
+        if (!subShell && !subPipeline) {
+          throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} requires run, command, or pipeline`);
         }
       }
     }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -178,6 +178,9 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (isInputStep(step.input)) {
         throw new Error(`Workflow step ${step.id} for_each steps cannot define input (use a separate step after the loop)`);
       }
+      if (step.stdin !== undefined && step.stdin !== null) {
+        throw new Error(`Workflow step ${step.id} for_each steps cannot define stdin (loop input comes from the for_each expression)`);
+      }
       const forEachShell = typeof step.run === 'string' ? step.run : step.command;
       const forEachPipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
       if (forEachShell || forEachPipeline) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -169,8 +169,8 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (step.batch_size !== undefined && (typeof step.batch_size !== 'number' || !Number.isInteger(step.batch_size) || step.batch_size < 1)) {
         throw new Error(`Workflow step ${step.id} batch_size must be a positive integer`);
       }
-      if (step.pause_ms !== undefined && (typeof step.pause_ms !== 'number' || step.pause_ms < 0)) {
-        throw new Error(`Workflow step ${step.id} pause_ms must be a non-negative number`);
+      if (step.pause_ms !== undefined && (typeof step.pause_ms !== 'number' || !Number.isFinite(step.pause_ms) || step.pause_ms < 0)) {
+        throw new Error(`Workflow step ${step.id} pause_ms must be a finite non-negative number`);
       }
       if (isApprovalStep(step.approval)) {
         throw new Error(`Workflow step ${step.id} for_each steps cannot define approval (use a separate step after the loop)`);
@@ -492,8 +492,9 @@ export async function runWorkflowFile({
             scopedResults[subStep.id] = { id: subStep.id, skipped: true };
             continue;
           }
-          const subEnv = mergeEnv(ctx.env, workflow.env, subStep.env, resolvedArgs, scopedResults);
-          const subCwd = resolveCwd(subStep.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
+          const loopEnv = mergeEnv(ctx.env, workflow.env, step.env, resolvedArgs, scopedResults);
+          const subEnv = subStep.env ? mergeEnv(loopEnv, undefined, subStep.env, resolvedArgs, scopedResults) : loopEnv;
+          const subCwd = resolveCwd(subStep.cwd ?? step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
           const subExecution = getStepExecution(subStep);
 
           let subResult: WorkflowStepResult;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -35,6 +35,12 @@ export type WorkflowStep = {
   input?: WorkflowInputRequest;
   condition?: unknown;
   when?: unknown;
+  for_each?: string;
+  item_var?: string;
+  index_var?: string;
+  batch_size?: number;
+  pause_ms?: number;
+  steps?: WorkflowStep[];
 };
 
 export type WorkflowApproval =
@@ -155,11 +161,28 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (!step.id || typeof step.id !== 'string') {
       throw new Error('Workflow step requires an id');
     }
+    const isForEach = typeof step.for_each === 'string';
+    if (isForEach) {
+      if (!Array.isArray(step.steps) || step.steps.length === 0) {
+        throw new Error(`Workflow step ${step.id} for_each requires a non-empty steps array`);
+      }
+      if (step.batch_size !== undefined && (typeof step.batch_size !== 'number' || step.batch_size < 1)) {
+        throw new Error(`Workflow step ${step.id} batch_size must be a positive integer`);
+      }
+      if (step.pause_ms !== undefined && (typeof step.pause_ms !== 'number' || step.pause_ms < 0)) {
+        throw new Error(`Workflow step ${step.id} pause_ms must be a non-negative number`);
+      }
+      for (const sub of step.steps) {
+        if (isApprovalStep(sub.approval) || isInputStep(sub.input)) {
+          throw new Error(`Workflow step ${step.id} for_each sub-steps cannot contain approval or input steps`);
+        }
+      }
+    }
     const shellCommand = typeof step.run === 'string' ? step.run : step.command;
     const pipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
     const executionCount = Number(Boolean(shellCommand)) + Number(Boolean(pipeline));
-    if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input)) {
-      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, approval, or input`);
+    if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input) && !isForEach) {
+      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, approval, input, or for_each`);
     }
     if (executionCount > 1) {
       throw new Error(`Workflow step ${step.id} can only define one of run, command, or pipeline`);
@@ -399,6 +422,91 @@ export async function runWorkflowFile({
         id: step.id,
         subject,
         response: parsed,
+      };
+      lastStepId = step.id;
+      continue;
+    }
+
+    if (typeof step.for_each === 'string' && Array.isArray(step.steps)) {
+      const itemsRef = resolveInputValue(step.for_each, resolvedArgs, results);
+      if (!Array.isArray(itemsRef)) {
+        throw new Error(`Workflow step ${step.id} for_each: expected array, got ${typeof itemsRef}`);
+      }
+      const itemVar = step.item_var ?? 'item';
+      const indexVar = step.index_var ?? 'index';
+      const batchSize = step.batch_size ?? 1;
+      const iterationResults: unknown[] = [];
+
+      for (let itemIdx = 0; itemIdx < itemsRef.length; itemIdx++) {
+        if (step.pause_ms && itemIdx > 0 && itemIdx % batchSize === 0) {
+          await new Promise((r) => setTimeout(r, step.pause_ms));
+        }
+        const item = itemsRef[itemIdx];
+        const scopedResults: Record<string, WorkflowStepResult> = { ...results };
+        scopedResults[itemVar] = {
+          id: itemVar,
+          json: item,
+          stdout: typeof item === 'string' ? item : JSON.stringify(item),
+        };
+        scopedResults[indexVar] = {
+          id: indexVar,
+          json: itemIdx,
+          stdout: String(itemIdx),
+        };
+
+        let lastSubResult: WorkflowStepResult | undefined;
+        for (const subStep of step.steps!) {
+          if (!evaluateCondition(subStep.when ?? subStep.condition, scopedResults)) {
+            scopedResults[subStep.id] = { id: subStep.id, skipped: true };
+            continue;
+          }
+          const subEnv = mergeEnv(ctx.env, workflow.env, subStep.env, resolvedArgs, scopedResults);
+          const subCwd = resolveCwd(subStep.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
+          const subExecution = getStepExecution(subStep);
+
+          let subResult: WorkflowStepResult;
+          if (subExecution.kind === 'shell') {
+            const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
+            const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
+            const { stdout } = await runShellCommand({ command, stdin: stdinValue, env: subEnv, cwd: subCwd, signal: ctx.signal });
+            subResult = { id: subStep.id, stdout, json: parseJson(stdout) };
+          } else if (subExecution.kind === 'pipeline') {
+            if (!ctx.registry) {
+              throw new Error(`Workflow step ${subStep.id} requires a command registry for pipeline execution`);
+            }
+            const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
+            const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
+            subResult = await runPipelineStep({
+              stepId: subStep.id,
+              pipelineText,
+              inputValue,
+              ctx,
+              env: subEnv,
+              cwd: subCwd,
+            });
+          } else {
+            const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
+            subResult = createSyntheticStepResult(subStep.id, inputValue);
+          }
+          scopedResults[subStep.id] = subResult;
+          lastSubResult = subResult;
+        }
+
+        // Collect iteration result: merge all sub-step results for this item
+        const iterResult: Record<string, unknown> = { [itemVar]: item, [indexVar]: itemIdx };
+        for (const subStep of step.steps!) {
+          const sr = scopedResults[subStep.id];
+          if (sr && !sr.skipped) {
+            iterResult[subStep.id] = sr.json !== undefined ? sr.json : sr.stdout;
+          }
+        }
+        iterationResults.push(iterResult);
+      }
+
+      results[step.id] = {
+        id: step.id,
+        json: iterationResults,
+        stdout: JSON.stringify(iterationResults),
       };
       lastStepId = step.id;
       continue;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -490,7 +490,7 @@ export async function runWorkflowFile({
 
       for (let itemIdx = 0; itemIdx < itemsRef.length; itemIdx++) {
         if (step.pause_ms && itemIdx > 0 && itemIdx % batchSize === 0) {
-          await new Promise((r) => setTimeout(r, step.pause_ms));
+          await abortableSleep(step.pause_ms, ctx.signal);
         }
         const item = itemsRef[itemIdx];
         const scopedResults: Record<string, WorkflowStepResult> = { ...results };
@@ -1683,6 +1683,26 @@ function createSyntheticStepResult(stepId: string, value: unknown): WorkflowStep
     stdout: serializeValueForStdout(value),
     json: value,
   };
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((r) => setTimeout(r, ms));
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+    };
+    timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function encodeShellInput(value: unknown) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -175,6 +175,14 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       if (isApprovalStep(step.approval)) {
         throw new Error(`Workflow step ${step.id} for_each steps cannot define approval (use a separate step after the loop)`);
       }
+      if (isInputStep(step.input)) {
+        throw new Error(`Workflow step ${step.id} for_each steps cannot define input (use a separate step after the loop)`);
+      }
+      const forEachShell = typeof step.run === 'string' ? step.run : step.command;
+      const forEachPipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
+      if (forEachShell || forEachPipeline) {
+        throw new Error(`Workflow step ${step.id} for_each cannot also define run, command, or pipeline`);
+      }
       for (const sub of step.steps) {
         if (!sub || typeof sub !== 'object' || !sub.id || typeof sub.id !== 'string') {
           throw new Error(`Workflow step ${step.id} for_each sub-step requires an id`);
@@ -186,6 +194,10 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
         const subPipeline = typeof sub.pipeline === 'string' ? sub.pipeline : undefined;
         if (!subShell && !subPipeline) {
           throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} requires run, command, or pipeline`);
+        }
+        const subExecCount = Number(Boolean(subShell)) + Number(Boolean(subPipeline));
+        if (subExecCount > 1) {
+          throw new Error(`Workflow step ${step.id} for_each sub-step ${sub.id} can only define one of run, command, or pipeline`);
         }
       }
     }

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -291,3 +291,48 @@ test('for_each validation rejects Infinity batch_size', async () => {
   await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
   await assert.rejects(loadWorkflowFile(filePath), /batch_size must be a positive integer/);
 });
+
+test('for_each validation rejects NaN pause_ms', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      pause_ms: NaN,
+      steps: [{ id: 'x', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /pause_ms must be a finite non-negative number/);
+});
+
+test('for_each propagates step-level env to sub-steps', async () => {
+  const workflow = {
+    name: 'env-test',
+    steps: [
+      {
+        id: 'data',
+        command: 'node -e "process.stdout.write(JSON.stringify([1,2]))"',
+      },
+      {
+        id: 'loop',
+        for_each: '$data.json',
+        env: { MY_FLAG: 'from_loop' },
+        steps: [
+          {
+            id: 'check',
+            command: 'node -e "process.stdout.write(JSON.stringify({flag: process.env.MY_FLAG}))"',
+          },
+        ],
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output.length, 2);
+  assert.equal(output[0].check.flag, 'from_loop');
+  assert.equal(output[1].check.flag, 'from_loop');
+});

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -197,3 +197,50 @@ test('for_each validation rejects sub-steps without execution', async () => {
   await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
   await assert.rejects(loadWorkflowFile(filePath), /requires run, command, or pipeline/);
 });
+
+test('for_each validation rejects input on the for_each step', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      input: { prompt: 'test?', responseSchema: { type: 'object' } },
+      steps: [{ id: 'x', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /for_each steps cannot define input/);
+});
+
+test('for_each validation rejects run/command/pipeline alongside for_each', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      run: 'echo ignored',
+      steps: [{ id: 'x', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /for_each cannot also define run, command, or pipeline/);
+});
+
+test('for_each validation rejects sub-steps with multiple executors', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      steps: [{ id: 'multi', run: 'echo a', pipeline: 'json' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /can only define one of run, command, or pipeline/);
+});

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -434,6 +434,22 @@ test('for_each dry-run shows loop structure', async () => {
   assert.ok(output.includes('process'), 'should list sub-steps');
 });
 
+test('for_each validation rejects stdin on the for_each step', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      stdin: '$other.stdout',
+      steps: [{ id: 'a', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /for_each steps cannot define stdin/);
+});
+
 test('for_each validation rejects whitespace-only run', async () => {
   const workflow = {
     name: 'bad',

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { createDefaultRegistry } from '../src/commands/registry.js';
+import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
+
+async function runWorkflow(workflow: any, args?: Record<string, unknown>) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+  const result = await runWorkflowFile({
+    filePath,
+    args,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env,
+      mode: 'tool',
+      registry: createDefaultRegistry(),
+    },
+  });
+  return result;
+}
+
+test('for_each iterates over items and collects results', async () => {
+  const workflow = {
+    name: 'test-foreach',
+    steps: [
+      {
+        id: 'data',
+        command: 'node -e "process.stdout.write(JSON.stringify([{name:\\"a\\"},{name:\\"b\\"}]))"',
+      },
+      {
+        id: 'process',
+        for_each: '$data.json',
+        steps: [
+          {
+            id: 'transform',
+            command: 'node -e "process.stdout.write(JSON.stringify({upper: process.env.LOBSTER_ARG_ITEM_NAME}))"',
+            env: { LOBSTER_ARG_ITEM_NAME: '$item.json.name' },
+          },
+        ],
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.ok(Array.isArray(result.output));
+  // Output is the for_each collected results array
+  const output = result.output as any[];
+  assert.equal(output.length, 2);
+  assert.equal(output[0].index, 0);
+  assert.equal(output[1].index, 1);
+});
+
+test('for_each with shell command per item', async () => {
+  const workflow = {
+    name: 'test-foreach-shell',
+    steps: [
+      {
+        id: 'items',
+        command: 'node -e "process.stdout.write(JSON.stringify([1,2,3]))"',
+      },
+      {
+        id: 'doubled',
+        for_each: '$items.json',
+        item_var: 'num',
+        steps: [
+          {
+            id: 'double',
+            command: 'node -e "const n=$num.json;process.stdout.write(JSON.stringify({result:n*2}))"',
+          },
+        ],
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output.length, 3);
+  assert.equal(output[0].double.result, 2);
+  assert.equal(output[1].double.result, 4);
+  assert.equal(output[2].double.result, 6);
+});
+
+test('for_each validation rejects empty steps', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'loop', for_each: '$x.json', steps: [] }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /for_each requires a non-empty steps/);
+});
+
+test('for_each validation rejects approval in sub-steps', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [
+      {
+        id: 'loop',
+        for_each: '$x.json',
+        steps: [{ id: 'bad_step', approval: true, command: 'echo hi' }],
+      },
+    ],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /cannot contain approval or input/);
+});
+
+test('for_each with custom item_var and index_var', async () => {
+  const workflow = {
+    name: 'custom-vars',
+    steps: [
+      {
+        id: 'data',
+        command: 'node -e "process.stdout.write(JSON.stringify([\\"x\\",\\"y\\"]))"',
+      },
+      {
+        id: 'loop',
+        for_each: '$data.json',
+        item_var: 'letter',
+        index_var: 'idx',
+        steps: [
+          {
+            id: 'echo',
+            command: 'node -e "process.stdout.write(JSON.stringify({letter:process.env.LOBSTER_ARG_LETTER, idx:process.env.LOBSTER_ARG_IDX}))"',
+            env: { LOBSTER_ARG_LETTER: '$letter.json', LOBSTER_ARG_IDX: '$idx.json' },
+          },
+        ],
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output.length, 2);
+  assert.equal(output[0].letter, 'x');
+  assert.equal(output[1].letter, 'y');
+});
+
+test('for_each throws on non-array input', async () => {
+  const workflow = {
+    name: 'bad-input',
+    steps: [
+      {
+        id: 'data',
+        command: 'node -e "process.stdout.write(JSON.stringify({not:\\"array\\"}))"',
+      },
+      {
+        id: 'loop',
+        for_each: '$data.json',
+        steps: [{ id: 'x', command: 'echo hi' }],
+      },
+    ],
+  };
+  await assert.rejects(runWorkflow(workflow), /expected array/);
+});

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -355,6 +355,85 @@ test('for_each validation rejects duplicate sub-step ids', async () => {
   await assert.rejects(loadWorkflowFile(filePath), /duplicate for_each sub-step id: dup/);
 });
 
+test('for_each validation rejects sub-step id shadowing item_var', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      steps: [{ id: 'item', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /conflicts with loop variable/);
+});
+
+test('for_each validation rejects item_var equal to index_var', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      item_var: 'x',
+      index_var: 'x',
+      steps: [{ id: 'a', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /item_var and index_var cannot be the same/);
+});
+
+test('for_each dry-run shows loop structure', async () => {
+  const workflow = {
+    name: 'dry-run-foreach',
+    steps: [
+      { id: 'data', command: 'echo "[1,2]"' },
+      {
+        id: 'loop',
+        for_each: '$data.json',
+        batch_size: 2,
+        steps: [
+          { id: 'process', command: 'echo hi' },
+          { id: 'analyze', pipeline: 'json' },
+        ],
+      },
+    ],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const { PassThrough } = await import('node:stream');
+  const { createDefaultRegistry } = await import('../src/commands/registry.js');
+  const chunks: string[] = [];
+  const stderr = new PassThrough();
+  stderr.on('data', (d: Buffer) => chunks.push(d.toString()));
+
+  await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+      registry: createDefaultRegistry(),
+      dryRun: true,
+    },
+  });
+
+  const output = chunks.join('');
+  assert.ok(output.includes('[for_each]'), 'should show [for_each] tag');
+  assert.ok(output.includes('sub-steps: 2'), 'should show sub-step count');
+  assert.ok(output.includes('batch_size: 2'), 'should show batch_size');
+  assert.ok(output.includes('process'), 'should list sub-steps');
+});
+
 test('for_each validation rejects whitespace-only run', async () => {
   const workflow = {
     name: 'bad',

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -244,3 +244,50 @@ test('for_each validation rejects sub-steps with multiple executors', async () =
   await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
   await assert.rejects(loadWorkflowFile(filePath), /can only define one of run, command, or pipeline/);
 });
+
+test('for_each validation rejects non-string command in sub-steps', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      steps: [{ id: 'bad_type', command: 123 }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /command must be a string/);
+});
+
+test('for_each validation rejects non-integer batch_size', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      batch_size: 1.5,
+      steps: [{ id: 'x', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /batch_size must be a positive integer/);
+});
+
+test('for_each validation rejects Infinity batch_size', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      batch_size: Infinity,
+      steps: [{ id: 'x', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /batch_size must be a positive integer/);
+});

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -336,3 +336,36 @@ test('for_each propagates step-level env to sub-steps', async () => {
   assert.equal(output[0].check.flag, 'from_loop');
   assert.equal(output[1].check.flag, 'from_loop');
 });
+
+test('for_each validation rejects duplicate sub-step ids', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      steps: [
+        { id: 'dup', command: 'echo a' },
+        { id: 'dup', command: 'echo b' },
+      ],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /duplicate for_each sub-step id: dup/);
+});
+
+test('for_each validation rejects whitespace-only run', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      steps: [{ id: 'blank', run: '   ' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /requires run, command, or pipeline/);
+});

--- a/test/for_each.test.ts
+++ b/test/for_each.test.ts
@@ -166,3 +166,34 @@ test('for_each throws on non-array input', async () => {
   };
   await assert.rejects(runWorkflow(workflow), /expected array/);
 });
+
+test('for_each validation rejects approval on the for_each step itself', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      approval: true,
+      steps: [{ id: 'x', command: 'echo hi' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /for_each steps cannot define approval/);
+});
+
+test('for_each validation rejects sub-steps without execution', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'loop',
+      for_each: '$x.json',
+      steps: [{ id: 'empty_sub' }],
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-foreach-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /requires run, command, or pipeline/);
+});


### PR DESCRIPTION
## Summary
- Adds `for_each` workflow step that iterates over a collection and runs sub-steps per item
- Supports `item_var`/`index_var` for custom variable names (defaults: `item`/`index`)
- Optional `batch_size` and `pause_ms` for rate limiting
- Collects all iteration results into an array accessible by subsequent steps
- Validation rejects approval/input steps inside for_each loops

## Example
```yaml
steps:
  - id: prs
    run: gh pr list --json number,title
  - id: reviews
    for_each: $prs.json
    item_var: pr
    batch_size: 3
    pause_ms: 1000
    steps:
      - id: review
        pipeline: llm.invoke --prompt "Review PR: ${pr.json.title}"
```

## Changes
- Updated `src/workflows/file.ts` — extended `WorkflowStep` type, added for_each execution logic and validation
- New `test/for_each.test.ts` — 6 tests covering iteration, custom vars, validation, and error cases

## Test plan
- [x] All 6 new tests pass
- [x] Build succeeds with no type errors