### PR TITLE
feat: step-level retry with configurable backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Add per-step workflow `retry` policies (`max`, `backoff`, `delay_ms`, `max_delay_ms`, `jitter`) with retry-aware stderr logs and dry-run visibility. Thanks to [@scottgl9](https://github.com/scottgl9) (PR [#84](https://github.com/openclaw/lobster/pull/84)).
 - Add optional approval identity constraints for workflow gates (`approval.initiated_by`, `approval.required_approver`, `approval.require_different_approver`) with resume-time enforcement via `LOBSTER_APPROVAL_APPROVED_BY` and envelope metadata for integrations. Thanks to [@coolmanns](https://github.com/coolmanns) (Issue [#44](https://github.com/openclaw/lobster/issues/44)).
 - Clarify `pipeline:` vs `run:` usage for `llm.invoke` / `llm_task.invoke` in workflow files, and add regression coverage to ensure `stdin: $step.stdout` is forwarded as LLM artifacts for `llm_task.invoke` pipeline steps. Thanks to [@RatkoJ](https://github.com/RatkoJ) (Issue [#41](https://github.com/openclaw/lobster/issues/41)).
 - Add `lobster graph` workflow visualization with `mermaid` (default), `dot`, and `ascii` outputs, including step-type nodes, `stdin` data-flow edges, conditional dependency labels (`when`/`condition`), approval-gate diamond shapes, and `--args-json` label resolution support. Thanks to [@vignesh07](https://github.com/vignesh07) (Issue [#53](https://github.com/openclaw/lobster/issues/53)).

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Notes:
 - `pipeline:` shares the same args/env/results model as shell steps, so later steps can still reference `$step.stdout` or `$step.json`.
 - If you need a human checkpoint before an LLM call, use a dedicated `approval:` step in the workflow file rather than `approve` inside the nested pipeline.
 - `cwd`, `env`, `stdin`, `when`, and `condition` work for both shell and pipeline steps.
+- Use `retry`, `timeout_ms`, and `on_error` per step to control transient-failure behavior and recovery.
 - Approval steps can optionally enforce identity constraints:
   - `approval.required_approver` (or `requiredApprover`) requires an exact approver id.
   - `approval.require_different_approver` (or `requireDifferentApprover`) requires approver id to differ from initiator.

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -1,0 +1,100 @@
+export type RetryConfig = {
+  max?: number;
+  backoff?: 'fixed' | 'exponential';
+  delay_ms?: number;
+  max_delay_ms?: number;
+  jitter?: boolean;
+};
+
+const DEFAULTS = {
+  max: 1,
+  backoff: 'fixed' as const,
+  delay_ms: 1000,
+  max_delay_ms: 30000,
+  jitter: false,
+};
+
+export function resolveRetryConfig(raw: RetryConfig | undefined): Required<RetryConfig> {
+  if (!raw) return { ...DEFAULTS };
+  return {
+    max: raw.max ?? DEFAULTS.max,
+    backoff: raw.backoff ?? DEFAULTS.backoff,
+    delay_ms: raw.delay_ms ?? DEFAULTS.delay_ms,
+    max_delay_ms: raw.max_delay_ms ?? DEFAULTS.max_delay_ms,
+    jitter: raw.jitter ?? DEFAULTS.jitter,
+  };
+}
+
+function computeDelay(config: Required<RetryConfig>, attempt: number): number {
+  let delay: number;
+  if (config.backoff === 'exponential') {
+    delay = Math.min(config.delay_ms * Math.pow(2, attempt), config.max_delay_ms);
+  } else {
+    delay = config.delay_ms;
+  }
+  if (config.jitter) {
+    // +/- 10% randomization, clamped to max_delay_ms
+    const jitterRange = delay * 0.1;
+    delay += (Math.random() * 2 - 1) * jitterRange;
+    delay = Math.min(delay, config.max_delay_ms);
+  }
+  return Math.max(0, Math.round(delay));
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((r) => setTimeout(r, ms));
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+    };
+    timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Execute `fn` with retries according to the given config.
+ * Abort errors always propagate immediately (no retry).
+ * Returns the result of the first successful call, or throws
+ * the last error after all retries are exhausted.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  config: Required<RetryConfig>,
+  options?: {
+    signal?: AbortSignal;
+    shouldRetry?: (error: any, attempt: number) => boolean;
+    onRetry?: (attempt: number, error: Error, delayMs: number) => void;
+  },
+): Promise<T> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < config.max; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      // Never retry abort/cancellation errors
+      if (err?.name === 'AbortError' || err?.code === 'ABORT_ERR') {
+        throw err;
+      }
+      lastError = err;
+      if (attempt + 1 < config.max) {
+        if (options?.shouldRetry && !options.shouldRetry(err, attempt + 1)) {
+          throw err;
+        }
+        const delay = computeDelay(config, attempt);
+        options?.onRetry?.(attempt + 1, err, delay);
+        await abortableSleep(delay, options?.signal);
+      }
+    }
+  }
+  throw lastError;
+}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -15,6 +15,8 @@ import { resolveInlineShellCommand } from '../shell.js';
 import { sharedAjv } from '../validation.js';
 import { CostTracker } from '../core/cost_tracker.js';
 import type { CostLimit, CostSummary } from '../core/cost_tracker.js';
+import { withRetry, resolveRetryConfig } from '../core/retry.js';
+import type { RetryConfig } from '../core/retry.js';
 
 export type WorkflowFile = {
   name?: string;
@@ -65,6 +67,13 @@ export type WorkflowStep = {
   steps?: WorkflowStep[];
   timeout_ms?: number;
   on_error?: 'stop' | 'continue' | 'skip_rest';
+  retry?: {
+    max?: number;
+    backoff?: 'fixed' | 'exponential';
+    delay_ms?: number;
+    max_delay_ms?: number;
+    jitter?: boolean;
+  };
 };
 
 export type WorkflowApproval =
@@ -483,6 +492,27 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     ) {
       throw new Error(`Workflow step ${step.id} on_error must be "stop", "continue", or "skip_rest"`);
     }
+    if (step.retry !== undefined) {
+      if (!step.retry || typeof step.retry !== 'object' || Array.isArray(step.retry)) {
+        throw new Error(`Workflow step ${step.id} retry must be an object`);
+      }
+      const r = step.retry;
+      if (r.max !== undefined && (typeof r.max !== 'number' || !Number.isInteger(r.max) || r.max < 1)) {
+        throw new Error(`Workflow step ${step.id} retry.max must be a positive integer`);
+      }
+      if (r.backoff !== undefined && r.backoff !== 'fixed' && r.backoff !== 'exponential') {
+        throw new Error(`Workflow step ${step.id} retry.backoff must be "fixed" or "exponential"`);
+      }
+      if (r.delay_ms !== undefined && (typeof r.delay_ms !== 'number' || !Number.isFinite(r.delay_ms) || r.delay_ms < 0)) {
+        throw new Error(`Workflow step ${step.id} retry.delay_ms must be a finite non-negative number`);
+      }
+      if (r.max_delay_ms !== undefined && (typeof r.max_delay_ms !== 'number' || !Number.isFinite(r.max_delay_ms) || r.max_delay_ms < 0)) {
+        throw new Error(`Workflow step ${step.id} retry.max_delay_ms must be a finite non-negative number`);
+      }
+      if (r.jitter !== undefined && typeof r.jitter !== 'boolean') {
+        throw new Error(`Workflow step ${step.id} retry.jitter must be a boolean`);
+      }
+    }
     if (seen.has(step.id)) {
       throw new Error(`Duplicate workflow step id: ${step.id}`);
     }
@@ -815,200 +845,230 @@ export async function runWorkflowFile({
     const env = mergeEnv(ctx.env, workflow.env, step.env, resolvedArgs, results);
     const cwd = resolveCwd(step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
     const execution = getStepExecution(step);
+    const retryConfig = resolveRetryConfig(step.retry);
 
-    // Combine external cancellation and optional per-step timeout into one signal.
-    let stepSignal: AbortSignal | undefined = ctx.signal;
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    if (step.timeout_ms) {
-      const timeoutController = new AbortController();
-      timeoutId = setTimeout(
-        () => timeoutController.abort(new Error(`Step '${step.id}' timed out after ${step.timeout_ms}ms`)),
-        step.timeout_ms,
-      );
-      stepSignal = ctx.signal
-        ? AbortSignal.any([ctx.signal, timeoutController.signal])
-        : timeoutController.signal;
-    }
+    const executeStepAttempt = async (): Promise<{
+      result: WorkflowStepResult;
+      parallelBranchResults: Record<string, WorkflowStepResult> | null;
+    }> => {
+      // Combine external cancellation and optional per-step timeout into one signal.
+      let stepSignal: AbortSignal | undefined = ctx.signal;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      if (step.timeout_ms) {
+        const timeoutController = new AbortController();
+        timeoutId = setTimeout(
+          () => timeoutController.abort(new Error(`Step '${step.id}' timed out after ${step.timeout_ms}ms`)),
+          step.timeout_ms,
+        );
+        stepSignal = ctx.signal
+          ? AbortSignal.any([ctx.signal, timeoutController.signal])
+          : timeoutController.signal;
+      }
+
+      let result: WorkflowStepResult;
+      let parallelBranchResults: Record<string, WorkflowStepResult> | null = null;
+      try {
+        if (execution.kind === 'parallel') {
+          const parallel = execution.value;
+          const wait = parallel.wait ?? 'all';
+          const branchAbortController = new AbortController();
+          const branchSignal = stepSignal
+            ? AbortSignal.any([stepSignal, branchAbortController.signal])
+            : branchAbortController.signal;
+          const shouldForceKill = Boolean(step.timeout_ms || parallel.timeout_ms);
+          const runBranch = async (branch: ParallelBranch): Promise<{ branchId: string; result: WorkflowStepResult }> => {
+            const mergedBranchEnv = { ...(step.env ?? {}), ...(branch.env ?? {}) };
+            const branchEnv = mergeEnv(ctx.env, workflow.env, mergedBranchEnv, resolvedArgs, results);
+            const branchCwd = resolveCwd(branch.cwd ?? step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
+            const branchShell = typeof branch.run === 'string' ? branch.run : branch.command;
+            const branchExec = typeof branch.pipeline === 'string' && branch.pipeline.trim()
+              ? { kind: 'pipeline' as const, value: branch.pipeline }
+              : (typeof branchShell === 'string' && branchShell.trim()
+                ? { kind: 'shell' as const, value: branchShell }
+                : { kind: 'none' as const });
+
+            if (branchExec.kind === 'shell') {
+              const command = resolveTemplate(branchExec.value, resolvedArgs, results);
+              const stdinValue = resolveShellStdin(branch.stdin, resolvedArgs, results);
+              const { stdout } = await runShellCommand({
+                command,
+                stdin: stdinValue,
+                env: branchEnv,
+                cwd: branchCwd,
+                signal: branchSignal,
+                ...(shouldForceKill ? { killSignal: 'SIGKILL' as NodeJS.Signals } : {}),
+              });
+              return { branchId: branch.id, result: { id: branch.id, stdout, json: parseJson(stdout) } };
+            }
+
+            if (branchExec.kind === 'pipeline') {
+              if (!ctx.registry) {
+                throw new Error(`Parallel branch ${branch.id} requires a command registry for pipeline execution`);
+              }
+              const pipelineText = resolveTemplate(branchExec.value, resolvedArgs, results);
+              const inputValue = resolveInputValue(branch.stdin, resolvedArgs, results);
+              const branchResult = await runPipelineStep({
+                stepId: branch.id,
+                pipelineText,
+                inputValue,
+                ctx: { ...ctx, signal: branchSignal },
+                env: branchEnv,
+                cwd: branchCwd,
+              });
+              return { branchId: branch.id, result: branchResult };
+            }
+
+            return { branchId: branch.id, result: { id: branch.id } };
+          };
+
+          let parallelTimeoutId: ReturnType<typeof setTimeout> | undefined;
+          const timeoutPromise = parallel.timeout_ms
+            ? new Promise<never>((_resolve, reject) => {
+              parallelTimeoutId = setTimeout(() => {
+                branchAbortController.abort();
+                reject(new Error(`Parallel step ${step.id} timed out after ${parallel.timeout_ms}ms`));
+              }, parallel.timeout_ms);
+            })
+            : null;
+
+          try {
+            if (wait === 'any') {
+              const branchPromises = parallel.branches.map((branch) => runBranch(branch));
+              const winner = await (timeoutPromise
+                ? Promise.race([...branchPromises, timeoutPromise])
+                : Promise.race(branchPromises)) as { branchId: string; result: WorkflowStepResult };
+              parallelBranchResults = { [winner.branchId]: winner.result };
+              branchAbortController.abort();
+            } else {
+              const branchPromises = parallel.branches.map((branch) => runBranch(branch));
+              const settled = await (timeoutPromise
+                ? Promise.race([Promise.allSettled(branchPromises), timeoutPromise])
+                : Promise.allSettled(branchPromises)) as PromiseSettledResult<{ branchId: string; result: WorkflowStepResult }>[];
+
+              parallelBranchResults = {};
+              for (const entry of settled) {
+                if (entry.status === 'rejected') {
+                  throw new Error(`Parallel branch failed: ${entry.reason?.message ?? String(entry.reason)}`);
+                }
+                parallelBranchResults[entry.value.branchId] = entry.value.result;
+              }
+            }
+          } finally {
+            if (parallelTimeoutId !== undefined) clearTimeout(parallelTimeoutId);
+          }
+
+          const merged: Record<string, unknown> = {};
+          for (const [branchId, branchResult] of Object.entries(parallelBranchResults ?? {})) {
+            merged[branchId] = branchResult.json;
+          }
+          result = {
+            id: step.id,
+            json: merged,
+            stdout: wait === 'any'
+              ? (Object.values(parallelBranchResults ?? {})[0]?.stdout ?? '')
+              : JSON.stringify(merged),
+          };
+        } else if (execution.kind === 'workflow') {
+          const workflowPath = resolveTemplate(execution.value, resolvedArgs, results);
+          const resolvedWorkflowPath = path.isAbsolute(workflowPath)
+            ? workflowPath
+            : path.resolve(path.dirname(resolvedFilePath), workflowPath);
+          const activeWorkflows = ctx._activeWorkflows ?? new Set<string>();
+          let canonicalWorkflowPath: string;
+          try {
+            canonicalWorkflowPath = await fsp.realpath(resolvedWorkflowPath);
+          } catch {
+            throw new Error(`Workflow step ${step.id} workflow file not found: ${resolvedWorkflowPath}`);
+          }
+          if (activeWorkflows.has(canonicalWorkflowPath)) {
+            throw new Error(`Workflow step ${step.id} creates a cycle: ${canonicalWorkflowPath} is already being executed`);
+          }
+          const childActive = new Set(activeWorkflows);
+          childActive.add(canonicalWorkflowPath);
+          const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
+          const subResult = await runWorkflowFile({
+            filePath: resolvedWorkflowPath,
+            args: subArgs,
+            ctx: { ...ctx, env, cwd, _activeWorkflows: childActive },
+          });
+          if (subResult.status === 'needs_approval' || subResult.status === 'needs_input') {
+            const resumeToken = subResult.requiresApproval?.resumeToken ?? subResult.requiresInput?.resumeToken;
+            if (resumeToken) {
+              try {
+                const decoded = decodeToken(resumeToken) as { stateKey?: string } | null;
+                if (decoded?.stateKey) {
+                  await deleteStateJson({ env: ctx.env, key: decoded.stateKey }).catch(() => {});
+                }
+              } catch {
+                // best-effort cleanup
+              }
+            }
+            throw new Error(
+              `Workflow step ${step.id} sub-workflow halted for ${
+                subResult.status === 'needs_approval' ? 'approval' : 'input'
+              }. Sub-workflow approval/input gates are not supported in composition.`,
+            );
+          }
+          const json = subResult.output.length === 1 ? subResult.output[0] : subResult.output;
+          const stdout = subResult.output.length ? serializeValueForStdout(json) : '';
+          result = { id: step.id, stdout, json };
+        } else if (execution.kind === 'shell') {
+          const command = resolveTemplate(execution.value, resolvedArgs, results);
+          const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
+          const { stdout } = await runShellCommand({
+            command,
+            stdin: stdinValue,
+            env,
+            cwd,
+            signal: stepSignal,
+            ...(step.timeout_ms ? { killSignal: 'SIGKILL' as NodeJS.Signals } : {}),
+          });
+          result = { id: step.id, stdout, json: parseJson(stdout) };
+        } else if (execution.kind === 'pipeline') {
+          if (!ctx.registry) {
+            throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
+          }
+          const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
+          const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
+          result = await runPipelineStep({
+            stepId: step.id,
+            pipelineText,
+            inputValue,
+            ctx: { ...ctx, signal: stepSignal },
+            env,
+            cwd,
+          });
+        } else {
+          const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
+          result = createSyntheticStepResult(step.id, inputValue);
+        }
+
+        return { result, parallelBranchResults };
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+      }
+    };
 
     let result: WorkflowStepResult;
     let parallelBranchResults: Record<string, WorkflowStepResult> | null = null;
     try {
-      if (execution.kind === 'parallel') {
-        const parallel = execution.value;
-        const wait = parallel.wait ?? 'all';
-        const branchAbortController = new AbortController();
-        const branchSignal = stepSignal
-          ? AbortSignal.any([stepSignal, branchAbortController.signal])
-          : branchAbortController.signal;
-        const shouldForceKill = Boolean(step.timeout_ms || parallel.timeout_ms);
-        const runBranch = async (branch: ParallelBranch): Promise<{ branchId: string; result: WorkflowStepResult }> => {
-          const mergedBranchEnv = { ...(step.env ?? {}), ...(branch.env ?? {}) };
-          const branchEnv = mergeEnv(ctx.env, workflow.env, mergedBranchEnv, resolvedArgs, results);
-          const branchCwd = resolveCwd(branch.cwd ?? step.cwd ?? workflow.cwd, resolvedArgs) ?? ctx.cwd;
-          const branchShell = typeof branch.run === 'string' ? branch.run : branch.command;
-          const branchExec = typeof branch.pipeline === 'string' && branch.pipeline.trim()
-            ? { kind: 'pipeline' as const, value: branch.pipeline }
-            : (typeof branchShell === 'string' && branchShell.trim()
-              ? { kind: 'shell' as const, value: branchShell }
-              : { kind: 'none' as const });
-
-          if (branchExec.kind === 'shell') {
-            const command = resolveTemplate(branchExec.value, resolvedArgs, results);
-            const stdinValue = resolveShellStdin(branch.stdin, resolvedArgs, results);
-            const { stdout } = await runShellCommand({
-              command,
-              stdin: stdinValue,
-              env: branchEnv,
-              cwd: branchCwd,
-              signal: branchSignal,
-              ...(shouldForceKill ? { killSignal: 'SIGKILL' as NodeJS.Signals } : {}),
-            });
-            return { branchId: branch.id, result: { id: branch.id, stdout, json: parseJson(stdout) } };
-          }
-
-          if (branchExec.kind === 'pipeline') {
-            if (!ctx.registry) {
-              throw new Error(`Parallel branch ${branch.id} requires a command registry for pipeline execution`);
-            }
-            const pipelineText = resolveTemplate(branchExec.value, resolvedArgs, results);
-            const inputValue = resolveInputValue(branch.stdin, resolvedArgs, results);
-            const branchResult = await runPipelineStep({
-              stepId: branch.id,
-              pipelineText,
-              inputValue,
-              ctx: { ...ctx, signal: branchSignal },
-              env: branchEnv,
-              cwd: branchCwd,
-            });
-            return { branchId: branch.id, result: branchResult };
-          }
-
-          return { branchId: branch.id, result: { id: branch.id } };
-        };
-
-        let parallelTimeoutId: ReturnType<typeof setTimeout> | undefined;
-        const timeoutPromise = parallel.timeout_ms
-          ? new Promise<never>((_resolve, reject) => {
-            parallelTimeoutId = setTimeout(() => {
-              branchAbortController.abort();
-              reject(new Error(`Parallel step ${step.id} timed out after ${parallel.timeout_ms}ms`));
-            }, parallel.timeout_ms);
-          })
-          : null;
-
-        try {
-          if (wait === 'any') {
-            const branchPromises = parallel.branches.map((branch) => runBranch(branch));
-            const winner = await (timeoutPromise
-              ? Promise.race([...branchPromises, timeoutPromise])
-              : Promise.race(branchPromises)) as { branchId: string; result: WorkflowStepResult };
-            parallelBranchResults = { [winner.branchId]: winner.result };
-            branchAbortController.abort();
-          } else {
-            const branchPromises = parallel.branches.map((branch) => runBranch(branch));
-            const settled = await (timeoutPromise
-              ? Promise.race([Promise.allSettled(branchPromises), timeoutPromise])
-              : Promise.allSettled(branchPromises)) as PromiseSettledResult<{ branchId: string; result: WorkflowStepResult }>[];
-
-            parallelBranchResults = {};
-            for (const entry of settled) {
-              if (entry.status === 'rejected') {
-                throw new Error(`Parallel branch failed: ${entry.reason?.message ?? String(entry.reason)}`);
-              }
-              parallelBranchResults[entry.value.branchId] = entry.value.result;
-            }
-          }
-        } finally {
-          if (parallelTimeoutId !== undefined) clearTimeout(parallelTimeoutId);
-        }
-
-        const merged: Record<string, unknown> = {};
-        for (const [branchId, branchResult] of Object.entries(parallelBranchResults ?? {})) {
-          merged[branchId] = branchResult.json;
-        }
-        result = {
-          id: step.id,
-          json: merged,
-          stdout: wait === 'any'
-            ? (Object.values(parallelBranchResults ?? {})[0]?.stdout ?? '')
-            : JSON.stringify(merged),
-        };
-      } else if (execution.kind === 'workflow') {
-        const workflowPath = resolveTemplate(execution.value, resolvedArgs, results);
-        const resolvedWorkflowPath = path.isAbsolute(workflowPath)
-          ? workflowPath
-          : path.resolve(path.dirname(resolvedFilePath), workflowPath);
-        const activeWorkflows = ctx._activeWorkflows ?? new Set<string>();
-        let canonicalWorkflowPath: string;
-        try {
-          canonicalWorkflowPath = await fsp.realpath(resolvedWorkflowPath);
-        } catch {
-          throw new Error(`Workflow step ${step.id} workflow file not found: ${resolvedWorkflowPath}`);
-        }
-        if (activeWorkflows.has(canonicalWorkflowPath)) {
-          throw new Error(`Workflow step ${step.id} creates a cycle: ${canonicalWorkflowPath} is already being executed`);
-        }
-        const childActive = new Set(activeWorkflows);
-        childActive.add(canonicalWorkflowPath);
-        const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
-        const subResult = await runWorkflowFile({
-          filePath: resolvedWorkflowPath,
-          args: subArgs,
-          ctx: { ...ctx, env, cwd, _activeWorkflows: childActive },
-        });
-        if (subResult.status === 'needs_approval' || subResult.status === 'needs_input') {
-          const resumeToken = subResult.requiresApproval?.resumeToken ?? subResult.requiresInput?.resumeToken;
-          if (resumeToken) {
-            try {
-              const decoded = decodeToken(resumeToken) as { stateKey?: string } | null;
-              if (decoded?.stateKey) {
-                await deleteStateJson({ env: ctx.env, key: decoded.stateKey }).catch(() => {});
-              }
-            } catch {
-              // best-effort cleanup
-            }
-          }
-          throw new Error(
-            `Workflow step ${step.id} sub-workflow halted for ${
-              subResult.status === 'needs_approval' ? 'approval' : 'input'
-            }. Sub-workflow approval/input gates are not supported in composition.`,
-          );
-        }
-        const json = subResult.output.length === 1 ? subResult.output[0] : subResult.output;
-        const stdout = subResult.output.length ? serializeValueForStdout(json) : '';
-        result = { id: step.id, stdout, json };
-      } else if (execution.kind === 'shell') {
-        const command = resolveTemplate(execution.value, resolvedArgs, results);
-        const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
-        const { stdout } = await runShellCommand({
-          command,
-          stdin: stdinValue,
-          env,
-          cwd,
-          signal: stepSignal,
-          ...(step.timeout_ms ? { killSignal: 'SIGKILL' as NodeJS.Signals } : {}),
-        });
-        result = { id: step.id, stdout, json: parseJson(stdout) };
-      } else if (execution.kind === 'pipeline') {
-        if (!ctx.registry) {
-          throw new Error(`Workflow step ${step.id} requires a command registry for pipeline execution`);
-        }
-        const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
-        const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
-        result = await runPipelineStep({
-          stepId: step.id,
-          pipelineText,
-          inputValue,
-          ctx: { ...ctx, signal: stepSignal },
-          env,
-          cwd,
-        });
-      } else {
-        const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
-        result = createSyntheticStepResult(step.id, inputValue);
-      }
+      const attemptResult = retryConfig.max > 1
+        ? await withRetry(executeStepAttempt, retryConfig, {
+          signal: ctx.signal,
+          shouldRetry: (error) => {
+            const message = error?.message ?? String(error);
+            return !/halted (for approval inside|before completion at) pipeline/.test(message);
+          },
+          onRetry: (attempt, error, delayMs) => {
+            ctx.stderr.write(
+              `[RETRY] Step '${step.id}' failed (attempt ${attempt}/${retryConfig.max}): ${error?.message ?? String(error)}. Retrying in ${delayMs}ms...\n`,
+            );
+          },
+        })
+        : await executeStepAttempt();
+      result = attemptResult.result;
+      parallelBranchResults = attemptResult.parallelBranchResults;
     } catch (err: any) {
-      if (timeoutId !== undefined) clearTimeout(timeoutId);
       if (ctx.signal?.aborted && (err?.name === 'AbortError' || err?.code === 'ABORT_ERR')) {
         throw err;
       }
@@ -1037,8 +1097,6 @@ export async function runWorkflowFile({
         break;
       }
       continue;
-    } finally {
-      if (timeoutId !== undefined) clearTimeout(timeoutId);
     }
 
     if (parallelBranchResults) {
@@ -1373,6 +1431,12 @@ function dryRunWorkflow({
     if (stdinNote) lines.push(`     stdin: ${stdinNote}`);
     if (step.timeout_ms) lines.push(`     timeout: ${step.timeout_ms}ms`);
     if (step.on_error && step.on_error !== 'stop') lines.push(`     on_error: ${step.on_error}`);
+    if (step.retry && typeof step.retry === 'object') {
+      const rc = resolveRetryConfig(step.retry as RetryConfig);
+      if (rc.max > 1) {
+        lines.push(`     retry: up to ${rc.max} attempts, ${rc.backoff} backoff (base: ${rc.delay_ms}ms${rc.jitter ? ', jitter' : ''})`);
+      }
+    }
     if (isApprovalStep(step.approval)) {
       lines.push(`     [approval required]`);
     }

--- a/test/step_retry.test.ts
+++ b/test/step_retry.test.ts
@@ -1,0 +1,255 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PassThrough } from 'node:stream';
+
+import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
+import { withRetry, resolveRetryConfig } from '../src/core/retry.js';
+
+// --- Retry utility unit tests ---
+
+test('resolveRetryConfig fills defaults', () => {
+  const config = resolveRetryConfig(undefined);
+  assert.equal(config.max, 1);
+  assert.equal(config.backoff, 'fixed');
+  assert.equal(config.delay_ms, 1000);
+  assert.equal(config.max_delay_ms, 30000);
+  assert.equal(config.jitter, false);
+});
+
+test('resolveRetryConfig preserves provided values', () => {
+  const config = resolveRetryConfig({ max: 5, backoff: 'exponential', jitter: true });
+  assert.equal(config.max, 5);
+  assert.equal(config.backoff, 'exponential');
+  assert.equal(config.jitter, true);
+  assert.equal(config.delay_ms, 1000); // default
+});
+
+test('withRetry succeeds on first try', async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => { calls++; return 'ok'; },
+    resolveRetryConfig({ max: 3 }),
+  );
+  assert.equal(result, 'ok');
+  assert.equal(calls, 1);
+});
+
+test('withRetry retries and succeeds', async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw new Error('transient');
+      return 'ok';
+    },
+    resolveRetryConfig({ max: 3, delay_ms: 10 }),
+  );
+  assert.equal(result, 'ok');
+  assert.equal(calls, 3);
+});
+
+test('withRetry throws after max exhausted', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(
+      async () => { calls++; throw new Error('always fails'); },
+      resolveRetryConfig({ max: 2, delay_ms: 10 }),
+    ),
+    /always fails/,
+  );
+  assert.equal(calls, 2);
+});
+
+test('withRetry never retries abort errors', async () => {
+  let calls = 0;
+  const abortErr = new DOMException('aborted', 'AbortError');
+  await assert.rejects(
+    withRetry(
+      async () => { calls++; throw abortErr; },
+      resolveRetryConfig({ max: 3, delay_ms: 10 }),
+    ),
+    (err: any) => err.name === 'AbortError',
+  );
+  assert.equal(calls, 1);
+});
+
+test('withRetry calls onRetry callback', async () => {
+  const retries: number[] = [];
+  let calls = 0;
+  await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw new Error('fail');
+      return 'ok';
+    },
+    resolveRetryConfig({ max: 3, delay_ms: 10 }),
+    { onRetry: (attempt) => retries.push(attempt) },
+  );
+  assert.deepEqual(retries, [1, 2]);
+});
+
+// --- Validation tests ---
+
+async function loadWorkflow(workflow: any) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  return loadWorkflowFile(filePath);
+}
+
+test('retry validation rejects non-object', async () => {
+  await assert.rejects(
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: 'yes' }] }),
+    /retry must be an object/,
+  );
+});
+
+test('retry validation rejects non-integer max', async () => {
+  await assert.rejects(
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { max: 1.5 } }] }),
+    /retry.max must be a positive integer/,
+  );
+});
+
+test('retry validation rejects max < 1', async () => {
+  await assert.rejects(
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { max: 0 } }] }),
+    /retry.max must be a positive integer/,
+  );
+});
+
+test('retry validation rejects invalid backoff', async () => {
+  await assert.rejects(
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { backoff: 'linear' } }] }),
+    /retry.backoff must be "fixed" or "exponential"/,
+  );
+});
+
+test('retry validation rejects negative delay_ms', async () => {
+  await assert.rejects(
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { delay_ms: -1 } }] }),
+    /retry.delay_ms must be a finite non-negative number/,
+  );
+});
+
+test('retry validation rejects non-boolean jitter', async () => {
+  await assert.rejects(
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { jitter: 'yes' } }] }),
+    /retry.jitter must be a boolean/,
+  );
+});
+
+test('retry validation accepts valid config', async () => {
+  const wf = await loadWorkflow({
+    name: 'ok',
+    steps: [{ id: 'x', command: 'echo', retry: { max: 3, backoff: 'exponential', delay_ms: 500, jitter: true } }],
+  });
+  assert.ok(wf.steps[0].retry);
+});
+
+// --- Integration tests ---
+
+async function runWorkflow(workflow: any) {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const stderrChunks: string[] = [];
+  const stderr = new PassThrough();
+  stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()));
+
+  const result = await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+    },
+  });
+  return { result, stderrOutput: stderrChunks.join('') };
+}
+
+test('step retries and succeeds after transient failure', async () => {
+  // Script that fails twice then succeeds on third run using a counter file
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const counterFile = path.join(tmpDir, 'counter');
+  await fsp.writeFile(counterFile, '0', 'utf8');
+
+  const workflow = {
+    name: 'retry-succeed',
+    steps: [{
+      id: 'flaky',
+      command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){process.exit(1);}process.stdout.write(JSON.stringify({attempt:c}))"`,
+      retry: { max: 3, delay_ms: 50 },
+    }],
+  };
+  const { result, stderrOutput } = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].attempt, 3);
+  assert.ok(stderrOutput.includes('[RETRY]'), 'should log retry attempts');
+});
+
+test('step exhausts retries and throws', async () => {
+  const workflow = {
+    name: 'retry-exhaust',
+    steps: [{
+      id: 'fail',
+      command: 'node -e "process.exit(1)"',
+      retry: { max: 2, delay_ms: 50 },
+    }],
+  };
+  await assert.rejects(
+    runWorkflow(workflow).then((r) => r.result),
+    /workflow command failed/,
+  );
+});
+
+test('step without retry fails immediately (no retry)', async () => {
+  const workflow = {
+    name: 'no-retry',
+    steps: [{ id: 'fail', command: 'node -e "process.exit(1)"' }],
+  };
+  await assert.rejects(
+    runWorkflow(workflow).then((r) => r.result),
+    /workflow command failed/,
+  );
+});
+
+test('dry-run renders retry config', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  const workflow = {
+    name: 'dry-run-retry',
+    steps: [{ id: 'fetch', command: 'curl https://example.com', retry: { max: 3, backoff: 'exponential', delay_ms: 1000 } }],
+  };
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+
+  const stderrChunks: string[] = [];
+  const stderr = new PassThrough();
+  stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()));
+
+  await runWorkflowFile({
+    filePath,
+    ctx: {
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr,
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+      mode: 'tool',
+      dryRun: true,
+    },
+  });
+
+  const output = stderrChunks.join('');
+  assert.ok(output.includes('retry:'), 'should show retry config');
+  assert.ok(output.includes('3 attempts'), 'should show max attempts');
+  assert.ok(output.includes('exponential'), 'should show backoff type');
+});


### PR DESCRIPTION
## Summary
- Adds `retry` field to workflow steps for automatic retry on transient failures
- Configurable: `max` attempts, `backoff` (fixed/exponential), `delay_ms`, `max_delay_ms`, `jitter`
- Abort errors never trigger retries — they propagate immediately
- Retry delays are signal-aware (cancellation during sleep aborts immediately)
- Each retry attempt logged to stderr as `[RETRY] Step '<id>' failed (attempt N/M): <error>. Retrying in <delay>ms...`
- Dry-run renders retry config in step output

## Example
```yaml
steps:
  - id: fetch_prs
    run: gh pr list --repo org/repo --json number,title
    retry:
      max: 3
      backoff: exponential
      delay_ms: 1000
      jitter: true

  - id: simple_retry
    run: curl https://flaky-api.example.com/data
    retry:
      max: 2
```

## Motivation
Real-world automations talk to flaky external services — GitHub API rate limits (429), transient network errors, Slack timeouts, cloud provider throttling. An email triage workflow that fails on a single Gmail API timeout kills the entire run. The only retry logic in lobster today is `--max-validation-retries` inside `llm.invoke`, which is narrow and internal to schema validation.

## Implementation
- New `src/core/retry.ts` — `withRetry` utility with exponential/fixed backoff, jitter (±10%), and abort-aware delay via `abortableSleep`
- `src/workflows/file.ts` — `retry` on `WorkflowStep` type, step execution wrapped in `withRetry` when `max > 1`, comprehensive validation, dry-run rendering
- `test/step_retry.test.ts` — 18 tests: 7 unit (retry utility), 7 validation, 4 integration (transient success, exhaustion, no-retry, dry-run)

## Changes
| File | Change |
|------|--------|
| `src/core/retry.ts` | New retry utility (~90 lines) |
| `src/workflows/file.ts` | `retry` type, validation, execution wrapping, dry-run |
| `test/step_retry.test.ts` | 18 tests |

## Test plan
- [x] All 18 new tests pass (~1.4s total)
- [x] All 11 existing workflow_file tests pass (no regressions)
- [x] Build succeeds with no type errors

## Related
Composes with `on_error` (PR #72) — retry exhaustion becomes the error that `on_error` handles. Composes with `timeout_ms` (PR #74) — timeout fires per-attempt, not across all retries.