### PR TITLE
[ai-assisted] fix(validation): memoize Ajv .compile() to prevent SchemaEnv leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Memoize Ajv schema compilation for repeated validation paths to avoid retained SchemaEnv/closure growth in long-running processes. Thanks to [@KrasimirKralev](https://github.com/KrasimirKralev) (PR [#98](https://github.com/openclaw/lobster/pull/98)) and [@cmi525](https://github.com/cmi525) (Issue [#96](https://github.com/openclaw/lobster/issues/96)).
 - Improve workflow resume compatibility for `stateKey` naming by accepting both `workflow_resume_` and `workflow-resume_` prefixes, including cleanup against the resolved on-disk key. Thanks to [@brownetw-ai](https://github.com/brownetw-ai) (PR [#4](https://github.com/openclaw/lobster/pull/4)).
 - Add per-step workflow `retry` policies (`max`, `backoff`, `delay_ms`, `max_delay_ms`, `jitter`) with retry-aware stderr logs and dry-run visibility. Thanks to [@scottgl9](https://github.com/scottgl9) (PR [#84](https://github.com/openclaw/lobster/pull/84)).
 - Add optional approval identity constraints for workflow gates (`approval.initiated_by`, `approval.required_approver`, `approval.require_different_approver`) with resume-time enforcement via `LOBSTER_APPROVAL_APPROVED_BY` and envelope metadata for integrations. Thanks to [@coolmanns](https://github.com/coolmanns) (Issue [#44](https://github.com/openclaw/lobster/issues/44)).

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -1,4 +1,4 @@
-import { sharedAjv } from '../../validation.js';
+import { compileCached } from '../../validation.js';
 
 function isInteractive(stdin) {
   return Boolean(stdin.isTTY);
@@ -6,7 +6,7 @@ function isInteractive(stdin) {
 
 function compileAskValidator(schema) {
   try {
-    return sharedAjv.compile(schema);
+    return compileCached(schema);
   } catch {
     throw new Error('ask response schema is invalid');
   }

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -1,4 +1,4 @@
-import { sharedAjv } from "../../validation.js";
+import { compileCached } from "../../validation.js";
 
 function isInteractive(stdin) {
   return Boolean(stdin.isTTY);
@@ -6,7 +6,7 @@ function isInteractive(stdin) {
 
 function compileAskValidator(schema) {
   try {
-    return sharedAjv.compile(schema);
+    return compileCached(schema);
   } catch {
     throw new Error("ask response schema is invalid");
   }

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -5,9 +5,11 @@ import { Ajv } from 'ajv';
 import type { ErrorObject } from 'ajv';
 
 import { readStateJson, writeStateJson, stableStringify } from '../../state/store.js';
+import { createCompileCached } from '../../validation.js';
 import type { LobsterCommand } from '../types.js';
 
 const ajv = new Ajv({ allErrors: true, strict: false });
+const compileCachedLocal = createCompileCached(ajv);
 
 const artifactSchema = {
   type: 'object',
@@ -369,7 +371,7 @@ async function runLlmInvoke({ input, args, ctx, config }: { input: AsyncIterable
     throw new Error(`${config.name} payload invalid: ${ajv.errorsText(validatePayload.errors)}`);
   }
 
-  const validator = userOutputSchema ? ajv.compile(userOutputSchema) : null;
+  const validator = userOutputSchema ? compileCachedLocal(userOutputSchema) : null;
   let attempt = 0;
   let lastValidationErrors: string[] = [];
 

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -5,9 +5,11 @@ import { Ajv } from "ajv";
 import type { ErrorObject } from "ajv";
 
 import { readStateJson, writeStateJson, stableStringify } from "../../state/store.js";
+import { createCompileCached } from "../../validation.js";
 import type { LobsterCommand } from "../types.js";
 
 const ajv = new Ajv({ allErrors: true, strict: false });
+const compileCachedLocal = createCompileCached(ajv);
 
 const artifactSchema = {
   type: "object",
@@ -412,7 +414,7 @@ async function runLlmInvoke({
     throw new Error(`${config.name} payload invalid: ${ajv.errorsText(validatePayload.errors)}`);
   }
 
-  const validator = userOutputSchema ? ajv.compile(userOutputSchema) : null;
+  const validator = userOutputSchema ? compileCachedLocal(userOutputSchema) : null;
   let attempt = 0;
   let lastValidationErrors: string[] = [];
 

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -8,7 +8,7 @@ import {
   readStateJson,
   writeStateJson,
 } from './state/store.js';
-import { sharedAjv } from './validation.js';
+import { compileCached } from './validation.js';
 
 export type PipelineResumeState = {
   pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
@@ -217,7 +217,7 @@ export function validatePipelineInputResponse(schema: unknown, response: unknown
   }
   let validator;
   try {
-    validator = sharedAjv.compile(schema as any);
+    validator = compileCached(schema as any);
   } catch {
     throw new Error('pipeline input response schema is invalid');
   }

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -8,7 +8,7 @@ import {
   readStateJson,
   writeStateJson,
 } from "./state/store.js";
-import { sharedAjv } from "./validation.js";
+import { compileCached } from "./validation.js";
 
 export type PipelineResumeState = {
   pipeline: Array<{ name: string; args: Record<string, unknown>; raw: string }>;
@@ -216,7 +216,7 @@ export function validatePipelineInputResponse(schema: unknown, response: unknown
   }
   let validator;
   try {
-    validator = sharedAjv.compile(schema as any);
+    validator = compileCached(schema as any);
   } catch {
     throw new Error("pipeline input response schema is invalid");
   }

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -1,6 +1,6 @@
 import { runPipelineInternal } from './runtime.js';
 import { encodeToken, decodeToken } from './token.js';
-import { sharedAjv } from '../validation.js';
+import { compileCached } from '../validation.js';
 
 type SdkResumePayload = {
   protocolVersion: 1;
@@ -212,7 +212,7 @@ export class Lobster {
       }
       let validator;
       try {
-        validator = sharedAjv.compile(schema as any);
+        validator = compileCached(schema as any);
       } catch {
         throw new Error('resume token input schema is invalid');
       }

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -1,6 +1,6 @@
 import { runPipelineInternal } from "./runtime.js";
 import { encodeToken, decodeToken } from "./token.js";
-import { sharedAjv } from "../validation.js";
+import { compileCached } from "../validation.js";
 
 type SdkResumePayload = {
   protocolVersion: 1;
@@ -219,7 +219,7 @@ export class Lobster {
       }
       let validator;
       try {
-        validator = sharedAjv.compile(schema as any);
+        validator = compileCached(schema as any);
       } catch {
         throw new Error("resume token input schema is invalid");
       }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,4 +1,5 @@
-import { Ajv } from 'ajv';
+import { Ajv, type AnySchema, type ValidateFunction } from 'ajv';
+import { stableStringify } from './state/store.js';
 
 export const sharedAjv = new Ajv({
   allErrors: false,
@@ -6,3 +7,36 @@ export const sharedAjv = new Ajv({
   // User-provided schemas may repeat `$id` across runs/resumes.
   addUsedSchema: false,
 });
+
+/**
+ * Build a memoized `compile()` for a given Ajv instance.
+ *
+ * Calling `ajv.compile(schema)` per-request leaks SchemaEnv / closure graphs
+ * that Ajv retains indefinitely (issue #96 — heap profile measured
+ * +1.19M nodes, +114 MiB over 3.5h on a ~1 compile/s workload). Memoization
+ * eliminates the leak for the common case where the same schema is recompiled
+ * across calls.
+ *
+ * Cache key is the stable JSON serialization of the schema, which catches
+ * structurally-identical schemas across reloads even when keys are inserted
+ * in different orders.
+ *
+ * Each Ajv instance gets its own cache (different instances may have
+ * different config — e.g. `allErrors: true` vs `false` — so their compiled
+ * validators are not interchangeable).
+ */
+export function createCompileCached(ajv: Ajv): (schema: AnySchema) => ValidateFunction {
+  const cache = new Map<string, ValidateFunction>();
+  return function compileCached(schema: AnySchema): ValidateFunction {
+    const key = stableStringify(schema);
+    let validator = cache.get(key);
+    if (!validator) {
+      validator = ajv.compile(schema);
+      cache.set(key, validator);
+    }
+    return validator;
+  };
+}
+
+/** Memoized compile bound to the module-level `sharedAjv` instance. */
+export const compileCached = createCompileCached(sharedAjv);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,4 +1,6 @@
-import { Ajv } from "ajv";
+import { Ajv, type AnySchema, type ValidateFunction } from "ajv";
+
+import { stableStringify } from "./state/store.js";
 
 export const sharedAjv = new Ajv({
   allErrors: false,
@@ -6,3 +8,34 @@ export const sharedAjv = new Ajv({
   // User-provided schemas may repeat `$id` across runs/resumes.
   addUsedSchema: false,
 });
+
+/**
+ * Build a memoized `compile()` for a given Ajv instance.
+ *
+ * Calling `ajv.compile(schema)` per request leaks SchemaEnv / closure graphs
+ * that Ajv retains indefinitely (issue #96). Memoization
+ * eliminates the leak for the common case where the same schema is recompiled
+ * across calls.
+ *
+ * Cache key is the stable JSON serialization of the schema, which catches
+ * structurally-identical schemas across reloads even when keys are inserted
+ * in different orders.
+ *
+ * Each Ajv instance gets its own cache because compiled validators are not
+ * interchangeable across different Ajv configurations.
+ */
+export function createCompileCached(ajv: Ajv): (schema: AnySchema) => ValidateFunction {
+  const cache = new Map<string, ValidateFunction>();
+  return function compileCached(schema: AnySchema): ValidateFunction {
+    const key = stableStringify(schema);
+    let validator = cache.get(key);
+    if (!validator) {
+      validator = ajv.compile(schema);
+      cache.set(key, validator);
+    }
+    return validator;
+  };
+}
+
+/** Memoized compile bound to the module-level `sharedAjv` instance. */
+export const compileCached = createCompileCached(sharedAjv);

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -12,7 +12,7 @@ import { encodeToken, decodeToken } from '../token.js';
 import { createApprovalIndex, deleteStateJson, readStateJson, writeStateJson } from '../state/store.js';
 import { readLineFromStream } from '../read_line.js';
 import { resolveInlineShellCommand } from '../shell.js';
-import { sharedAjv } from '../validation.js';
+import { compileCached } from '../validation.js';
 import { CostTracker } from '../core/cost_tracker.js';
 import type { CostLimit, CostSummary } from '../core/cost_tracker.js';
 import { withRetry, resolveRetryConfig } from '../core/retry.js';
@@ -440,7 +440,7 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     }
     if (step.input) {
       try {
-        sharedAjv.compile(step.input.responseSchema as any);
+        compileCached(step.input.responseSchema as any);
       } catch (err: any) {
         throw new Error(`Workflow step ${step.id} input.responseSchema is invalid: ${err?.message ?? String(err)}`);
       }
@@ -1923,7 +1923,7 @@ function validateInputResponse(params: {
   response: unknown;
   stepId: string;
 }) {
-  const validator = sharedAjv.compile(params.schema as object);
+  const validator = compileCached(params.schema as object);
   const ok = validator(params.response);
   if (ok) return;
   const first = validator.errors?.[0];

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -17,7 +17,7 @@ import {
 } from "../state/store.js";
 import { readLineFromStream } from "../read_line.js";
 import { resolveInlineShellCommand } from "../shell.js";
-import { sharedAjv } from "../validation.js";
+import { compileCached } from "../validation.js";
 import { CostTracker } from "../core/cost_tracker.js";
 import type { CostLimit, CostSummary } from "../core/cost_tracker.js";
 import { withRetry, resolveRetryConfig } from "../core/retry.js";
@@ -501,7 +501,7 @@ export async function loadWorkflowFile(filePath: string): Promise<WorkflowFile> 
     }
     if (step.input) {
       try {
-        sharedAjv.compile(step.input.responseSchema as any);
+        compileCached(step.input.responseSchema as any);
       } catch (err: any) {
         throw new Error(
           `Workflow step ${step.id} input.responseSchema is invalid: ${err?.message ?? String(err)}`,
@@ -2122,7 +2122,7 @@ function parseResponseJson(raw: string): unknown {
 }
 
 function validateInputResponse(params: { schema: unknown; response: unknown; stepId: string }) {
-  const validator = sharedAjv.compile(params.schema as object);
+  const validator = compileCached(params.schema as object);
   const ok = validator(params.response);
   if (ok) return;
   const first = validator.errors?.[0];

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Ajv } from "ajv";
+
+import { createCompileCached } from "../src/validation.js";
+
+test("compileCached reuses validators for structurally equivalent schemas", () => {
+  const ajv = new Ajv({ strict: false });
+  const compile = ajv.compile.bind(ajv);
+  let compileCount = 0;
+
+  ajv.compile = ((schema) => {
+    compileCount += 1;
+    return compile(schema);
+  }) as typeof ajv.compile;
+
+  const compileCached = createCompileCached(ajv);
+  const first = compileCached({
+    type: "object",
+    properties: { value: { type: "string" } },
+    required: ["value"],
+  });
+  const second = compileCached({
+    required: ["value"],
+    properties: { value: { type: "string" } },
+    type: "object",
+  });
+
+  assert.equal(second, first);
+  assert.equal(compileCount, 1);
+  assert.equal(first({ value: "ok" }), true);
+});


### PR DESCRIPTION
## What

Closes #96.

Memoizes Ajv `.compile(schema)` to prevent the SchemaEnv / closure-graph leak documented in the issue (+1.19M nodes / +114 MiB heap growth over 3.5h on a ~1 compile/s workload, eventually OOM-killing the gateway near 2 GB RSS).

This implements **Option 1** from the issue body (the reporter's preferred fix): a small content-hash memoization wrapping `ajv.compile()`.

## Why

Per the issue's heap profile, every `.compile()` call leaves a durable graph of `SchemaEnv`, `ValueScopeName`, `_Code`, `Name`, and run-closure objects that Ajv retains indefinitely. With 6 hot call sites all routing through `sharedAjv` (or `llm_invoke.ts`'s module-local `ajv`), even modest workloads accumulate on the order of 10K compile artifacts per few hours. The reporter saw the gateway tripping `--max-old-space-size=2048` and requiring systemd restart.

Memoization eliminates the leak for the common case where the same schema is compiled across calls (which all 6 sites exhibit in practice — schemas come from workflow definitions, command schemas, and resume tokens, not from per-call user input).

## How

| File | Change |
|---|---|
| `src/validation.ts` | New `createCompileCached(ajv)` factory + `compileCached` export bound to `sharedAjv`. Cache keyed by `stableStringify(schema)` (catches structurally-equivalent schemas regardless of key order). |
| `src/commands/stdlib/ask.ts` | `sharedAjv.compile` → `compileCached` |
| `src/commands/stdlib/llm_invoke.ts` | local `ajv.compile(userOutputSchema)` → `compileCachedLocal` (built via `createCompileCached(ajv)` since this file's local Ajv has `allErrors: true`, different from `sharedAjv`) |
| `src/pipeline_resume_state.ts` | `sharedAjv.compile` → `compileCached` |
| `src/sdk/Lobster.ts` | `sharedAjv.compile` → `compileCached` |
| `src/workflows/file.ts` (line 443) | `sharedAjv.compile` → `compileCached` (validation-only compile path) |
| `src/workflows/file.ts` (line 1926) | `sharedAjv.compile` → `compileCached` (input-step response validator) |

The factory pattern keeps each Ajv instance's cache scoped (different config options like `allErrors: true` produce non-interchangeable validators).

## Testing

- [x] **AI-assisted disclosure:** This PR was authored with AI assistance. Degree of testing: **lightly-tested**
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (6 pre-existing warnings unrelated to this change)
- [x] `node --test dist/test/llm_invoke.test.js dist/test/sdk_lobster.test.js` — 4/4 pass (validates the affected compile paths in `llm.invoke` and `sdk Lobster.resume` with structured input responses)
- [ ] Full `pnpm test` — not run; broader test failures on the local Windows machine are pre-existing on `main` (Windows shell-escaping issues in `node -e "..."` invocations, unrelated to this change). CI on Linux should be definitive.

## Notes

- The reporter (@cmi525) explicitly offered to PR Option 1. This PR is a complementary implementation; happy to defer or hand off if maintainers prefer to coordinate with the reporter directly.
- Marked **draft** until maintainers confirm Option 1 is the preferred direction (the issue lists 4 alternatives — Options 2–4 are larger or differently scoped).
- For future-proofing: each `Ajv` instance gets its own cache via `createCompileCached`. If new Ajv instances are added in this codebase later, wrapping their `compile` follows the same pattern shown here.
