### PR TITLE
feat: workflow composition via workflow: step type

### DIFF
--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -8,7 +8,7 @@ import { PassThrough } from 'node:stream';
 
 import { parsePipeline } from '../parser.js';
 import { runPipeline } from '../runtime.js';
-import { encodeToken } from '../token.js';
+import { encodeToken, decodeToken } from '../token.js';
 import { createApprovalIndex, deleteStateJson, readStateJson, writeStateJson } from '../state/store.js';
 import { readLineFromStream } from '../read_line.js';
 import { resolveInlineShellCommand } from '../shell.js';
@@ -292,11 +292,12 @@ export async function runWorkflowFile({
   if (!resolvedFilePath) {
     throw new Error('Workflow file path required');
   }
-  // Track active workflows for cycle detection in composition
+  // Track active workflows for cycle detection in composition (realpath resolves symlinks)
   if (!ctx._activeWorkflows) {
     ctx._activeWorkflows = new Set<string>();
   }
-  ctx._activeWorkflows.add(path.resolve(resolvedFilePath));
+  const canonicalFilePath = await fsp.realpath(resolvedFilePath);
+  ctx._activeWorkflows.add(canonicalFilePath);
   const workflow = await loadWorkflowFile(resolvedFilePath);
   const resolvedArgs = resolveWorkflowArgs(workflow.args, args ?? resumeState?.args);
   const steps = workflow.steps;
@@ -435,7 +436,7 @@ export async function runWorkflowFile({
         ? workflowPath
         : path.resolve(path.dirname(resolvedFilePath), workflowPath);
       const activeWorkflows = ctx._activeWorkflows ?? new Set<string>();
-      const canonicalPath = path.resolve(resolvedWorkflowPath);
+      const canonicalPath = await fsp.realpath(resolvedWorkflowPath);
       if (activeWorkflows.has(canonicalPath)) {
         throw new Error(
           `Workflow step ${step.id} creates a cycle: ${canonicalPath} is already being executed`,
@@ -450,6 +451,18 @@ export async function runWorkflowFile({
         ctx: { ...ctx, env, cwd, _activeWorkflows: childActive },
       });
       if (subResult.status === 'needs_approval' || subResult.status === 'needs_input') {
+        // Clean up child resume state artifacts since composition rejects these gates
+        const resumeToken = subResult.requiresApproval?.resumeToken ?? subResult.requiresInput?.resumeToken;
+        if (resumeToken) {
+          try {
+            const decoded = decodeToken(resumeToken);
+            if (decoded?.stateKey) {
+              await deleteStateJson({ env: ctx.env, key: decoded.stateKey }).catch(() => {});
+            }
+          } catch {
+            // best-effort cleanup
+          }
+        }
         throw new Error(
           `Workflow step ${step.id} sub-workflow halted for ${subResult.status === 'needs_approval' ? 'approval' : 'input'}. ` +
           `Sub-workflow approval/input gates are not supported in composition.`,

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -433,7 +433,7 @@ export async function runWorkflowFile({
         );
       }
       const json = subResult.output.length === 1 ? subResult.output[0] : subResult.output;
-      const stdout = subResult.output.length ? JSON.stringify(json) : '';
+      const stdout = subResult.output.length ? serializeValueForStdout(json) : '';
       result = { id: step.id, stdout, json };
     } else if (execution.kind === 'shell') {
       const command = resolveTemplate(execution.value, resolvedArgs, results);
@@ -623,7 +623,18 @@ function dryRunWorkflow({
     // rather than silently collapsing the reference to an empty string.
     const stdinNote = dryRunStdinNote(step.stdin);
 
-    if (execution.kind === 'shell') {
+    if (execution.kind === 'workflow') {
+      const workflowPath = resolveDryRunTemplate(execution.value, resolvedArgs, results);
+      const pathNote = dryRunTemplateNote(workflowPath);
+      lines.push(`  ${num}. ${step.id}  [workflow]`);
+      lines.push(`     workflow: ${workflowPath}${pathNote ? `  ${pathNote}` : ''}`);
+      if (step.workflow_args && typeof step.workflow_args === 'object') {
+        const argKeys = Object.keys(step.workflow_args);
+        if (argKeys.length) {
+          lines.push(`     args: ${argKeys.join(', ')}`);
+        }
+      }
+    } else if (execution.kind === 'shell') {
       const command = resolveDryRunTemplate(execution.value, resolvedArgs, results);
       const commandNote = dryRunTemplateNote(command);
       lines.push(`  ${num}. ${step.id}  [shell]`);

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -28,6 +28,8 @@ export type WorkflowStep = {
   command?: string;
   run?: string;
   pipeline?: string;
+  workflow?: string;
+  workflow_args?: Record<string, unknown>;
   env?: Record<string, string>;
   cwd?: string;
   stdin?: unknown;
@@ -157,15 +159,19 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     }
     const shellCommand = typeof step.run === 'string' ? step.run : step.command;
     const pipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
-    const executionCount = Number(Boolean(shellCommand)) + Number(Boolean(pipeline));
+    const workflowRef = typeof step.workflow === 'string' ? step.workflow : undefined;
+    const executionCount = Number(Boolean(shellCommand)) + Number(Boolean(pipeline)) + Number(Boolean(workflowRef));
     if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input)) {
-      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, approval, or input`);
+      throw new Error(`Workflow step ${step.id} requires run, command, pipeline, workflow, approval, or input`);
     }
     if (executionCount > 1) {
-      throw new Error(`Workflow step ${step.id} can only define one of run, command, or pipeline`);
+      throw new Error(`Workflow step ${step.id} can only define one of run, command, pipeline, or workflow`);
+    }
+    if (step.workflow !== undefined && typeof step.workflow !== 'string') {
+      throw new Error(`Workflow step ${step.id} workflow must be a string (file path)`);
     }
     if (executionCount > 0 && isInputStep(step.input)) {
-      throw new Error(`Workflow step ${step.id} input steps cannot define run, command, or pipeline`);
+      throw new Error(`Workflow step ${step.id} input steps cannot define run, command, pipeline, or workflow`);
     }
     if (isApprovalStep(step.approval) && isInputStep(step.input)) {
       throw new Error(`Workflow step ${step.id} cannot define both approval and input`);
@@ -409,7 +415,27 @@ export async function runWorkflowFile({
     const execution = getStepExecution(step);
 
     let result: WorkflowStepResult;
-    if (execution.kind === 'shell') {
+    if (execution.kind === 'workflow') {
+      const workflowPath = resolveTemplate(execution.value, resolvedArgs, results);
+      const resolvedWorkflowPath = path.isAbsolute(workflowPath)
+        ? workflowPath
+        : path.resolve(path.dirname(resolvedFilePath), workflowPath);
+      const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
+      const subResult = await runWorkflowFile({
+        filePath: resolvedWorkflowPath,
+        args: subArgs,
+        ctx: { ...ctx, env, cwd },
+      });
+      if (subResult.status === 'needs_approval' || subResult.status === 'needs_input') {
+        throw new Error(
+          `Workflow step ${step.id} sub-workflow halted for ${subResult.status === 'needs_approval' ? 'approval' : 'input'}. ` +
+          `Sub-workflow approval/input gates are not supported in composition.`,
+        );
+      }
+      const json = subResult.output.length === 1 ? subResult.output[0] : subResult.output;
+      const stdout = subResult.output.length ? JSON.stringify(json) : '';
+      result = { id: step.id, stdout, json };
+    } else if (execution.kind === 'shell') {
       const command = resolveTemplate(execution.value, resolvedArgs, results);
       const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
       const { stdout } = await runShellCommand({ command, stdin: stdinValue, env, cwd, signal: ctx.signal });
@@ -759,6 +785,23 @@ function resolveTemplate(
 ) {
   const withArgs = resolveArgsTemplate(input, args);
   return resolveStepRefs(withArgs, results);
+}
+
+function resolveWorkflowStepArgs(
+  workflowArgs: Record<string, unknown> | undefined,
+  parentArgs: Record<string, unknown>,
+  results: Record<string, WorkflowStepResult>,
+): Record<string, unknown> {
+  if (!workflowArgs) return {};
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(workflowArgs)) {
+    if (typeof value === 'string') {
+      resolved[key] = resolveTemplate(value, parentArgs, results);
+    } else {
+      resolved[key] = value;
+    }
+  }
+  return resolved;
 }
 
 function resolveArgsTemplate(input: string, args: Record<string, unknown>) {
@@ -1368,6 +1411,10 @@ async function runShellCommand({
 }
 
 function getStepExecution(step: WorkflowStep) {
+  if (typeof step.workflow === 'string' && step.workflow.trim()) {
+    return { kind: 'workflow' as const, value: step.workflow };
+  }
+
   if (typeof step.pipeline === 'string' && step.pipeline.trim()) {
     return { kind: 'pipeline' as const, value: step.pipeline };
   }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -99,6 +99,7 @@ type RunContext = {
   };
   llmAdapters?: Record<string, any>;
   dryRun?: boolean;
+  _activeWorkflows?: Set<string>;
 };
 
 export type WorkflowResumePayload = {
@@ -157,18 +158,26 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     if (!step.id || typeof step.id !== 'string') {
       throw new Error('Workflow step requires an id');
     }
+    if (step.workflow !== undefined && typeof step.workflow !== 'string') {
+      throw new Error(`Workflow step ${step.id} workflow must be a string (file path)`);
+    }
+    if (typeof step.workflow === 'string' && !step.workflow.trim()) {
+      throw new Error(`Workflow step ${step.id} workflow path cannot be blank`);
+    }
+    if (step.workflow_args !== undefined) {
+      if (!step.workflow_args || typeof step.workflow_args !== 'object' || Array.isArray(step.workflow_args)) {
+        throw new Error(`Workflow step ${step.id} workflow_args must be a plain object`);
+      }
+    }
     const shellCommand = typeof step.run === 'string' ? step.run : step.command;
     const pipeline = typeof step.pipeline === 'string' ? step.pipeline : undefined;
-    const workflowRef = typeof step.workflow === 'string' ? step.workflow : undefined;
+    const workflowRef = typeof step.workflow === 'string' && step.workflow.trim() ? step.workflow : undefined;
     const executionCount = Number(Boolean(shellCommand)) + Number(Boolean(pipeline)) + Number(Boolean(workflowRef));
     if (executionCount === 0 && !isApprovalStep(step.approval) && !isInputStep(step.input)) {
       throw new Error(`Workflow step ${step.id} requires run, command, pipeline, workflow, approval, or input`);
     }
     if (executionCount > 1) {
       throw new Error(`Workflow step ${step.id} can only define one of run, command, pipeline, or workflow`);
-    }
-    if (step.workflow !== undefined && typeof step.workflow !== 'string') {
-      throw new Error(`Workflow step ${step.id} workflow must be a string (file path)`);
     }
     if (executionCount > 0 && isInputStep(step.input)) {
       throw new Error(`Workflow step ${step.id} input steps cannot define run, command, pipeline, or workflow`);
@@ -283,6 +292,11 @@ export async function runWorkflowFile({
   if (!resolvedFilePath) {
     throw new Error('Workflow file path required');
   }
+  // Track active workflows for cycle detection in composition
+  if (!ctx._activeWorkflows) {
+    ctx._activeWorkflows = new Set<string>();
+  }
+  ctx._activeWorkflows.add(path.resolve(resolvedFilePath));
   const workflow = await loadWorkflowFile(resolvedFilePath);
   const resolvedArgs = resolveWorkflowArgs(workflow.args, args ?? resumeState?.args);
   const steps = workflow.steps;
@@ -420,11 +434,20 @@ export async function runWorkflowFile({
       const resolvedWorkflowPath = path.isAbsolute(workflowPath)
         ? workflowPath
         : path.resolve(path.dirname(resolvedFilePath), workflowPath);
+      const activeWorkflows = ctx._activeWorkflows ?? new Set<string>();
+      const canonicalPath = path.resolve(resolvedWorkflowPath);
+      if (activeWorkflows.has(canonicalPath)) {
+        throw new Error(
+          `Workflow step ${step.id} creates a cycle: ${canonicalPath} is already being executed`,
+        );
+      }
+      const childActive = new Set(activeWorkflows);
+      childActive.add(canonicalPath);
       const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
       const subResult = await runWorkflowFile({
         filePath: resolvedWorkflowPath,
         args: subArgs,
-        ctx: { ...ctx, env, cwd },
+        ctx: { ...ctx, env, cwd, _activeWorkflows: childActive },
       });
       if (subResult.status === 'needs_approval' || subResult.status === 'needs_input') {
         throw new Error(

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -298,6 +298,7 @@ export async function runWorkflowFile({
   }
   const canonicalFilePath = await fsp.realpath(resolvedFilePath);
   ctx._activeWorkflows.add(canonicalFilePath);
+  try {
   const workflow = await loadWorkflowFile(resolvedFilePath);
   const resolvedArgs = resolveWorkflowArgs(workflow.args, args ?? resumeState?.args);
   const steps = workflow.steps;
@@ -557,6 +558,9 @@ export async function runWorkflowFile({
     await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
   }
   return { status: 'ok', output };
+  } finally {
+    ctx._activeWorkflows?.delete(canonicalFilePath);
+  }
 }
 
 // Returns a human-readable note if a step.stdin value references a prior step's

--- a/test/workflow_composition.test.ts
+++ b/test/workflow_composition.test.ts
@@ -228,6 +228,65 @@ test('dry-run shows workflow steps instead of no-op', async () => {
   assert.ok(dryRunOutput.includes('args: key'), 'should show workflow_args keys');
 });
 
+test('direct self-reference cycle is detected', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'self.lobster': {
+      name: 'self',
+      steps: [
+        { id: 'recurse', workflow: 'self.lobster' },
+      ],
+    },
+  });
+  await assert.rejects(runWorkflow(paths['self.lobster'], stateDir), /creates a cycle/);
+});
+
+test('indirect cycle (a -> b -> a) is detected', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'a.lobster': {
+      name: 'a',
+      steps: [{ id: 'call_b', workflow: 'b.lobster' }],
+    },
+    'b.lobster': {
+      name: 'b',
+      steps: [{ id: 'call_a', workflow: 'a.lobster' }],
+    },
+  });
+  await assert.rejects(runWorkflow(paths['a.lobster'], stateDir), /creates a cycle/);
+});
+
+test('validation rejects blank workflow path', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'x', workflow: '   ' }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-compose-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /workflow path cannot be blank/);
+});
+
+test('validation rejects non-object workflow_args', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'x', workflow: 'child.lobster', workflow_args: 'not-an-object' }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-compose-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /workflow_args must be a plain object/);
+});
+
+test('validation rejects array workflow_args', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'x', workflow: 'child.lobster', workflow_args: ['a', 'b'] }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-compose-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /workflow_args must be a plain object/);
+});
+
 test('chained workflow composition', async () => {
   const { stateDir, paths } = await setupWorkflows({
     'leaf.lobster': {

--- a/test/workflow_composition.test.ts
+++ b/test/workflow_composition.test.ts
@@ -163,6 +163,71 @@ test('workflow validation rejects workflow combined with pipeline', async () => 
   await assert.rejects(loadWorkflowFile(filePath), /can only define one of/);
 });
 
+test('sub-workflow string output is raw in stdout, not JSON-quoted', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'child.lobster': {
+      name: 'child',
+      steps: [
+        { id: 'out', command: 'echo "plain text"' },
+      ],
+    },
+    'parent.lobster': {
+      name: 'parent',
+      steps: [
+        { id: 'sub', workflow: 'child.lobster' },
+        {
+          id: 'check',
+          command: 'node -e "process.stdout.write(JSON.stringify({got: process.env.LOBSTER_ARG_VAL}))"',
+          env: { LOBSTER_ARG_VAL: '$sub.stdout' },
+        },
+      ],
+    },
+  });
+
+  const result = await runWorkflow(paths['parent.lobster'], stateDir);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  // Should be raw "plain text\n", not '"plain text\n"'
+  assert.equal(output[0].got, 'plain text\n');
+});
+
+test('dry-run shows workflow steps instead of no-op', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'child.lobster': {
+      name: 'child',
+      steps: [{ id: 'out', command: 'echo hi' }],
+    },
+    'parent.lobster': {
+      name: 'parent',
+      steps: [
+        { id: 'sub', workflow: 'child.lobster', workflow_args: { key: 'val' } },
+      ],
+    },
+  });
+
+  const chunks: string[] = [];
+  const stderr = new (await import('node:stream')).PassThrough();
+  stderr.on('data', (d: Buffer) => chunks.push(d.toString()));
+
+  const { runWorkflowFile: rwf } = await import('../src/workflows/file.js');
+  await rwf({
+    filePath: paths['parent.lobster'],
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+      dryRun: true,
+    },
+  });
+
+  const dryRunOutput = chunks.join('');
+  assert.ok(dryRunOutput.includes('[workflow]'), 'should show [workflow] tag');
+  assert.ok(dryRunOutput.includes('child.lobster'), 'should show workflow path');
+  assert.ok(dryRunOutput.includes('args: key'), 'should show workflow_args keys');
+});
+
 test('chained workflow composition', async () => {
   const { stateDir, paths } = await setupWorkflows({
     'leaf.lobster': {

--- a/test/workflow_composition.test.ts
+++ b/test/workflow_composition.test.ts
@@ -1,0 +1,197 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
+
+async function setupWorkflows(files: Record<string, any>) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-compose-'));
+  const stateDir = path.join(tmpDir, 'state');
+
+  const paths: Record<string, string> = {};
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(tmpDir, name);
+    await fsp.writeFile(filePath, JSON.stringify(content, null, 2), 'utf8');
+    paths[name] = filePath;
+  }
+
+  return { tmpDir, stateDir, paths };
+}
+
+async function runWorkflow(filePath: string, stateDir: string, args?: Record<string, unknown>) {
+  return runWorkflowFile({
+    filePath,
+    args,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+}
+
+test('workflow step calls sub-workflow and gets output', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'child.lobster': {
+      name: 'child',
+      steps: [
+        { id: 'greet', command: 'node -e "process.stdout.write(JSON.stringify({msg:\\"hello from child\\"}))"' },
+      ],
+    },
+    'parent.lobster': {
+      name: 'parent',
+      steps: [
+        { id: 'sub', workflow: 'child.lobster' },
+        {
+          id: 'use',
+          command: 'node -e "process.stdout.write(JSON.stringify({got: process.env.LOBSTER_ARG_MSG}))"',
+          env: { LOBSTER_ARG_MSG: '$sub.json.msg' },
+        },
+      ],
+    },
+  });
+
+  const result = await runWorkflow(paths['parent.lobster'], stateDir);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].got, 'hello from child');
+});
+
+test('workflow step passes args to sub-workflow', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'child.lobster': {
+      name: 'child',
+      args: { name: { default: 'world' } },
+      steps: [
+        {
+          id: 'greet',
+          command: 'node -e "process.stdout.write(JSON.stringify({greeting: \'hi \' + process.env.LOBSTER_ARG_NAME}))"',
+        },
+      ],
+    },
+    'parent.lobster': {
+      name: 'parent',
+      steps: [
+        {
+          id: 'sub',
+          workflow: 'child.lobster',
+          workflow_args: { name: 'lobster' },
+        },
+      ],
+    },
+  });
+
+  const result = await runWorkflow(paths['parent.lobster'], stateDir);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].greeting, 'hi lobster');
+});
+
+test('workflow step args can reference parent step results', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'child.lobster': {
+      name: 'child',
+      args: { val: { default: '0' } },
+      steps: [
+        {
+          id: 'echo',
+          command: 'node -e "process.stdout.write(JSON.stringify({val: process.env.LOBSTER_ARG_VAL}))"',
+        },
+      ],
+    },
+    'parent.lobster': {
+      name: 'parent',
+      steps: [
+        { id: 'data', command: 'node -e "process.stdout.write(JSON.stringify({num: 42}))"' },
+        {
+          id: 'sub',
+          workflow: 'child.lobster',
+          workflow_args: { val: '$data.json.num' },
+        },
+      ],
+    },
+  });
+
+  const result = await runWorkflow(paths['parent.lobster'], stateDir);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].val, '42');
+});
+
+test('workflow step with sub-workflow that fails propagates error', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'bad-child.lobster': {
+      name: 'bad-child',
+      steps: [
+        { id: 'fail', command: 'node -e "process.exit(1)"' },
+      ],
+    },
+    'parent.lobster': {
+      name: 'parent',
+      steps: [
+        { id: 'sub', workflow: 'bad-child.lobster' },
+      ],
+    },
+  });
+
+  await assert.rejects(runWorkflow(paths['parent.lobster'], stateDir), /workflow command failed/);
+});
+
+test('workflow validation rejects workflow combined with run', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'x', workflow: 'child.lobster', run: 'echo hi' }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-compose-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /can only define one of/);
+});
+
+test('workflow validation rejects workflow combined with pipeline', async () => {
+  const workflow = {
+    name: 'bad',
+    steps: [{ id: 'x', workflow: 'child.lobster', pipeline: 'json' }],
+  };
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-compose-'));
+  const filePath = path.join(tmpDir, 'w.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  await assert.rejects(loadWorkflowFile(filePath), /can only define one of/);
+});
+
+test('chained workflow composition', async () => {
+  const { stateDir, paths } = await setupWorkflows({
+    'leaf.lobster': {
+      name: 'leaf',
+      steps: [
+        { id: 'out', command: 'node -e "process.stdout.write(JSON.stringify({leaf: true}))"' },
+      ],
+    },
+    'middle.lobster': {
+      name: 'middle',
+      steps: [
+        { id: 'call_leaf', workflow: 'leaf.lobster' },
+        {
+          id: 'wrap',
+          command: 'node -e "process.stdout.write(JSON.stringify({middle: true, leaf_result: $call_leaf.json.leaf}))"',
+        },
+      ],
+    },
+    'top.lobster': {
+      name: 'top',
+      steps: [
+        { id: 'call_middle', workflow: 'middle.lobster' },
+      ],
+    },
+  });
+
+  const result = await runWorkflow(paths['top.lobster'], stateDir);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].middle, true);
+  assert.equal(output[0].leaf_result, true);
+});


### PR DESCRIPTION
## Summary
- Adds `workflow:` field to workflow steps for calling sub-workflows
- Sub-workflow file path resolved relative to parent workflow file
- Supports `workflow_args:` with template resolution from parent args and step results
- Output from sub-workflow available as `$step.json` / `$step.stdout`
- Mutually exclusive with `run`/`command`/`pipeline` (validated at load time)
- Sub-workflows that halt for approval/input are rejected with a clear error

## Example
```yaml
# parent.lobster
steps:
  - id: data
    run: gh pr list --json number,title

  - id: analyze
    workflow: analyze-prs.lobster
    workflow_args:
      prs: "$data.stdout"

  - id: report
    run: echo "Analysis complete"
    stdin: $analyze.json
```

```yaml
# analyze-prs.lobster
name: analyze-prs
args:
  prs: { default: "[]" }
steps:
  - id: process
    run: node -e "process.stdout.write(process.env.LOBSTER_ARG_PRS)"
```

## Changes
- `src/workflows/file.ts` — added `workflow`/`workflow_args` to `WorkflowStep`, `workflow` execution kind in `getStepExecution`, recursive `runWorkflowFile` call with arg resolution, `resolveWorkflowStepArgs` helper, validation updates
- `test/workflow_composition.test.ts` — 7 tests covering basic composition, arg passing, parent result references, error propagation, mutual exclusion validation, and 3-level chained composition

## Test plan
- [x] All 7 new tests pass
- [x] All 11 existing workflow_file tests pass (no regressions)
- [x] Build succeeds with no type errors