### PR TITLE
feat: per-step on_error handling (continue/stop/skip_rest)

### DIFF
--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -444,8 +444,9 @@ export async function runWorkflowFile({
       if (err?.name === 'AbortError' || err?.code === 'ABORT_ERR') {
         throw err;
       }
-      // Always re-throw approval-halt errors — these are safety mechanisms, not transient failures
-      if (err?.message && /halted for approval inside pipeline/.test(err.message)) {
+      // Always re-throw pipeline halt errors — these are structural safety mechanisms
+      // (approval gates, input requests, unexpected halts), not transient failures
+      if (err?.message && /halted (for approval inside|before completion at) pipeline/.test(err.message)) {
         throw err;
       }
       const policy = step.on_error ?? 'stop';

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -444,6 +444,10 @@ export async function runWorkflowFile({
       if (err?.name === 'AbortError' || err?.code === 'ABORT_ERR') {
         throw err;
       }
+      // Always re-throw approval-halt errors — these are safety mechanisms, not transient failures
+      if (err?.message && /halted for approval inside pipeline/.test(err.message)) {
+        throw err;
+      }
       const policy = step.on_error ?? 'stop';
       if (policy === 'stop') {
         throw err;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -453,12 +453,11 @@ export async function runWorkflowFile({
         error: true,
         errorMessage: err?.message ?? String(err),
       };
-      // For skip_rest, preserve lastStepId from prior successful step
-      // so output comes from the last good result, not the error placeholder
+      // Preserve lastStepId from prior successful step so output comes
+      // from the last good result, not the error placeholder
       if (policy === 'skip_rest') {
         break;
       }
-      lastStepId = step.id;
       // policy === 'continue': proceed to next step
       continue;
     }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -35,6 +35,7 @@ export type WorkflowStep = {
   input?: WorkflowInputRequest;
   condition?: unknown;
   when?: unknown;
+  on_error?: 'stop' | 'continue' | 'skip_rest';
 };
 
 export type WorkflowApproval =
@@ -61,6 +62,8 @@ export type WorkflowStepResult = {
   subject?: unknown;
   response?: unknown;
   skipped?: boolean;
+  error?: boolean;
+  errorMessage?: string;
 };
 
 export type WorkflowRunResult = {
@@ -194,6 +197,9 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
       } catch (err: any) {
         throw new Error(`Workflow step ${step.id} input.responseSchema is invalid: ${err?.message ?? String(err)}`);
       }
+    }
+    if (step.on_error !== undefined && step.on_error !== 'stop' && step.on_error !== 'continue' && step.on_error !== 'skip_rest') {
+      throw new Error(`Workflow step ${step.id} on_error must be "stop", "continue", or "skip_rest"`);
     }
     if (seen.has(step.id)) {
       throw new Error(`Duplicate workflow step id: ${step.id}`);
@@ -409,28 +415,46 @@ export async function runWorkflowFile({
     const execution = getStepExecution(step);
 
     let result: WorkflowStepResult;
-    if (execution.kind === 'shell') {
-      const command = resolveTemplate(execution.value, resolvedArgs, results);
-      const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
-      const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
-      result = { id: step.id, stdout, json: parseJson(stdout) };
-    } else if (execution.kind === 'pipeline') {
-      if (!ctx.registry) {
-        throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
+    try {
+      if (execution.kind === 'shell') {
+        const command = resolveTemplate(execution.value, resolvedArgs, results);
+        const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
+        const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
+        result = { id: step.id, stdout, json: parseJson(stdout) };
+      } else if (execution.kind === 'pipeline') {
+        if (!ctx.registry) {
+          throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
+        }
+        const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
+        const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
+        result = await runPipelineStep({
+          stepId: step.id,
+          pipelineText,
+          inputValue,
+          ctx,
+          env,
+          cwd,
+        });
+      } else {
+        const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
+        result = createSyntheticStepResult(step.id, inputValue);
       }
-      const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
-      const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
-      result = await runPipelineStep({
-        stepId: step.id,
-        pipelineText,
-        inputValue,
-        ctx,
-        env,
-        cwd,
-      });
-    } else {
-      const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
-      result = createSyntheticStepResult(step.id, inputValue);
+    } catch (err: any) {
+      const policy = step.on_error ?? 'stop';
+      if (policy === 'stop') {
+        throw err;
+      }
+      results[step.id] = {
+        id: step.id,
+        error: true,
+        errorMessage: err?.message ?? String(err),
+      };
+      lastStepId = step.id;
+      if (policy === 'skip_rest') {
+        break;
+      }
+      // policy === 'continue': proceed to next step
+      continue;
     }
 
     results[step.id] = result;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -440,6 +440,10 @@ export async function runWorkflowFile({
         result = createSyntheticStepResult(step.id, inputValue);
       }
     } catch (err: any) {
+      // Always re-throw abort/cancellation errors regardless of on_error policy
+      if (err?.name === 'AbortError' || err?.code === 'ABORT_ERR') {
+        throw err;
+      }
       const policy = step.on_error ?? 'stop';
       if (policy === 'stop') {
         throw err;
@@ -449,10 +453,12 @@ export async function runWorkflowFile({
         error: true,
         errorMessage: err?.message ?? String(err),
       };
-      lastStepId = step.id;
+      // For skip_rest, preserve lastStepId from prior successful step
+      // so output comes from the last good result, not the error placeholder
       if (policy === 'skip_rest') {
         break;
       }
+      lastStepId = step.id;
       // policy === 'continue': proceed to next step
       continue;
     }

--- a/test/on_error.test.ts
+++ b/test/on_error.test.ts
@@ -152,6 +152,39 @@ test('on_error: skip_rest preserves output from last successful step', async () 
   assert.equal(output[0].data, 'kept');
 });
 
+test('approval-halt errors bypass on_error: continue', async () => {
+  const tmpDir = await (await import('node:fs')).promises.mkdtemp(
+    (await import('node:path')).join((await import('node:os')).tmpdir(), 'lobster-approval-halt-'),
+  );
+  const stateDir = (await import('node:path')).join(tmpDir, 'state');
+  const filePath = (await import('node:path')).join(tmpDir, 'workflow.lobster');
+  const workflow = {
+    name: 'approval-halt-test',
+    steps: [
+      { id: 'bad', pipeline: "approve --prompt 'ok?'", on_error: 'continue' },
+      { id: 'after', command: 'echo "should not run"' },
+    ],
+  };
+  await (await import('node:fs')).promises.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+
+  const { createDefaultRegistry } = await import('../src/commands/registry.js');
+  const { runWorkflowFile: rwf } = await import('../src/workflows/file.js');
+  await assert.rejects(
+    rwf({
+      filePath,
+      ctx: {
+        stdin: process.stdin,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+        mode: 'tool',
+        registry: createDefaultRegistry(),
+      },
+    }),
+    /halted for approval inside pipeline/,
+  );
+});
+
 test('on_error: continue preserves output when last step fails', async () => {
   const workflow = {
     name: 'continue-last-fail',

--- a/test/on_error.test.ts
+++ b/test/on_error.test.ts
@@ -152,6 +152,21 @@ test('on_error: skip_rest preserves output from last successful step', async () 
   assert.equal(output[0].data, 'kept');
 });
 
+test('on_error: continue preserves output when last step fails', async () => {
+  const workflow = {
+    name: 'continue-last-fail',
+    steps: [
+      { id: 'good', command: 'node -e "process.stdout.write(JSON.stringify({kept:true}))"' },
+      { id: 'fail_last', command: 'node -e "process.exit(1)"', on_error: 'continue' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output.length, 1);
+  assert.equal(output[0].kept, true);
+});
+
 test('abort errors propagate even with on_error: continue', async () => {
   // Simulate an abort by running a command with an already-aborted signal
   const tmpDir = await (await import('node:fs')).promises.mkdtemp(

--- a/test/on_error.test.ts
+++ b/test/on_error.test.ts
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
+
+async function runWorkflow(workflow: any) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-onerror-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  return runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+}
+
+test('on_error: stop (default) propagates error', async () => {
+  const workflow = {
+    name: 'stop-test',
+    steps: [
+      { id: 'fail', command: 'node -e "process.exit(1)"' },
+      { id: 'after', command: 'echo "should not run"' },
+    ],
+  };
+  await assert.rejects(runWorkflow(workflow), /workflow command failed/);
+});
+
+test('on_error: stop explicit also propagates', async () => {
+  const workflow = {
+    name: 'stop-explicit',
+    steps: [
+      { id: 'fail', command: 'node -e "process.exit(1)"', on_error: 'stop' },
+      { id: 'after', command: 'echo "should not run"' },
+    ],
+  };
+  await assert.rejects(runWorkflow(workflow), /workflow command failed/);
+});
+
+test('on_error: continue records error and proceeds', async () => {
+  const workflow = {
+    name: 'continue-test',
+    steps: [
+      { id: 'fail', command: 'node -e "process.exit(1)"', on_error: 'continue' },
+      { id: 'after', command: 'echo "ran"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['ran\n']);
+});
+
+test('on_error: continue sets error fields on step result', async () => {
+  const workflow = {
+    name: 'error-fields',
+    steps: [
+      { id: 'fail', command: 'node -e "process.exit(1)"', on_error: 'continue' },
+      {
+        id: 'check',
+        command: 'node -e "process.stdout.write(JSON.stringify({saw_error: process.env.LOBSTER_ARG_ERR}))"',
+        env: { LOBSTER_ARG_ERR: '$fail.error' },
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].saw_error, 'true');
+});
+
+test('on_error: skip_rest records error and stops remaining steps', async () => {
+  const workflow = {
+    name: 'skip-rest-test',
+    steps: [
+      { id: 'ok', command: 'echo "first"' },
+      { id: 'fail', command: 'node -e "process.exit(1)"', on_error: 'skip_rest' },
+      { id: 'skipped', command: 'echo "should not run"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  // Output comes from the last step that ran, which is 'fail' (with error fields)
+  // The 'skipped' step never executes
+});
+
+test('on_error: continue allows condition-based branching on error', async () => {
+  const workflow = {
+    name: 'branch-on-error',
+    steps: [
+      { id: 'risky', command: 'node -e "process.exit(1)"', on_error: 'continue' },
+      { id: 'on_success', command: 'echo "success path"', when: '$risky.error != true' },
+      { id: 'on_failure', command: 'echo "failure path"', when: '$risky.error == true' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.output, ['failure path\n']);
+});
+
+test('on_error validation rejects invalid values', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'x', command: 'echo hi', on_error: 'invalid' }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-onerror-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /on_error must be/);
+});
+
+test('multiple steps with on_error: continue collects all errors', async () => {
+  const workflow = {
+    name: 'multi-error',
+    steps: [
+      { id: 'a', command: 'node -e "process.exit(1)"', on_error: 'continue' },
+      { id: 'b', command: 'node -e "process.exit(1)"', on_error: 'continue' },
+      {
+        id: 'report',
+        command: 'node -e "process.stdout.write(JSON.stringify({a_err:process.env.A_ERR,b_err:process.env.B_ERR}))"',
+        env: { A_ERR: '$a.error', B_ERR: '$b.error' },
+      },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].a_err, 'true');
+  assert.equal(output[0].b_err, 'true');
+});

--- a/test/on_error.test.ts
+++ b/test/on_error.test.ts
@@ -136,3 +136,54 @@ test('multiple steps with on_error: continue collects all errors', async () => {
   assert.equal(output[0].a_err, 'true');
   assert.equal(output[0].b_err, 'true');
 });
+
+test('on_error: skip_rest preserves output from last successful step', async () => {
+  const workflow = {
+    name: 'skip-rest-output',
+    steps: [
+      { id: 'good', command: 'node -e "process.stdout.write(JSON.stringify({data:\\"kept\\"}))"' },
+      { id: 'fail', command: 'node -e "process.exit(1)"', on_error: 'skip_rest' },
+      { id: 'skipped', command: 'echo "never"' },
+    ],
+  };
+  const result = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].data, 'kept');
+});
+
+test('abort errors propagate even with on_error: continue', async () => {
+  // Simulate an abort by running a command with an already-aborted signal
+  const tmpDir = await (await import('node:fs')).promises.mkdtemp(
+    (await import('node:path')).join((await import('node:os')).tmpdir(), 'lobster-abort-'),
+  );
+  const stateDir = (await import('node:path')).join(tmpDir, 'state');
+  const filePath = (await import('node:path')).join(tmpDir, 'workflow.lobster');
+  const workflow = {
+    name: 'abort-test',
+    steps: [
+      { id: 'slow', command: 'sleep 60', on_error: 'continue' },
+    ],
+  };
+  await (await import('node:fs')).promises.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+
+  const controller = new AbortController();
+  // Abort immediately
+  controller.abort();
+
+  const { runWorkflowFile } = await import('../src/workflows/file.js');
+  await assert.rejects(
+    runWorkflowFile({
+      filePath,
+      ctx: {
+        stdin: process.stdin,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+        mode: 'tool',
+        signal: controller.signal,
+      },
+    }),
+    (err: any) => err.name === 'AbortError' || err.code === 'ABORT_ERR',
+  );
+});


### PR DESCRIPTION
## Summary
- Adds `on_error` field to workflow steps with three policies:
  - `stop` (default): propagate error, halt workflow — same as current behavior
  - `continue`: record error on step result, proceed to next step
  - `skip_rest`: record error, skip remaining steps, return partial output
- Failed steps get `error: true` and `errorMessage` fields on their result
- Enables condition-based error branching: `when: $step.error == true`

## Example
```yaml
steps:
  - id: risky_fetch
    run: curl https://flaky-api.example.com/data
    on_error: continue

  - id: on_success
    run: echo "Got data"
    when: $risky_fetch.error != true

  - id: on_failure
    run: echo "Fetch failed, using cached data"
    when: $risky_fetch.error == true
```

## Changes
- `src/workflows/file.ts` — added `on_error` to `WorkflowStep`, `error`/`errorMessage` to `WorkflowStepResult`, wrapped step execution in try/catch with policy dispatch, validation for on_error values
- `test/on_error.test.ts` — 8 tests covering all policies, error field access, condition branching, multi-error collection, and validation

## Test plan
- [x] All 8 new tests pass
- [x] All 11 existing workflow_file tests pass (no regressions)
- [x] Build succeeds with no type errors