### PR TITLE
[ai-assisted] fix: timeout_ms + retry — per-attempt AbortError now flows through shouldRetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Fix `timeout_ms` + `retry` so per-attempt timeouts retry as documented while external workflow cancellation still stops immediately. Thanks to [@KrasimirKralev](https://github.com/KrasimirKralev) (PR [#106](https://github.com/openclaw/lobster/pull/106)).
+
 ## 2026.5.22
 
 - Memoize Ajv schema compilation for repeated validation paths to avoid retained SchemaEnv/closure growth in long-running processes. Thanks to [@KrasimirKralev](https://github.com/KrasimirKralev) (PR [#98](https://github.com/openclaw/lobster/pull/98)) and [@cmi525](https://github.com/cmi525) (Issue [#96](https://github.com/openclaw/lobster/issues/96)).

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -1,6 +1,6 @@
 export type RetryConfig = {
   max?: number;
-  backoff?: "fixed" | "exponential";
+  backoff?: 'fixed' | 'exponential';
   delay_ms?: number;
   max_delay_ms?: number;
   jitter?: boolean;
@@ -8,7 +8,7 @@ export type RetryConfig = {
 
 const DEFAULTS = {
   max: 1,
-  backoff: "fixed" as const,
+  backoff: 'fixed' as const,
   delay_ms: 1000,
   max_delay_ms: 30000,
   jitter: false,
@@ -27,7 +27,7 @@ export function resolveRetryConfig(raw: RetryConfig | undefined): Required<Retry
 
 function computeDelay(config: Required<RetryConfig>, attempt: number): number {
   let delay: number;
-  if (config.backoff === "exponential") {
+  if (config.backoff === 'exponential') {
     delay = Math.min(config.delay_ms * Math.pow(2, attempt), config.max_delay_ms);
   } else {
     delay = config.delay_ms;
@@ -45,19 +45,19 @@ function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (!signal) return new Promise((r) => setTimeout(r, ms));
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
-      reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
       return;
     }
     let timer: ReturnType<typeof setTimeout>;
     const onAbort = () => {
       clearTimeout(timer);
-      reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
     };
     timer = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
+      signal.removeEventListener('abort', onAbort);
       resolve();
     }, ms);
-    signal.addEventListener("abort", onAbort, { once: true });
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 
@@ -86,7 +86,7 @@ export async function withRetry<T>(
       // Only propagate AbortError immediately for external workflow cancellation.
       // Per-attempt timeout AbortErrors (options.signal not aborted) flow through
       // shouldRetry so timeout_ms + retry.max combinations work as documented.
-      if ((err?.name === "AbortError" || err?.code === "ABORT_ERR") && options?.signal?.aborted) {
+      if ((err?.name === 'AbortError' || err?.code === 'ABORT_ERR') && options?.signal?.aborted) {
         throw err;
       }
       lastError = err;

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -63,7 +63,9 @@ function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
 
 /**
  * Execute `fn` with retries according to the given config.
- * Abort errors always propagate immediately (no retry).
+ * External cancellation (options.signal aborted) always propagates immediately.
+ * Per-attempt timeout AbortErrors flow through shouldRetry like any other error,
+ * so timeout_ms + retry.max combinations work as documented.
  * Returns the result of the first successful call, or throws
  * the last error after all retries are exhausted.
  */
@@ -81,8 +83,10 @@ export async function withRetry<T>(
     try {
       return await fn();
     } catch (err: any) {
-      // Never retry abort/cancellation errors
-      if (err?.name === "AbortError" || err?.code === "ABORT_ERR") {
+      // Only propagate AbortError immediately for external workflow cancellation.
+      // Per-attempt timeout AbortErrors (options.signal not aborted) flow through
+      // shouldRetry so timeout_ms + retry.max combinations work as documented.
+      if ((err?.name === "AbortError" || err?.code === "ABORT_ERR") && options?.signal?.aborted) {
         throw err;
       }
       lastError = err;

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -1,6 +1,6 @@
 export type RetryConfig = {
   max?: number;
-  backoff?: 'fixed' | 'exponential';
+  backoff?: "fixed" | "exponential";
   delay_ms?: number;
   max_delay_ms?: number;
   jitter?: boolean;
@@ -8,7 +8,7 @@ export type RetryConfig = {
 
 const DEFAULTS = {
   max: 1,
-  backoff: 'fixed' as const,
+  backoff: "fixed" as const,
   delay_ms: 1000,
   max_delay_ms: 30000,
   jitter: false,
@@ -27,7 +27,7 @@ export function resolveRetryConfig(raw: RetryConfig | undefined): Required<Retry
 
 function computeDelay(config: Required<RetryConfig>, attempt: number): number {
   let delay: number;
-  if (config.backoff === 'exponential') {
+  if (config.backoff === "exponential") {
     delay = Math.min(config.delay_ms * Math.pow(2, attempt), config.max_delay_ms);
   } else {
     delay = config.delay_ms;
@@ -45,19 +45,19 @@ function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (!signal) return new Promise((r) => setTimeout(r, ms));
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
-      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
       return;
     }
     let timer: ReturnType<typeof setTimeout>;
     const onAbort = () => {
       clearTimeout(timer);
-      reject(signal.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+      reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
     };
     timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort);
+      signal.removeEventListener("abort", onAbort);
       resolve();
     }, ms);
-    signal.addEventListener('abort', onAbort, { once: true });
+    signal.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -86,7 +86,7 @@ export async function withRetry<T>(
       // Only propagate AbortError immediately for external workflow cancellation.
       // Per-attempt timeout AbortErrors (options.signal not aborted) flow through
       // shouldRetry so timeout_ms + retry.max combinations work as documented.
-      if ((err?.name === 'AbortError' || err?.code === 'ABORT_ERR') && options?.signal?.aborted) {
+      if ((err?.name === "AbortError" || err?.code === "ABORT_ERR") && options?.signal?.aborted) {
         throw err;
       }
       lastError = err;

--- a/test/step_retry.test.ts
+++ b/test/step_retry.test.ts
@@ -1,67 +1,61 @@
-import test from "node:test";
-import assert from "node:assert/strict";
-import { promises as fsp } from "node:fs";
-import path from "node:path";
-import os from "node:os";
-import { PassThrough } from "node:stream";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PassThrough } from 'node:stream';
 
-import { runWorkflowFile, loadWorkflowFile } from "../src/workflows/file.js";
-import { withRetry, resolveRetryConfig } from "../src/core/retry.js";
+import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
+import { withRetry, resolveRetryConfig } from '../src/core/retry.js';
 
 // --- Retry utility unit tests ---
 
-test("resolveRetryConfig fills defaults", () => {
+test('resolveRetryConfig fills defaults', () => {
   const config = resolveRetryConfig(undefined);
   assert.equal(config.max, 1);
-  assert.equal(config.backoff, "fixed");
+  assert.equal(config.backoff, 'fixed');
   assert.equal(config.delay_ms, 1000);
   assert.equal(config.max_delay_ms, 30000);
   assert.equal(config.jitter, false);
 });
 
-test("resolveRetryConfig preserves provided values", () => {
-  const config = resolveRetryConfig({ max: 5, backoff: "exponential", jitter: true });
+test('resolveRetryConfig preserves provided values', () => {
+  const config = resolveRetryConfig({ max: 5, backoff: 'exponential', jitter: true });
   assert.equal(config.max, 5);
-  assert.equal(config.backoff, "exponential");
+  assert.equal(config.backoff, 'exponential');
   assert.equal(config.jitter, true);
   assert.equal(config.delay_ms, 1000); // default
 });
 
-test("withRetry succeeds on first try", async () => {
+test('withRetry succeeds on first try', async () => {
   let calls = 0;
   const result = await withRetry(
-    async () => {
-      calls++;
-      return "ok";
-    },
+    async () => { calls++; return 'ok'; },
     resolveRetryConfig({ max: 3 }),
   );
-  assert.equal(result, "ok");
+  assert.equal(result, 'ok');
   assert.equal(calls, 1);
 });
 
-test("withRetry retries and succeeds", async () => {
+test('withRetry retries and succeeds', async () => {
   let calls = 0;
   const result = await withRetry(
     async () => {
       calls++;
-      if (calls < 3) throw new Error("transient");
-      return "ok";
+      if (calls < 3) throw new Error('transient');
+      return 'ok';
     },
     resolveRetryConfig({ max: 3, delay_ms: 10 }),
   );
-  assert.equal(result, "ok");
+  assert.equal(result, 'ok');
   assert.equal(calls, 3);
 });
 
-test("withRetry throws after max exhausted", async () => {
+test('withRetry throws after max exhausted', async () => {
   let calls = 0;
   await assert.rejects(
     withRetry(
-      async () => {
-        calls++;
-        throw new Error("always fails");
-      },
+      async () => { calls++; throw new Error('always fails'); },
       resolveRetryConfig({ max: 2, delay_ms: 10 }),
     ),
     /always fails/,
@@ -69,49 +63,46 @@ test("withRetry throws after max exhausted", async () => {
   assert.equal(calls, 2);
 });
 
-test("withRetry never retries external abort errors", async () => {
+test('withRetry never retries external abort errors', async () => {
   let calls = 0;
   const controller = new AbortController();
   controller.abort();
-  const abortErr = new DOMException("aborted", "AbortError");
+  const abortErr = new DOMException('aborted', 'AbortError');
   await assert.rejects(
     withRetry(
-      async () => {
-        calls++;
-        throw abortErr;
-      },
+      async () => { calls++; throw abortErr; },
       resolveRetryConfig({ max: 3, delay_ms: 10 }),
       { signal: controller.signal },
     ),
-    (err: any) => err.name === "AbortError",
+    (err: any) => err.name === 'AbortError',
   );
   assert.equal(calls, 1);
 });
 
-test("withRetry retries per-attempt timeout AbortErrors when external signal is not aborted", async () => {
+test('withRetry retries per-attempt timeout AbortErrors when external signal is not aborted', async () => {
   let calls = 0;
-  const timeoutAbortErr = new DOMException("step timed out", "AbortError");
+  const timeoutAbortErr = new DOMException('step timed out', 'AbortError');
   // No external signal — per-attempt timeout abort should be retriable
   const result = await withRetry(
     async () => {
       calls++;
       if (calls < 3) throw timeoutAbortErr;
-      return "recovered";
+      return 'recovered';
     },
     resolveRetryConfig({ max: 3, delay_ms: 10 }),
   );
-  assert.equal(result, "recovered");
+  assert.equal(result, 'recovered');
   assert.equal(calls, 3);
 });
 
-test("withRetry calls onRetry callback", async () => {
+test('withRetry calls onRetry callback', async () => {
   const retries: number[] = [];
   let calls = 0;
   await withRetry(
     async () => {
       calls++;
-      if (calls < 3) throw new Error("fail");
-      return "ok";
+      if (calls < 3) throw new Error('fail');
+      return 'ok';
     },
     resolveRetryConfig({ max: 3, delay_ms: 10 }),
     { onRetry: (attempt) => retries.push(attempt) },
@@ -122,67 +113,58 @@ test("withRetry calls onRetry callback", async () => {
 // --- Validation tests ---
 
 async function loadWorkflow(workflow: any) {
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
-  const filePath = path.join(tmpDir, "workflow.lobster");
-  await fsp.writeFile(filePath, JSON.stringify(workflow), "utf8");
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
   return loadWorkflowFile(filePath);
 }
 
-test("retry validation rejects non-object", async () => {
+test('retry validation rejects non-object', async () => {
   await assert.rejects(
-    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: "yes" }] }),
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: 'yes' }] }),
     /retry must be an object/,
   );
 });
 
-test("retry validation rejects non-integer max", async () => {
+test('retry validation rejects non-integer max', async () => {
   await assert.rejects(
-    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { max: 1.5 } }] }),
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { max: 1.5 } }] }),
     /retry.max must be a positive integer/,
   );
 });
 
-test("retry validation rejects max < 1", async () => {
+test('retry validation rejects max < 1', async () => {
   await assert.rejects(
-    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { max: 0 } }] }),
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { max: 0 } }] }),
     /retry.max must be a positive integer/,
   );
 });
 
-test("retry validation rejects invalid backoff", async () => {
+test('retry validation rejects invalid backoff', async () => {
   await assert.rejects(
-    loadWorkflow({
-      name: "bad",
-      steps: [{ id: "x", command: "echo", retry: { backoff: "linear" } }],
-    }),
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { backoff: 'linear' } }] }),
     /retry.backoff must be "fixed" or "exponential"/,
   );
 });
 
-test("retry validation rejects negative delay_ms", async () => {
+test('retry validation rejects negative delay_ms', async () => {
   await assert.rejects(
-    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { delay_ms: -1 } }] }),
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { delay_ms: -1 } }] }),
     /retry.delay_ms must be a finite non-negative number/,
   );
 });
 
-test("retry validation rejects non-boolean jitter", async () => {
+test('retry validation rejects non-boolean jitter', async () => {
   await assert.rejects(
-    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { jitter: "yes" } }] }),
+    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { jitter: 'yes' } }] }),
     /retry.jitter must be a boolean/,
   );
 });
 
-test("retry validation accepts valid config", async () => {
+test('retry validation accepts valid config', async () => {
   const wf = await loadWorkflow({
-    name: "ok",
-    steps: [
-      {
-        id: "x",
-        command: "echo",
-        retry: { max: 3, backoff: "exponential", delay_ms: 500, jitter: true },
-      },
-    ],
+    name: 'ok',
+    steps: [{ id: 'x', command: 'echo', retry: { max: 3, backoff: 'exponential', delay_ms: 500, jitter: true } }],
   });
   assert.ok(wf.steps[0].retry);
 });
@@ -190,14 +172,14 @@ test("retry validation accepts valid config", async () => {
 // --- Integration tests ---
 
 async function runWorkflow(workflow: any) {
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
-  const stateDir = path.join(tmpDir, "state");
-  const filePath = path.join(tmpDir, "workflow.lobster");
-  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
 
   const stderrChunks: string[] = [];
   const stderr = new PassThrough();
-  stderr.on("data", (d: Buffer) => stderrChunks.push(d.toString()));
+  stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()));
 
   const result = await runWorkflowFile({
     filePath,
@@ -206,45 +188,41 @@ async function runWorkflow(workflow: any) {
       stdout: process.stdout,
       stderr,
       env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
-      mode: "tool",
+      mode: 'tool',
     },
   });
-  return { result, stderrOutput: stderrChunks.join("") };
+  return { result, stderrOutput: stderrChunks.join('') };
 }
 
-test("step retries and succeeds after transient failure", async () => {
+test('step retries and succeeds after transient failure', async () => {
   // Script that fails twice then succeeds on third run using a counter file
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
-  const counterFile = path.join(tmpDir, "counter");
-  await fsp.writeFile(counterFile, "0", "utf8");
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const counterFile = path.join(tmpDir, 'counter');
+  await fsp.writeFile(counterFile, '0', 'utf8');
 
   const workflow = {
-    name: "retry-succeed",
-    steps: [
-      {
-        id: "flaky",
-        command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){process.exit(1);}process.stdout.write(JSON.stringify({attempt:c}))"`,
-        retry: { max: 3, delay_ms: 50 },
-      },
-    ],
+    name: 'retry-succeed',
+    steps: [{
+      id: 'flaky',
+      command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){process.exit(1);}process.stdout.write(JSON.stringify({attempt:c}))"`,
+      retry: { max: 3, delay_ms: 50 },
+    }],
   };
   const { result, stderrOutput } = await runWorkflow(workflow);
-  assert.equal(result.status, "ok");
+  assert.equal(result.status, 'ok');
   const output = result.output as any[];
   assert.equal(output[0].attempt, 3);
-  assert.ok(stderrOutput.includes("[RETRY]"), "should log retry attempts");
+  assert.ok(stderrOutput.includes('[RETRY]'), 'should log retry attempts');
 });
 
-test("step exhausts retries and throws", async () => {
+test('step exhausts retries and throws', async () => {
   const workflow = {
-    name: "retry-exhaust",
-    steps: [
-      {
-        id: "fail",
-        command: 'node -e "process.exit(1)"',
-        retry: { max: 2, delay_ms: 50 },
-      },
-    ],
+    name: 'retry-exhaust',
+    steps: [{
+      id: 'fail',
+      command: 'node -e "process.exit(1)"',
+      retry: { max: 2, delay_ms: 50 },
+    }],
   };
   await assert.rejects(
     runWorkflow(workflow).then((r) => r.result),
@@ -252,10 +230,10 @@ test("step exhausts retries and throws", async () => {
   );
 });
 
-test("step without retry fails immediately (no retry)", async () => {
+test('step without retry fails immediately (no retry)', async () => {
   const workflow = {
-    name: "no-retry",
-    steps: [{ id: "fail", command: 'node -e "process.exit(1)"' }],
+    name: 'no-retry',
+    steps: [{ id: 'fail', command: 'node -e "process.exit(1)"' }],
   };
   await assert.rejects(
     runWorkflow(workflow).then((r) => r.result),
@@ -263,25 +241,19 @@ test("step without retry fails immediately (no retry)", async () => {
   );
 });
 
-test("dry-run renders retry config", async () => {
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
-  const stateDir = path.join(tmpDir, "state");
-  const filePath = path.join(tmpDir, "workflow.lobster");
+test('dry-run renders retry config', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const stateDir = path.join(tmpDir, 'state');
+  const filePath = path.join(tmpDir, 'workflow.lobster');
   const workflow = {
-    name: "dry-run-retry",
-    steps: [
-      {
-        id: "fetch",
-        command: "curl https://example.com",
-        retry: { max: 3, backoff: "exponential", delay_ms: 1000 },
-      },
-    ],
+    name: 'dry-run-retry',
+    steps: [{ id: 'fetch', command: 'curl https://example.com', retry: { max: 3, backoff: 'exponential', delay_ms: 1000 } }],
   };
-  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
 
   const stderrChunks: string[] = [];
   const stderr = new PassThrough();
-  stderr.on("data", (d: Buffer) => stderrChunks.push(d.toString()));
+  stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()));
 
   await runWorkflowFile({
     filePath,
@@ -290,13 +262,13 @@ test("dry-run renders retry config", async () => {
       stdout: process.stdout,
       stderr,
       env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
-      mode: "tool",
+      mode: 'tool',
       dryRun: true,
     },
   });
 
-  const output = stderrChunks.join("");
-  assert.ok(output.includes("retry:"), "should show retry config");
-  assert.ok(output.includes("3 attempts"), "should show max attempts");
-  assert.ok(output.includes("exponential"), "should show backoff type");
+  const output = stderrChunks.join('');
+  assert.ok(output.includes('retry:'), 'should show retry config');
+  assert.ok(output.includes('3 attempts'), 'should show max attempts');
+  assert.ok(output.includes('exponential'), 'should show backoff type');
 });

--- a/test/step_retry.test.ts
+++ b/test/step_retry.test.ts
@@ -215,6 +215,34 @@ test('step retries and succeeds after transient failure', async () => {
   assert.ok(stderrOutput.includes('[RETRY]'), 'should log retry attempts');
 });
 
+test('step with timeout_ms + retry retries on per-attempt timeout (issue #105)', async () => {
+  // Behavior proof: a step that hangs past timeout_ms on its first two attempts
+  // must be retried (per-attempt timeout produces an AbortError that should NOT
+  // bypass retry) and succeed on the third. Pre-fix, withRetry short-circuited on
+  // any AbortError, so retry.max was inert for timed-out steps and this ran once.
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
+  const counterFile = path.join(tmpDir, 'counter');
+  await fsp.writeFile(counterFile, '0', 'utf8');
+
+  // The counter is incremented synchronously before the hang, so each timed-out
+  // (SIGKILLed) attempt is still recorded. Attempts 1-2 hang 6s (killed by the
+  // 1500ms timeout); attempt 3 returns immediately.
+  const workflow = {
+    name: 'retry-timeout',
+    steps: [{
+      id: 'slow',
+      command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){setTimeout(()=>{},6000);}else{process.stdout.write(JSON.stringify({attempt:c}));}"`,
+      timeout_ms: 1500,
+      retry: { max: 3, delay_ms: 50 },
+    }],
+  };
+  const { result, stderrOutput } = await runWorkflow(workflow);
+  assert.equal(result.status, 'ok');
+  const output = result.output as any[];
+  assert.equal(output[0].attempt, 3);
+  assert.ok(stderrOutput.includes('[RETRY]'), 'should log retry attempts on timeout');
+});
+
 test('step exhausts retries and throws', async () => {
   const workflow = {
     name: 'retry-exhaust',

--- a/test/step_retry.test.ts
+++ b/test/step_retry.test.ts
@@ -225,14 +225,15 @@ test('step with timeout_ms + retry retries on per-attempt timeout (issue #105)',
   await fsp.writeFile(counterFile, '0', 'utf8');
 
   // The counter is incremented synchronously before the hang, so each timed-out
-  // (SIGKILLed) attempt is still recorded. Attempts 1-2 hang 6s (killed by the
-  // 1500ms timeout); attempt 3 returns immediately.
+  // (SIGKILLed) attempt is still recorded. Attempts 1-2 hang 8s (killed by the
+  // 3000ms timeout); attempt 3 returns immediately. The timeout leaves enough
+  // room for slow CI machines to start Node and write the counter before kill.
   const workflow = {
     name: 'retry-timeout',
     steps: [{
       id: 'slow',
       command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){setTimeout(()=>{},6000);}else{process.stdout.write(JSON.stringify({attempt:c}));}"`,
-      timeout_ms: 1500,
+      timeout_ms: 3000,
       retry: { max: 3, delay_ms: 50 },
     }],
   };

--- a/test/step_retry.test.ts
+++ b/test/step_retry.test.ts
@@ -69,8 +69,10 @@ test("withRetry throws after max exhausted", async () => {
   assert.equal(calls, 2);
 });
 
-test("withRetry never retries abort errors", async () => {
+test("withRetry never retries external abort errors", async () => {
   let calls = 0;
+  const controller = new AbortController();
+  controller.abort();
   const abortErr = new DOMException("aborted", "AbortError");
   await assert.rejects(
     withRetry(
@@ -79,10 +81,27 @@ test("withRetry never retries abort errors", async () => {
         throw abortErr;
       },
       resolveRetryConfig({ max: 3, delay_ms: 10 }),
+      { signal: controller.signal },
     ),
     (err: any) => err.name === "AbortError",
   );
   assert.equal(calls, 1);
+});
+
+test("withRetry retries per-attempt timeout AbortErrors when external signal is not aborted", async () => {
+  let calls = 0;
+  const timeoutAbortErr = new DOMException("step timed out", "AbortError");
+  // No external signal — per-attempt timeout abort should be retriable
+  const result = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw timeoutAbortErr;
+      return "recovered";
+    },
+    resolveRetryConfig({ max: 3, delay_ms: 10 }),
+  );
+  assert.equal(result, "recovered");
+  assert.equal(calls, 3);
 });
 
 test("withRetry calls onRetry callback", async () => {

--- a/test/step_retry.test.ts
+++ b/test/step_retry.test.ts
@@ -1,61 +1,67 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { promises as fsp } from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
-import { PassThrough } from 'node:stream';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { PassThrough } from "node:stream";
 
-import { runWorkflowFile, loadWorkflowFile } from '../src/workflows/file.js';
-import { withRetry, resolveRetryConfig } from '../src/core/retry.js';
+import { runWorkflowFile, loadWorkflowFile } from "../src/workflows/file.js";
+import { withRetry, resolveRetryConfig } from "../src/core/retry.js";
 
 // --- Retry utility unit tests ---
 
-test('resolveRetryConfig fills defaults', () => {
+test("resolveRetryConfig fills defaults", () => {
   const config = resolveRetryConfig(undefined);
   assert.equal(config.max, 1);
-  assert.equal(config.backoff, 'fixed');
+  assert.equal(config.backoff, "fixed");
   assert.equal(config.delay_ms, 1000);
   assert.equal(config.max_delay_ms, 30000);
   assert.equal(config.jitter, false);
 });
 
-test('resolveRetryConfig preserves provided values', () => {
-  const config = resolveRetryConfig({ max: 5, backoff: 'exponential', jitter: true });
+test("resolveRetryConfig preserves provided values", () => {
+  const config = resolveRetryConfig({ max: 5, backoff: "exponential", jitter: true });
   assert.equal(config.max, 5);
-  assert.equal(config.backoff, 'exponential');
+  assert.equal(config.backoff, "exponential");
   assert.equal(config.jitter, true);
   assert.equal(config.delay_ms, 1000); // default
 });
 
-test('withRetry succeeds on first try', async () => {
-  let calls = 0;
-  const result = await withRetry(
-    async () => { calls++; return 'ok'; },
-    resolveRetryConfig({ max: 3 }),
-  );
-  assert.equal(result, 'ok');
-  assert.equal(calls, 1);
-});
-
-test('withRetry retries and succeeds', async () => {
+test("withRetry succeeds on first try", async () => {
   let calls = 0;
   const result = await withRetry(
     async () => {
       calls++;
-      if (calls < 3) throw new Error('transient');
-      return 'ok';
+      return "ok";
+    },
+    resolveRetryConfig({ max: 3 }),
+  );
+  assert.equal(result, "ok");
+  assert.equal(calls, 1);
+});
+
+test("withRetry retries and succeeds", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw new Error("transient");
+      return "ok";
     },
     resolveRetryConfig({ max: 3, delay_ms: 10 }),
   );
-  assert.equal(result, 'ok');
+  assert.equal(result, "ok");
   assert.equal(calls, 3);
 });
 
-test('withRetry throws after max exhausted', async () => {
+test("withRetry throws after max exhausted", async () => {
   let calls = 0;
   await assert.rejects(
     withRetry(
-      async () => { calls++; throw new Error('always fails'); },
+      async () => {
+        calls++;
+        throw new Error("always fails");
+      },
       resolveRetryConfig({ max: 2, delay_ms: 10 }),
     ),
     /always fails/,
@@ -63,46 +69,49 @@ test('withRetry throws after max exhausted', async () => {
   assert.equal(calls, 2);
 });
 
-test('withRetry never retries external abort errors', async () => {
+test("withRetry never retries external abort errors", async () => {
   let calls = 0;
   const controller = new AbortController();
   controller.abort();
-  const abortErr = new DOMException('aborted', 'AbortError');
+  const abortErr = new DOMException("aborted", "AbortError");
   await assert.rejects(
     withRetry(
-      async () => { calls++; throw abortErr; },
+      async () => {
+        calls++;
+        throw abortErr;
+      },
       resolveRetryConfig({ max: 3, delay_ms: 10 }),
       { signal: controller.signal },
     ),
-    (err: any) => err.name === 'AbortError',
+    (err: any) => err.name === "AbortError",
   );
   assert.equal(calls, 1);
 });
 
-test('withRetry retries per-attempt timeout AbortErrors when external signal is not aborted', async () => {
+test("withRetry retries per-attempt timeout AbortErrors when external signal is not aborted", async () => {
   let calls = 0;
-  const timeoutAbortErr = new DOMException('step timed out', 'AbortError');
+  const timeoutAbortErr = new DOMException("step timed out", "AbortError");
   // No external signal — per-attempt timeout abort should be retriable
   const result = await withRetry(
     async () => {
       calls++;
       if (calls < 3) throw timeoutAbortErr;
-      return 'recovered';
+      return "recovered";
     },
     resolveRetryConfig({ max: 3, delay_ms: 10 }),
   );
-  assert.equal(result, 'recovered');
+  assert.equal(result, "recovered");
   assert.equal(calls, 3);
 });
 
-test('withRetry calls onRetry callback', async () => {
+test("withRetry calls onRetry callback", async () => {
   const retries: number[] = [];
   let calls = 0;
   await withRetry(
     async () => {
       calls++;
-      if (calls < 3) throw new Error('fail');
-      return 'ok';
+      if (calls < 3) throw new Error("fail");
+      return "ok";
     },
     resolveRetryConfig({ max: 3, delay_ms: 10 }),
     { onRetry: (attempt) => retries.push(attempt) },
@@ -113,58 +122,67 @@ test('withRetry calls onRetry callback', async () => {
 // --- Validation tests ---
 
 async function loadWorkflow(workflow: any) {
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
-  const filePath = path.join(tmpDir, 'workflow.lobster');
-  await fsp.writeFile(filePath, JSON.stringify(workflow), 'utf8');
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
+  const filePath = path.join(tmpDir, "workflow.lobster");
+  await fsp.writeFile(filePath, JSON.stringify(workflow), "utf8");
   return loadWorkflowFile(filePath);
 }
 
-test('retry validation rejects non-object', async () => {
+test("retry validation rejects non-object", async () => {
   await assert.rejects(
-    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: 'yes' }] }),
+    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: "yes" }] }),
     /retry must be an object/,
   );
 });
 
-test('retry validation rejects non-integer max', async () => {
+test("retry validation rejects non-integer max", async () => {
   await assert.rejects(
-    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { max: 1.5 } }] }),
+    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { max: 1.5 } }] }),
     /retry.max must be a positive integer/,
   );
 });
 
-test('retry validation rejects max < 1', async () => {
+test("retry validation rejects max < 1", async () => {
   await assert.rejects(
-    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { max: 0 } }] }),
+    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { max: 0 } }] }),
     /retry.max must be a positive integer/,
   );
 });
 
-test('retry validation rejects invalid backoff', async () => {
+test("retry validation rejects invalid backoff", async () => {
   await assert.rejects(
-    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { backoff: 'linear' } }] }),
+    loadWorkflow({
+      name: "bad",
+      steps: [{ id: "x", command: "echo", retry: { backoff: "linear" } }],
+    }),
     /retry.backoff must be "fixed" or "exponential"/,
   );
 });
 
-test('retry validation rejects negative delay_ms', async () => {
+test("retry validation rejects negative delay_ms", async () => {
   await assert.rejects(
-    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { delay_ms: -1 } }] }),
+    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { delay_ms: -1 } }] }),
     /retry.delay_ms must be a finite non-negative number/,
   );
 });
 
-test('retry validation rejects non-boolean jitter', async () => {
+test("retry validation rejects non-boolean jitter", async () => {
   await assert.rejects(
-    loadWorkflow({ name: 'bad', steps: [{ id: 'x', command: 'echo', retry: { jitter: 'yes' } }] }),
+    loadWorkflow({ name: "bad", steps: [{ id: "x", command: "echo", retry: { jitter: "yes" } }] }),
     /retry.jitter must be a boolean/,
   );
 });
 
-test('retry validation accepts valid config', async () => {
+test("retry validation accepts valid config", async () => {
   const wf = await loadWorkflow({
-    name: 'ok',
-    steps: [{ id: 'x', command: 'echo', retry: { max: 3, backoff: 'exponential', delay_ms: 500, jitter: true } }],
+    name: "ok",
+    steps: [
+      {
+        id: "x",
+        command: "echo",
+        retry: { max: 3, backoff: "exponential", delay_ms: 500, jitter: true },
+      },
+    ],
   });
   assert.ok(wf.steps[0].retry);
 });
@@ -172,14 +190,14 @@ test('retry validation accepts valid config', async () => {
 // --- Integration tests ---
 
 async function runWorkflow(workflow: any) {
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
-  const stateDir = path.join(tmpDir, 'state');
-  const filePath = path.join(tmpDir, 'workflow.lobster');
-  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
+  const stateDir = path.join(tmpDir, "state");
+  const filePath = path.join(tmpDir, "workflow.lobster");
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
 
   const stderrChunks: string[] = [];
   const stderr = new PassThrough();
-  stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()));
+  stderr.on("data", (d: Buffer) => stderrChunks.push(d.toString()));
 
   const result = await runWorkflowFile({
     filePath,
@@ -188,70 +206,76 @@ async function runWorkflow(workflow: any) {
       stdout: process.stdout,
       stderr,
       env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
-      mode: 'tool',
+      mode: "tool",
     },
   });
-  return { result, stderrOutput: stderrChunks.join('') };
+  return { result, stderrOutput: stderrChunks.join("") };
 }
 
-test('step retries and succeeds after transient failure', async () => {
+test("step retries and succeeds after transient failure", async () => {
   // Script that fails twice then succeeds on third run using a counter file
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
-  const counterFile = path.join(tmpDir, 'counter');
-  await fsp.writeFile(counterFile, '0', 'utf8');
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
+  const counterFile = path.join(tmpDir, "counter");
+  await fsp.writeFile(counterFile, "0", "utf8");
 
   const workflow = {
-    name: 'retry-succeed',
-    steps: [{
-      id: 'flaky',
-      command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){process.exit(1);}process.stdout.write(JSON.stringify({attempt:c}))"`,
-      retry: { max: 3, delay_ms: 50 },
-    }],
+    name: "retry-succeed",
+    steps: [
+      {
+        id: "flaky",
+        command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){process.exit(1);}process.stdout.write(JSON.stringify({attempt:c}))"`,
+        retry: { max: 3, delay_ms: 50 },
+      },
+    ],
   };
   const { result, stderrOutput } = await runWorkflow(workflow);
-  assert.equal(result.status, 'ok');
+  assert.equal(result.status, "ok");
   const output = result.output as any[];
   assert.equal(output[0].attempt, 3);
-  assert.ok(stderrOutput.includes('[RETRY]'), 'should log retry attempts');
+  assert.ok(stderrOutput.includes("[RETRY]"), "should log retry attempts");
 });
 
-test('step with timeout_ms + retry retries on per-attempt timeout (issue #105)', async () => {
+test("step with timeout_ms + retry retries on per-attempt timeout (issue #105)", async () => {
   // Behavior proof: a step that hangs past timeout_ms on its first two attempts
   // must be retried (per-attempt timeout produces an AbortError that should NOT
   // bypass retry) and succeed on the third. Pre-fix, withRetry short-circuited on
   // any AbortError, so retry.max was inert for timed-out steps and this ran once.
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
-  const counterFile = path.join(tmpDir, 'counter');
-  await fsp.writeFile(counterFile, '0', 'utf8');
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
+  const counterFile = path.join(tmpDir, "counter");
+  await fsp.writeFile(counterFile, "0", "utf8");
 
   // The counter is incremented synchronously before the hang, so each timed-out
   // (SIGKILLed) attempt is still recorded. Attempts 1-2 hang 8s (killed by the
   // 3000ms timeout); attempt 3 returns immediately. The timeout leaves enough
   // room for slow CI machines to start Node and write the counter before kill.
   const workflow = {
-    name: 'retry-timeout',
-    steps: [{
-      id: 'slow',
-      command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){setTimeout(()=>{},6000);}else{process.stdout.write(JSON.stringify({attempt:c}));}"`,
-      timeout_ms: 3000,
-      retry: { max: 3, delay_ms: 50 },
-    }],
+    name: "retry-timeout",
+    steps: [
+      {
+        id: "slow",
+        command: `node -e "const fs=require('fs');const c=Number(fs.readFileSync('${counterFile}','utf8'))+1;fs.writeFileSync('${counterFile}',String(c));if(c<3){setTimeout(()=>{},6000);}else{process.stdout.write(JSON.stringify({attempt:c}));}"`,
+        timeout_ms: 3000,
+        retry: { max: 3, delay_ms: 50 },
+      },
+    ],
   };
   const { result, stderrOutput } = await runWorkflow(workflow);
-  assert.equal(result.status, 'ok');
+  assert.equal(result.status, "ok");
   const output = result.output as any[];
   assert.equal(output[0].attempt, 3);
-  assert.ok(stderrOutput.includes('[RETRY]'), 'should log retry attempts on timeout');
+  assert.ok(stderrOutput.includes("[RETRY]"), "should log retry attempts on timeout");
 });
 
-test('step exhausts retries and throws', async () => {
+test("step exhausts retries and throws", async () => {
   const workflow = {
-    name: 'retry-exhaust',
-    steps: [{
-      id: 'fail',
-      command: 'node -e "process.exit(1)"',
-      retry: { max: 2, delay_ms: 50 },
-    }],
+    name: "retry-exhaust",
+    steps: [
+      {
+        id: "fail",
+        command: 'node -e "process.exit(1)"',
+        retry: { max: 2, delay_ms: 50 },
+      },
+    ],
   };
   await assert.rejects(
     runWorkflow(workflow).then((r) => r.result),
@@ -259,10 +283,10 @@ test('step exhausts retries and throws', async () => {
   );
 });
 
-test('step without retry fails immediately (no retry)', async () => {
+test("step without retry fails immediately (no retry)", async () => {
   const workflow = {
-    name: 'no-retry',
-    steps: [{ id: 'fail', command: 'node -e "process.exit(1)"' }],
+    name: "no-retry",
+    steps: [{ id: "fail", command: 'node -e "process.exit(1)"' }],
   };
   await assert.rejects(
     runWorkflow(workflow).then((r) => r.result),
@@ -270,19 +294,25 @@ test('step without retry fails immediately (no retry)', async () => {
   );
 });
 
-test('dry-run renders retry config', async () => {
-  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lobster-retry-'));
-  const stateDir = path.join(tmpDir, 'state');
-  const filePath = path.join(tmpDir, 'workflow.lobster');
+test("dry-run renders retry config", async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-retry-"));
+  const stateDir = path.join(tmpDir, "state");
+  const filePath = path.join(tmpDir, "workflow.lobster");
   const workflow = {
-    name: 'dry-run-retry',
-    steps: [{ id: 'fetch', command: 'curl https://example.com', retry: { max: 3, backoff: 'exponential', delay_ms: 1000 } }],
+    name: "dry-run-retry",
+    steps: [
+      {
+        id: "fetch",
+        command: "curl https://example.com",
+        retry: { max: 3, backoff: "exponential", delay_ms: 1000 },
+      },
+    ],
   };
-  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), 'utf8');
+  await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
 
   const stderrChunks: string[] = [];
   const stderr = new PassThrough();
-  stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()));
+  stderr.on("data", (d: Buffer) => stderrChunks.push(d.toString()));
 
   await runWorkflowFile({
     filePath,
@@ -291,13 +321,13 @@ test('dry-run renders retry config', async () => {
       stdout: process.stdout,
       stderr,
       env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
-      mode: 'tool',
+      mode: "tool",
       dryRun: true,
     },
   });
 
-  const output = stderrChunks.join('');
-  assert.ok(output.includes('retry:'), 'should show retry config');
-  assert.ok(output.includes('3 attempts'), 'should show max attempts');
-  assert.ok(output.includes('exponential'), 'should show backoff type');
+  const output = stderrChunks.join("");
+  assert.ok(output.includes("retry:"), "should show retry config");
+  assert.ok(output.includes("3 attempts"), "should show max attempts");
+  assert.ok(output.includes("exponential"), "should show backoff type");
 });


### PR DESCRIPTION
## What

Closes #105.

`withRetry` in `src/core/retry.ts` unconditionally re-threw all `AbortError`s before calling `shouldRetry`, causing any step configured with both `timeout_ms` and `retry` to always run exactly once regardless of `retry.max`. This PR conditions the short-circuit on `options?.signal?.aborted`, so only genuine external workflow cancellation bypasses retry — per-attempt timeout `AbortError`s now flow through `shouldRetry` and the retry policy as documented.

## Why

Reported in #105: a workflow step with `timeout_ms: 100` and `retry: { max: 3 }` made a single attempt and exited — no `[RETRY]` log lines, `retry.max` had no effect. Root cause traced to `src/core/retry.ts:84-86`: the AbortError guard ran before `shouldRetry` could decide whether to retry. Per-step timeouts use an internal `AbortController` that fires an `AbortError`; without context from the external `options.signal`, `withRetry` could not distinguish a per-attempt timeout from an external cancellation.

## How

- **`src/core/retry.ts`** — Change the AbortError short-circuit guard from `if (err?.name === "AbortError" || err?.code === "ABORT_ERR")` to `if ((err?.name === "AbortError" || err?.code === "ABORT_ERR") && options?.signal?.aborted)`. External cancellations (the workflow's `ctx.signal` aborted) still propagate immediately; per-attempt timeout `AbortError`s now fall through to `shouldRetry`.
- **`test/step_retry.test.ts`** — Update the existing `"withRetry never retries abort errors"` unit test to pass an explicitly-aborted `AbortController.signal`, matching the actual external-cancellation path that the guard protects. Add `"withRetry retries per-attempt timeout AbortErrors when external signal is not aborted"` unit test covering the fixed behavior.

## Testing

- [x] **AI-assisted disclosure (per CONTRIBUTING.md):** This PR was authored with AI assistance. Degree of testing: **lightly-tested**
- [x] `pnpm check` passes locally
- [x] `pnpm test:extension` (or relevant lane validation) passes
- [x] `codex review --base origin/main` run; findings: **codex unavailable on this runner — not blocking per CONTRIBUTING.md**

---

> _PR prepared with AI assistance — author reviewed the diff, ran `pnpm check` locally, and accepts feedback or closure if this isn't the right fix or direction._
