### PR TITLE
feat: LLM cost tracking and limits

### DIFF
--- a/src/core/cost_tracker.ts
+++ b/src/core/cost_tracker.ts
@@ -1,0 +1,96 @@
+export type StepCost = {
+  stepId: string;
+  model: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+};
+
+export type CostSummary = {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedCostUsd: number;
+  byStep: StepCost[];
+};
+
+export type CostLimit = {
+  max_usd: number;
+  action?: 'warn' | 'stop';
+};
+
+// Per-million-token pricing (approximate, as of early 2026)
+const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
+  'gpt-4o': { input: 2.50, output: 10.00 },
+  'gpt-4o-mini': { input: 0.15, output: 0.60 },
+  'gpt-4-turbo': { input: 10.00, output: 30.00 },
+  'gpt-3.5-turbo': { input: 0.50, output: 1.50 },
+  'claude-opus-4-20250514': { input: 15.00, output: 75.00 },
+  'claude-sonnet-4-5-20250514': { input: 3.00, output: 15.00 },
+  'claude-haiku-3-5': { input: 0.80, output: 4.00 },
+  'gemini-1.5-pro': { input: 1.25, output: 5.00 },
+  'gemini-1.5-flash': { input: 0.075, output: 0.30 },
+};
+
+export class CostTracker {
+  private steps: StepCost[] = [];
+  private pricing: Record<string, { input: number; output: number }>;
+
+  constructor(customPricing?: Record<string, { input: number; output: number }>) {
+    this.pricing = { ...DEFAULT_PRICING, ...customPricing };
+  }
+
+  recordUsage(stepId: string, model: string | null, usage: Record<string, unknown>): void {
+    const inputTokens = Number(usage.inputTokens ?? usage.input_tokens ?? usage.prompt_tokens ?? 0);
+    const outputTokens = Number(usage.outputTokens ?? usage.output_tokens ?? usage.completion_tokens ?? 0);
+    const pricing = this.pricing[model ?? ''] ?? { input: 0, output: 0 };
+    const costUsd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
+    this.steps.push({ stepId, model, inputTokens, outputTokens, costUsd });
+  }
+
+  getSummary(): CostSummary {
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let estimatedCostUsd = 0;
+    for (const s of this.steps) {
+      totalInputTokens += s.inputTokens;
+      totalOutputTokens += s.outputTokens;
+      estimatedCostUsd += s.costUsd;
+    }
+    return {
+      totalInputTokens,
+      totalOutputTokens,
+      estimatedCostUsd: Math.round(estimatedCostUsd * 1_000_000) / 1_000_000,
+      byStep: [...this.steps],
+    };
+  }
+
+  checkLimit(limit: CostLimit, stderr?: NodeJS.WritableStream): void {
+    const summary = this.getSummary();
+    if (summary.estimatedCostUsd > limit.max_usd) {
+      if (limit.action === 'stop') {
+        throw new Error(
+          `Cost limit exceeded: $${summary.estimatedCostUsd.toFixed(4)} > $${limit.max_usd.toFixed(2)} limit`,
+        );
+      }
+      if (stderr) {
+        stderr.write(
+          `[WARN] Cost $${summary.estimatedCostUsd.toFixed(4)} exceeds limit $${limit.max_usd.toFixed(2)}\n`,
+        );
+      }
+    }
+  }
+
+  hasUsage(): boolean {
+    return this.steps.length > 0;
+  }
+
+  static parsePricingFromEnv(env: Record<string, string | undefined>): Record<string, { input: number; output: number }> | undefined {
+    const raw = env.LOBSTER_LLM_PRICING_JSON;
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -13,6 +13,8 @@ import { createApprovalIndex, deleteStateJson, readStateJson, writeStateJson } f
 import { readLineFromStream } from '../read_line.js';
 import { resolveInlineShellCommand } from '../shell.js';
 import { sharedAjv } from '../validation.js';
+import { CostTracker } from '../core/cost_tracker.js';
+import type { CostLimit, CostSummary } from '../core/cost_tracker.js';
 
 export type WorkflowFile = {
   name?: string;
@@ -21,6 +23,7 @@ export type WorkflowFile = {
   env?: Record<string, string>;
   cwd?: string;
   steps: WorkflowStep[];
+  cost_limit?: CostLimit;
 };
 
 export type WorkflowStep = {
@@ -81,6 +84,9 @@ export type WorkflowRunResult = {
     defaults?: unknown;
     subject?: unknown;
     resumeToken?: string;
+  };
+  _meta?: {
+    cost?: CostSummary;
   };
 };
 
@@ -323,6 +329,7 @@ export async function runWorkflowFile({
     return dryRunWorkflow({ steps, resolvedArgs, results, startIndex, ctx });
   }
 
+  const costTracker = new CostTracker(CostTracker.parsePricingFromEnv(ctx.env));
   let lastStepId: string | null = resumeState?.inputStepId ?? findLastCompletedStepId(steps, results);
 
   for (let idx = startIndex; idx < steps.length; idx++) {
@@ -436,6 +443,12 @@ export async function runWorkflowFile({
     results[step.id] = result;
     lastStepId = step.id;
 
+    // Track LLM cost from pipeline step results that contain usage data
+    trackStepCost(costTracker, step.id, result);
+    if (workflow.cost_limit) {
+      costTracker.checkLimit(workflow.cost_limit, ctx.stderr);
+    }
+
     if (isApprovalStep(step.approval)) {
       const approval = extractApprovalRequest(step, results[step.id]);
 
@@ -494,7 +507,11 @@ export async function runWorkflowFile({
   if (consumedResumeStateKey) {
     await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
   }
-  return { status: 'ok', output };
+  const runResult: WorkflowRunResult = { status: 'ok', output };
+  if (costTracker.hasUsage()) {
+    runResult._meta = { cost: costTracker.getSummary() };
+  }
+  return runResult;
 }
 
 // Returns a human-readable note if a step.stdin value references a prior step's
@@ -865,6 +882,19 @@ function extractApprovalRequest(step: WorkflowStep, result: WorkflowStepResult) 
     items,
     ...(preview ? { preview } : null),
   };
+}
+
+function trackStepCost(costTracker: CostTracker, stepId: string, result: WorkflowStepResult): void {
+  const json = result.json;
+  if (!json || typeof json !== 'object') return;
+  // Handle both single item and array of items (pipeline output)
+  const items = Array.isArray(json) ? json : [json];
+  for (const item of items) {
+    if (item && typeof item === 'object' && 'usage' in item && item.usage && typeof item.usage === 'object') {
+      const model = ('model' in item && typeof item.model === 'string') ? item.model : null;
+      costTracker.recordUsage(stepId, model, item.usage as Record<string, unknown>);
+    }
+  }
 }
 
 function parseJson(stdout: string) {

--- a/test/cost_tracker.test.ts
+++ b/test/cost_tracker.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CostTracker } from '../src/core/cost_tracker.js';
+import { createDefaultRegistry } from '../src/commands/registry.js';
+import { runWorkflowFile } from '../src/workflows/file.js';
+
+// --- CostTracker unit tests ---
+
+test('CostTracker records usage and calculates cost', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('step1', 'gpt-4o', { inputTokens: 1000, outputTokens: 500 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.totalInputTokens, 1000);
+  assert.equal(summary.totalOutputTokens, 500);
+  // gpt-4o: 1000 * 2.50/1M + 500 * 10.00/1M = 0.0025 + 0.005 = 0.0075
+  assert.equal(summary.estimatedCostUsd, 0.0075);
+  assert.equal(summary.byStep.length, 1);
+  assert.equal(summary.byStep[0].stepId, 'step1');
+});
+
+test('CostTracker accumulates across steps', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('a', 'gpt-4o', { inputTokens: 1000, outputTokens: 0 });
+  tracker.recordUsage('b', 'gpt-4o', { inputTokens: 1000, outputTokens: 0 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.totalInputTokens, 2000);
+  assert.equal(summary.byStep.length, 2);
+});
+
+test('CostTracker handles unknown model with zero cost', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('step1', 'unknown-model', { inputTokens: 1000, outputTokens: 500 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.estimatedCostUsd, 0);
+  assert.equal(summary.totalInputTokens, 1000);
+});
+
+test('CostTracker supports custom pricing', () => {
+  const tracker = new CostTracker({ 'my-model': { input: 5.0, output: 15.0 } });
+  tracker.recordUsage('step1', 'my-model', { inputTokens: 1_000_000, outputTokens: 1_000_000 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.estimatedCostUsd, 20.0);
+});
+
+test('CostTracker checkLimit throws on stop', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('step1', 'gpt-4o', { inputTokens: 10_000_000, outputTokens: 10_000_000 });
+  assert.throws(
+    () => tracker.checkLimit({ max_usd: 0.01, action: 'stop' }),
+    /Cost limit exceeded/,
+  );
+});
+
+test('CostTracker checkLimit does not throw on warn', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('step1', 'gpt-4o', { inputTokens: 10_000_000, outputTokens: 10_000_000 });
+  // Should not throw
+  tracker.checkLimit({ max_usd: 0.01, action: 'warn' });
+});
+
+test('CostTracker hasUsage returns false when empty', () => {
+  const tracker = new CostTracker();
+  assert.equal(tracker.hasUsage(), false);
+});
+
+test('CostTracker hasUsage returns true after recording', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('step1', null, { inputTokens: 100 });
+  assert.equal(tracker.hasUsage(), true);
+});
+
+test('CostTracker handles OpenAI-style field names', () => {
+  const tracker = new CostTracker();
+  tracker.recordUsage('step1', 'gpt-4o', { prompt_tokens: 1000, completion_tokens: 500 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.totalInputTokens, 1000);
+  assert.equal(summary.totalOutputTokens, 500);
+});
+
+test('CostTracker parsePricingFromEnv', () => {
+  const pricing = CostTracker.parsePricingFromEnv({
+    LOBSTER_LLM_PRICING_JSON: '{"custom":{"input":1,"output":2}}',
+  });
+  assert.deepEqual(pricing, { custom: { input: 1, output: 2 } });
+});
+
+test('CostTracker parsePricingFromEnv returns undefined for missing env', () => {
+  assert.equal(CostTracker.parsePricingFromEnv({}), undefined);
+});
+
+// --- Integration: cost metadata in workflow results ---
+
+test('workflow result includes _meta.cost when LLM usage is present', async () => {
+  // Simulate a workflow where a step produces output with usage data
+  // We use a shell command that outputs JSON with usage field
+  const workflow = {
+    name: 'cost-test',
+    steps: [
+      {
+        id: 'llm_step',
+        command: `node -e "process.stdout.write(JSON.stringify({model:'gpt-4o',output:{text:'hi'},usage:{inputTokens:100,outputTokens:50}}))"`,
+      },
+    ],
+  };
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-cost-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.ok(result._meta?.cost);
+  assert.equal(result._meta!.cost!.totalInputTokens, 100);
+  assert.equal(result._meta!.cost!.totalOutputTokens, 50);
+  assert.equal(result._meta!.cost!.byStep.length, 1);
+  assert.equal(result._meta!.cost!.byStep[0].model, 'gpt-4o');
+});
+
+test('workflow result omits _meta.cost when no LLM usage', async () => {
+  const workflow = {
+    name: 'no-cost-test',
+    steps: [
+      { id: 'plain', command: 'echo "hello"' },
+    ],
+  };
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-cost-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result._meta, undefined);
+});


### PR DESCRIPTION
## Summary
- Aggregates token usage data already flowing through `llm.invoke` output into per-workflow cost summaries
- Returns `_meta.cost` on workflow results when LLM usage is detected (no change when no LLM steps)
- Optional `cost_limit` in workflow files with `warn` or `stop` action
- Built-in pricing table for common models (GPT-4o, Claude, Gemini), overridable via `LOBSTER_LLM_PRICING_JSON` env var
- Handles both Anthropic (`inputTokens`/`outputTokens`) and OpenAI (`prompt_tokens`/`completion_tokens`) field names

## Example
```yaml
name: pr-triage
cost_limit:
  max_usd: 1.00
  action: stop
steps:
  - id: classify
    pipeline: llm.invoke --prompt "Classify this" --model gpt-4o
```

Output includes:
```json
{ "_meta": { "cost": { "totalInputTokens": 2450, "totalOutputTokens": 890, "estimatedCostUsd": 0.0234, "byStep": [...] } } }
```

## Changes
- New `src/core/cost_tracker.ts` — `CostTracker` class with pricing table, accumulation, and limit checking
- Updated `src/workflows/file.ts` — integrates tracker into step loop, adds `_meta.cost` to results, supports `cost_limit` in workflow files
- New `test/cost_tracker.test.ts` — 13 tests (unit + integration)

## Test plan
- [x] All 13 new tests pass
- [x] Existing workflow_file tests still pass (11/11)
- [x] Build succeeds with no type errors