### PR TITLE
feat: parallel step execution with wait strategies

### DIFF
--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -23,6 +23,22 @@ export type WorkflowFile = {
   steps: WorkflowStep[];
 };
 
+export type ParallelBranch = {
+  id: string;
+  run?: string;
+  command?: string;
+  pipeline?: string;
+  env?: Record<string, string>;
+  cwd?: string;
+  stdin?: unknown;
+};
+
+export type ParallelConfig = {
+  wait?: 'all' | 'any';
+  timeout_ms?: number;
+  branches: ParallelBranch[];
+};
+
 export type WorkflowStep = {
   id: string;
   command?: string;
@@ -35,6 +51,7 @@ export type WorkflowStep = {
   input?: WorkflowInputRequest;
   condition?: unknown;
   when?: unknown;
+  parallel?: ParallelConfig;
 };
 
 export type WorkflowApproval =
@@ -155,11 +172,39 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (!step.id || typeof step.id !== 'string') {
       throw new Error('Workflow step requires an id');
     }
+    const isParallel = step.parallel && typeof step.parallel === 'object';
+    if (isParallel) {
+      const pc = step.parallel!;
+      if (!Array.isArray(pc.branches) || pc.branches.length === 0) {
+        throw new Error(`Workflow step ${step.id} parallel requires a non-empty branches array`);
+      }
+      if (pc.wait !== undefined && pc.wait !== 'all' && pc.wait !== 'any') {
+        throw new Error(`Workflow step ${step.id} parallel wait must be "all" or "any"`);
+      }
+      if (pc.timeout_ms !== undefined && (typeof pc.timeout_ms !== 'number' || pc.timeout_ms < 1)) {
+        throw new Error(`Workflow step ${step.id} parallel timeout_ms must be a positive number`);
+      }
+      const branchIds = new Set<string>();
+      for (const branch of pc.branches) {
+        if (!branch.id || typeof branch.id !== 'string') {
+          throw new Error(`Workflow step ${step.id} parallel branch requires an id`);
+        }
+        if (branchIds.has(branch.id)) {
+          throw new Error(`Workflow step ${step.id} duplicate parallel branch id: ${branch.id}`);
+        }
+        branchIds.add(branch.id);
+        const bShell = typeof branch.run === 'string' ? branch.run : branch.command;
+        const bPipeline = typeof branch.pipeline === 'string' ? branch.pipeline : undefined;
+        if (!bShell && !bPipeline) {
+          throw new Error(`Workflow step ${step.id} parallel branch ${branch.id} requires run, command, or pipeline`);
+        }
+      }
+    }
     const shellCommand = typeof step.run === 'string' ? step.run : step.command;
     const pipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
     const executionCount = Number(Boolean(shellCommand)) + Number(Boolean(pipeline));
-    if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input)) {
-      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, approval, or input`);
+    if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input) && !isParallel) {
+      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, approval, input, or parallel`);
     }
     if (executionCount > 1) {
       throw new Error(`Workflow step ${step.id} can only define one of run, command, or pipeline`);
@@ -400,6 +445,88 @@ export async function runWorkflowFile({
         subject,
         response: parsed,
       };
+      lastStepId = step.id;
+      continue;
+    }
+
+    if (step.parallel && typeof step.parallel === 'object') {
+      const pc = step.parallel;
+      const branches = pc.branches;
+      const wait = pc.wait ?? 'all';
+
+      const runBranch = async (branch: ParallelBranch): Promise<WorkflowStepResult> => {
+        const branchEnv = mergeEnv(ctx.env, workflow.env, branch.env, resolvedArgs, results);
+        const branchCwd = resolveCwd(branch.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
+        const branchExec = getStepExecution(branch as WorkflowStep);
+
+        if (branchExec.kind === 'shell') {
+          const command = resolveTemplate(branchExec.value, resolvedArgs, results);
+          const stdinValue = resolveShellStdin(branch.stdin, resolvedArgs, results);
+          const { stdout } = await runShellCommand({ command, stdin: stdinValue, env: branchEnv, cwd: branchCwd, signal: ctx.signal });
+          return { id: branch.id, stdout, json: parseJson(stdout) };
+        } else if (branchExec.kind === 'pipeline') {
+          if (!ctx.registry) {
+            throw new Error(`Parallel branch ${branch.id} requires a command registry for pipeline execution`);
+          }
+          const pipelineText = resolveTemplate(branchExec.value, resolvedArgs, results);
+          const inputValue = resolveInputValue(branch.stdin, resolvedArgs, results);
+          return await runPipelineStep({
+            stepId: branch.id,
+            pipelineText,
+            inputValue,
+            ctx,
+            env: branchEnv,
+            cwd: branchCwd,
+          });
+        }
+        return { id: branch.id };
+      };
+
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = pc.timeout_ms
+        ? new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new Error(`Parallel step ${step.id} timed out after ${pc.timeout_ms}ms`)), pc.timeout_ms);
+        })
+        : null;
+
+      try {
+        if (wait === 'any') {
+          const promises = branches.map((b) => runBranch(b).then((r) => ({ branch: b, result: r })));
+          const allPromises = timeoutPromise ? [...promises, timeoutPromise] : promises;
+          const winner = await Promise.race(allPromises) as { branch: ParallelBranch; result: WorkflowStepResult };
+          results[winner.branch.id] = winner.result;
+          results[step.id] = {
+            id: step.id,
+            json: { [winner.branch.id]: winner.result.json },
+            stdout: winner.result.stdout ?? '',
+          };
+        } else {
+          // wait === 'all'
+          const promises = branches.map((b) => runBranch(b).then((r) => ({ branch: b, result: r })));
+          const allSettled = timeoutPromise
+            ? await Promise.race([Promise.allSettled(promises), timeoutPromise])
+            : await Promise.allSettled(promises);
+          const settled = allSettled as PromiseSettledResult<{ branch: ParallelBranch; result: WorkflowStepResult }>[];
+
+          const merged: Record<string, unknown> = {};
+          for (const s of settled) {
+            if (s.status === 'fulfilled') {
+              results[s.value.branch.id] = s.value.result;
+              merged[s.value.branch.id] = s.value.result.json;
+            } else {
+              throw new Error(`Parallel branch failed: ${s.reason?.message ?? String(s.reason)}`);
+            }
+          }
+          results[step.id] = {
+            id: step.id,
+            json: merged,
+            stdout: JSON.stringify(merged),
+          };
+        }
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+      }
+
       lastStepId = step.id;
       continue;
     }

--- a/test/parallel.test.ts
+++ b/test/parallel.test.ts
@@ -1,0 +1,165 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { createDefaultRegistry } from '../src/commands/registry.js';
+import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
+
+async function runWorkflow(workflow: any) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-parallel-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+  return runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env,
+      mode: 'tool',
+      registry: createDefaultRegistry(),
+    },
+  });
+}
+
+test('parallel wait=all runs all branches and merges results', async () => {
+  const workflow = {
+    name: 'test-parallel',
+    steps: [
+      {
+        id: 'fetch',
+        parallel: {
+          wait: 'all',
+          branches: [
+            { id: 'a', command: 'node -e "process.stdout.write(JSON.stringify({src:\\"a\\"}))"' },
+            { id: 'b', command: 'node -e "process.stdout.write(JSON.stringify({src:\\"b\\"}))"' },
+            { id: 'c', command: 'node -e "process.stdout.write(JSON.stringify({src:\\"c\\"}))"' },
+          ],
+        },
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output.length, 1);
+  assert.equal(output[0].a.src, 'a');
+  assert.equal(output[0].b.src, 'b');
+  assert.equal(output[0].c.src, 'c');
+});
+
+test('parallel wait=any returns first completed branch', async () => {
+  const workflow = {
+    name: 'test-parallel-any',
+    steps: [
+      {
+        id: 'race',
+        parallel: {
+          wait: 'any',
+          branches: [
+            // fast branch returns immediately
+            { id: 'fast', command: 'node -e "process.stdout.write(JSON.stringify({winner:true}))"' },
+            // slow branch sleeps 5s (should not be waited for)
+            { id: 'slow', command: 'node -e "setTimeout(()=>process.stdout.write(JSON.stringify({winner:false})),5000)"' },
+          ],
+        },
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+});
+
+test('parallel branch results are accessible in subsequent steps', async () => {
+  const workflow = {
+    name: 'test-parallel-refs',
+    steps: [
+      {
+        id: 'fetch',
+        parallel: {
+          wait: 'all',
+          branches: [
+            { id: 'x', command: 'node -e "process.stdout.write(JSON.stringify({val:10}))"' },
+            { id: 'y', command: 'node -e "process.stdout.write(JSON.stringify({val:20}))"' },
+          ],
+        },
+      },
+      {
+        id: 'use_x',
+        command: 'node -e "process.stdout.write(JSON.stringify({x_val:$x.json.val}))"',
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].x_val, 10);
+});
+
+test('parallel validation rejects empty branches', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'p', parallel: { branches: [] } }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-par-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /non-empty branches/);
+});
+
+test('parallel validation rejects duplicate branch ids', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'p',
+      parallel: {
+        branches: [
+          { id: 'dup', command: 'echo a' },
+          { id: 'dup', command: 'echo b' },
+        ],
+      },
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-par-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /duplicate parallel branch id/);
+});
+
+test('parallel validation rejects branch without execution', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{
+      id: 'p',
+      parallel: {
+        branches: [{ id: 'empty' }],
+      },
+    }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-par-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /requires run, command, or pipeline/);
+});
+
+test('parallel wait=all propagates branch failure', async () => {
+  const workflow = {
+    name: 'fail-test',
+    steps: [{
+      id: 'p',
+      parallel: {
+        wait: 'all',
+        branches: [
+          { id: 'ok', command: 'echo ok' },
+          { id: 'fail', command: 'node -e "process.exit(1)"' },
+        ],
+      },
+    }],
+  };
+  await assert.rejects(runWorkflow(workflow), /Parallel branch failed/);
+});


### PR DESCRIPTION
## Summary
- Adds `parallel` workflow step type with named branches that run concurrently
- Wait strategies: `all` (default, wait for every branch) and `any` (first to complete wins)
- Optional `timeout_ms` per parallel block
- Branch results stored by ID — accessible as `$branch_id.json` in subsequent steps
- Validation enforces unique branch IDs and requires run/command/pipeline on each branch

## Example
```yaml
steps:
  - id: fetch
    parallel:
      wait: all
      timeout_ms: 30000
      branches:
        - id: github
          run: gh pr list --json number,title
        - id: jira
          run: curl -s https://jira.example.com/api/sprint
  - id: merge
    run: echo "Got $github.json and $jira.json"
```

## Changes
- Updated `src/workflows/file.ts` — added `ParallelBranch`/`ParallelConfig` types, parallel execution logic with `Promise.allSettled`/`Promise.race`, and validation
- New `test/parallel.test.ts` — 7 tests covering all/any strategies, result access, failure propagation, and validation

## Test plan
- [x] All 7 new tests pass
- [x] Existing workflow_file tests still pass (11/11)
- [x] Build succeeds with no type errors