### PR TITLE
feat: add <, <=, >, >= comparison operators to conditions

### DIFF
--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1093,7 +1093,7 @@ function getValueByPath(value: unknown, pathValue: string) {
 }
 
 type ConditionToken =
-  | { type: 'lparen' | 'rparen' | 'and' | 'or' | 'eq' | 'neq' | 'not' }
+  | { type: 'lparen' | 'rparen' | 'and' | 'or' | 'eq' | 'neq' | 'lt' | 'lte' | 'gt' | 'gte' | 'not' }
   | { type: 'step_ref'; value: { id: string; path: string } }
   | { type: 'string' | 'number' | 'boolean' | 'null' | 'identifier'; value: unknown };
 
@@ -1132,6 +1132,18 @@ function evaluateConditionExpression(
     }
     if (match('neq')) {
       return !compareConditionValues(left, parseUnary(true));
+    }
+    if (match('lt')) {
+      return numericCompare(left, parseUnary(true), (a, b) => a < b);
+    }
+    if (match('lte')) {
+      return numericCompare(left, parseUnary(true), (a, b) => a <= b);
+    }
+    if (match('gt')) {
+      return numericCompare(left, parseUnary(true), (a, b) => a > b);
+    }
+    if (match('gte')) {
+      return numericCompare(left, parseUnary(true), (a, b) => a >= b);
     }
     return left;
   }
@@ -1193,6 +1205,13 @@ function compareConditionValues(left: unknown, right: unknown) {
   return Object.is(left, right);
 }
 
+function numericCompare(left: unknown, right: unknown, cmp: (a: number, b: number) => boolean): boolean {
+  const a = Number(left);
+  const b = Number(right);
+  if (Number.isNaN(a) || Number.isNaN(b)) return false;
+  return cmp(a, b);
+}
+
 function isPlainConditionObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -1235,6 +1254,26 @@ function tokenizeCondition(expression: string): ConditionToken[] {
     if (expression.startsWith('!=', index)) {
       tokens.push({ type: 'neq' });
       index += 2;
+      continue;
+    }
+    if (expression.startsWith('<=', index)) {
+      tokens.push({ type: 'lte' });
+      index += 2;
+      continue;
+    }
+    if (expression.startsWith('>=', index)) {
+      tokens.push({ type: 'gte' });
+      index += 2;
+      continue;
+    }
+    if (ch === '<') {
+      tokens.push({ type: 'lt' });
+      index += 1;
+      continue;
+    }
+    if (ch === '>') {
+      tokens.push({ type: 'gt' });
+      index += 1;
       continue;
     }
     if (ch === '!') {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1205,11 +1205,15 @@ function compareConditionValues(left: unknown, right: unknown) {
   return Object.is(left, right);
 }
 
+function isStrictlyNumeric(v: unknown): boolean {
+  if (typeof v === 'number') return !Number.isNaN(v);
+  if (typeof v === 'string') return v.trim() !== '' && !Number.isNaN(Number(v));
+  return false;
+}
+
 function numericCompare(left: unknown, right: unknown, cmp: (a: number, b: number) => boolean): boolean {
-  const a = Number(left);
-  const b = Number(right);
-  if (Number.isNaN(a) || Number.isNaN(b)) return false;
-  return cmp(a, b);
+  if (!isStrictlyNumeric(left) || !isStrictlyNumeric(right)) return false;
+  return cmp(Number(left), Number(right));
 }
 
 function isPlainConditionObject(value: unknown): value is Record<string, unknown> {

--- a/test/condition_comparison.test.ts
+++ b/test/condition_comparison.test.ts
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile } from '../src/workflows/file.js';
+
+async function runWorkflow(workflow: any) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-cond-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  return runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+}
+
+test('condition > works with numbers', async () => {
+  const workflow = {
+    name: 'gt-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({count:5}))"' },
+      { id: 'check', command: 'echo "big"', when: '$data.json.count > 3' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['big\n']);
+});
+
+test('condition > skips when false', async () => {
+  const workflow = {
+    name: 'gt-false-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({count:1}))"' },
+      { id: 'check', command: 'echo "big"', when: '$data.json.count > 3' },
+      { id: 'fallback', command: 'echo "small"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['small\n']);
+});
+
+test('condition < works', async () => {
+  const workflow = {
+    name: 'lt-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({val:2}))"' },
+      { id: 'check', command: 'echo "low"', when: '$data.json.val < 10' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['low\n']);
+});
+
+test('condition >= works at boundary', async () => {
+  const workflow = {
+    name: 'gte-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({val:5}))"' },
+      { id: 'check', command: 'echo "yes"', when: '$data.json.val >= 5' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['yes\n']);
+});
+
+test('condition <= works at boundary', async () => {
+  const workflow = {
+    name: 'lte-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({val:5}))"' },
+      { id: 'check', command: 'echo "yes"', when: '$data.json.val <= 5' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['yes\n']);
+});
+
+test('comparison operators combine with && and ||', async () => {
+  const workflow = {
+    name: 'combo-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({a:5,b:20}))"' },
+      { id: 'check', command: 'echo "in range"', when: '$data.json.a >= 1 && $data.json.b < 100' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['in range\n']);
+});
+
+test('comparison with non-numeric values returns false', async () => {
+  const workflow = {
+    name: 'nan-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({val:\\"hello\\"}))"' },
+      { id: 'check', command: 'echo "yes"', when: '$data.json.val > 3' },
+      { id: 'fallback', command: 'echo "no"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['no\n']);
+});
+
+test('existing == and != still work', async () => {
+  const workflow = {
+    name: 'eq-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({status:\\"ok\\"}))"' },
+      { id: 'check', command: 'echo "good"', when: '$data.json.status == "ok"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['good\n']);
+});

--- a/test/condition_comparison.test.ts
+++ b/test/condition_comparison.test.ts
@@ -117,6 +117,34 @@ test('comparison with non-numeric values returns false', async () => {
   assert.deepEqual(result.output, ['no\n']);
 });
 
+test('comparison rejects boolean true as non-numeric', async () => {
+  const workflow = {
+    name: 'bool-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({val:true}))"' },
+      { id: 'check', command: 'echo "yes"', when: '$data.json.val > 0' },
+      { id: 'fallback', command: 'echo "no"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['no\n']);
+});
+
+test('comparison rejects null as non-numeric', async () => {
+  const workflow = {
+    name: 'null-test',
+    steps: [
+      { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({val:null}))"' },
+      { id: 'check', command: 'echo "yes"', when: '$data.json.val >= 0' },
+      { id: 'fallback', command: 'echo "no"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['no\n']);
+});
+
 test('existing == and != still work', async () => {
   const workflow = {
     name: 'eq-test',


### PR DESCRIPTION
## Summary
- Adds `<`, `<=`, `>`, `>=` to the workflow condition parser
- Enables numeric comparisons in `when:`/`condition:` expressions: `$step.json.count > 0`
- Consistent with the pipeline `where` command which already supports these operators
- Non-numeric comparisons safely return false (no crash)

## Example
```yaml
steps:
  - id: data
    run: gh pr list --json number --limit 100
  - id: alert
    run: curl -X POST https://slack.example.com/webhook
    when: $data.json | length > 50
  - id: range_check
    run: echo "in range"
    when: $data.json.score >= 1 && $data.json.score <= 100
```

## Changes
- `src/workflows/file.ts` — extended `ConditionToken` type, added `lt`/`lte`/`gt`/`gte` tokenization and evaluation with `numericCompare` helper
- `test/condition_comparison.test.ts` — 8 tests covering all operators, boundary conditions, combined expressions, NaN handling, and backward compatibility

## Test plan
- [x] All 8 new tests pass
- [x] All 11 existing workflow_file tests still pass
- [x] Build succeeds with no type errors