### PR TITLE
fix: warn on unknown LLM cost models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Warn when LLM usage records an unknown or missing model ID or invalid `LOBSTER_LLM_PRICING_JSON`, keeping zero-cost fallback behavior visible for `cost_limit` users. Thanks to [@KrasimirKralev](https://github.com/KrasimirKralev) (Issue [#107](https://github.com/openclaw/lobster/issues/107)).
 - Require Node.js 22 or newer for the npm package, matching release CI.
 - Write Lobster state files atomically while preserving restricted file modes, preventing truncated resume/session state after process termination. Thanks to [@KrasimirKralev](https://github.com/KrasimirKralev) (Issues [#108](https://github.com/openclaw/lobster/issues/108), [#109](https://github.com/openclaw/lobster/issues/109), PR [#110](https://github.com/openclaw/lobster/pull/110)).
 - Harden LLM cache files, diff snapshots, and approval ID indexes against truncated JSON after process termination. Disposable cache/snapshot corruption now recovers as a miss, authoritative resume state still surfaces malformed JSON, and approval short-ID indexes are published atomically without overwriting existing mappings. Thanks to [@TurboTheTurtle](https://github.com/TurboTheTurtle) (Issues [#111](https://github.com/openclaw/lobster/issues/111), [#112](https://github.com/openclaw/lobster/issues/112), [#113](https://github.com/openclaw/lobster/issues/113), PR [#114](https://github.com/openclaw/lobster/pull/114)).

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Built-in providers today:
 - `pi` via `LOBSTER_PI_LLM_ADAPTER_URL` (typically supplied by the Pi extension)
 - `http` via `LOBSTER_LLM_ADAPTER_URL`
 
+Workflow `_meta.cost` and `cost_limit` use a static pricing table plus optional overrides from `LOBSTER_LLM_PRICING_JSON`, for example `{"my-model":{"input":1.0,"output":2.0}}` in USD per million tokens. Unknown or missing model IDs still record token counts with zero estimated cost, but Lobster warns on stderr so stale or missing pricing does not fail silently.
+
 `llm_task.invoke` remains available as a backward-compatible alias for the OpenClaw provider.
 
 ### `pipeline:` vs `run:` for LLM calls

--- a/src/core/cost_tracker.ts
+++ b/src/core/cost_tracker.ts
@@ -30,6 +30,9 @@ const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
   "gemini-1.5-flash": { input: 0.075, output: 0.3 },
 };
 
+const INVALID_PRICING_JSON_WARNING =
+  "[WARN] Ignoring invalid LOBSTER_LLM_PRICING_JSON; custom LLM pricing must be a JSON object whose model entries have finite non-negative input and output rates.\n";
+
 function toTokenCount(value: unknown): number {
   const parsed = Number(value ?? 0);
   if (!Number.isFinite(parsed) || parsed < 0) return 0;
@@ -41,8 +44,16 @@ export class CostTracker {
 
   private pricing: Record<string, { input: number; output: number }>;
 
-  constructor(customPricing?: Record<string, { input: number; output: number }>) {
-    this.pricing = { ...DEFAULT_PRICING, ...(customPricing ?? {}) };
+  private stderr?: NodeJS.WritableStream;
+
+  private warnedUnknownModels = new Set<string>();
+
+  constructor(
+    customPricing?: Record<string, { input: number; output: number }>,
+    stderr?: NodeJS.WritableStream,
+  ) {
+    this.pricing = { ...DEFAULT_PRICING, ...customPricing };
+    this.stderr = stderr;
   }
 
   recordUsage(stepId: string, model: string | null, usage: Record<string, unknown>) {
@@ -52,8 +63,17 @@ export class CostTracker {
     const outputTokens = toTokenCount(
       usage.outputTokens ?? usage.output_tokens ?? usage.completion_tokens,
     );
-    const pricing = this.pricing[model ?? ""] ?? { input: 0, output: 0 };
-    const costUsd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
+    const pricingKey = typeof model === "string" && model.trim() ? model : null;
+    const pricing =
+      pricingKey && Object.prototype.hasOwnProperty.call(this.pricing, pricingKey)
+        ? this.pricing[pricingKey]
+        : undefined;
+    if (!pricing) {
+      this.warnUnknownModel(pricingKey ?? "<missing>");
+    }
+    const effectivePricing = pricing ?? { input: 0, output: 0 };
+    const costUsd =
+      (inputTokens * effectivePricing.input + outputTokens * effectivePricing.output) / 1_000_000;
     this.steps.push({ stepId, model, inputTokens, outputTokens, costUsd });
   }
 
@@ -99,13 +119,50 @@ export class CostTracker {
 
   static parsePricingFromEnv(
     env: Record<string, string | undefined>,
+    stderr?: NodeJS.WritableStream,
   ): Record<string, { input: number; output: number }> | undefined {
     const raw = env.LOBSTER_LLM_PRICING_JSON;
     if (!raw) return undefined;
     try {
-      return JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      if (!isPricingMap(parsed)) {
+        stderr?.write(INVALID_PRICING_JSON_WARNING);
+        return undefined;
+      }
+      return parsed;
     } catch {
+      stderr?.write(INVALID_PRICING_JSON_WARNING);
       return undefined;
     }
   }
+
+  private warnUnknownModel(model: string) {
+    if (this.warnedUnknownModels.has(model)) return;
+    this.warnedUnknownModels.add(model);
+    const safeModel = safeJsonString(model);
+    this.stderr?.write(
+      `[WARN] No LLM pricing configured for model ${safeModel}; recording zero cost. Set LOBSTER_LLM_PRICING_JSON to enable cost_limit enforcement for this model.\n`,
+    );
+  }
+}
+
+function isPricingMap(value: unknown): value is Record<string, { input: number; output: number }> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  for (const [model, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!model.trim()) return false;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+    const rates = entry as Record<string, unknown>;
+    if (!isValidRate(rates.input) || !isValidRate(rates.output)) return false;
+  }
+  return true;
+}
+
+function isValidRate(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function safeJsonString(value: string) {
+  return JSON.stringify(value).replace(/[\u007f-\u009f\u2028\u2029]/g, (char) => {
+    return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`;
+  });
 }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -761,7 +761,10 @@ export async function runWorkflowFile({
       return dryRunWorkflow({ steps, resolvedArgs, results, startIndex, ctx });
     }
 
-    const costTracker = new CostTracker(CostTracker.parsePricingFromEnv(ctx.env));
+    const costTracker = new CostTracker(
+      CostTracker.parsePricingFromEnv(ctx.env, ctx.stderr),
+      ctx.stderr,
+    );
     let lastStepId: string | null =
       resumeState?.inputStepId ?? findLastCompletedStepId(steps, results);
 

--- a/test/cost_tracker.test.ts
+++ b/test/cost_tracker.test.ts
@@ -27,11 +27,83 @@ test("CostTracker handles OpenAI token field names", () => {
   assert.equal(summary.totalOutputTokens, 500);
 });
 
-test("CostTracker uses zero cost for unknown models", () => {
-  const tracker = new CostTracker();
+function captureWritable() {
+  const stream = new PassThrough();
+  let output = "";
+  stream.on("data", (d: Buffer | string) => {
+    output += String(d);
+  });
+  return { stream, output: () => output };
+}
+
+test("CostTracker uses zero cost for unknown models and warns once", () => {
+  const stderr = captureWritable();
+  const tracker = new CostTracker(undefined, stderr.stream);
   tracker.recordUsage("step1", "unknown-model", { inputTokens: 1000, outputTokens: 500 });
+  tracker.recordUsage("step2", "unknown-model", { inputTokens: 1000, outputTokens: 500 });
   const summary = tracker.getSummary();
   assert.equal(summary.estimatedCostUsd, 0);
+  assert.equal(
+    stderr.output().match(/No LLM pricing configured for model "unknown-model"/g)?.length,
+    1,
+  );
+});
+
+test("CostTracker warns when usage omits the model id", () => {
+  const stderr = captureWritable();
+  const tracker = new CostTracker({ "": { input: 100, output: 100 } }, stderr.stream);
+  tracker.recordUsage("step1", null, { inputTokens: 1000, outputTokens: 500 });
+  tracker.recordUsage("step2", "", { inputTokens: 1000, outputTokens: 500 });
+  tracker.recordUsage("step3", "   ", { inputTokens: 1000, outputTokens: 500 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.estimatedCostUsd, 0);
+  assert.equal(stderr.output().match(/model "<missing>"/g)?.length, 1);
+});
+
+test("CostTracker treats inherited object keys as unknown model ids", () => {
+  const stderr = captureWritable();
+  const tracker = new CostTracker(undefined, stderr.stream);
+  tracker.recordUsage("step1", "constructor", { inputTokens: 1000, outputTokens: 500 });
+  const summary = tracker.getSummary();
+  assert.equal(summary.estimatedCostUsd, 0);
+  assert.equal(Number.isNaN(summary.byStep[0].costUsd), false);
+  assert.match(stderr.output(), /No LLM pricing configured for model "constructor"/);
+});
+
+test("CostTracker warns when pricing env json is invalid", () => {
+  const stderr = captureWritable();
+  const pricing = CostTracker.parsePricingFromEnv(
+    {
+      LOBSTER_LLM_PRICING_JSON: "{not-json",
+    },
+    stderr.stream,
+  );
+  assert.equal(pricing, undefined);
+  assert.match(stderr.output(), /Ignoring invalid LOBSTER_LLM_PRICING_JSON/);
+});
+
+test("CostTracker rejects structurally invalid pricing env json", () => {
+  const stderr = captureWritable();
+  const pricing = CostTracker.parsePricingFromEnv(
+    {
+      LOBSTER_LLM_PRICING_JSON: '{"my-model":{"input":1.0}}',
+    },
+    stderr.stream,
+  );
+  assert.equal(pricing, undefined);
+  assert.match(stderr.output(), /Ignoring invalid LOBSTER_LLM_PRICING_JSON/);
+});
+
+test("CostTracker rejects blank pricing model keys", () => {
+  const stderr = captureWritable();
+  const pricing = CostTracker.parsePricingFromEnv(
+    {
+      LOBSTER_LLM_PRICING_JSON: '{"":{"input":1.0,"output":2.0}}',
+    },
+    stderr.stream,
+  );
+  assert.equal(pricing, undefined);
+  assert.match(stderr.output(), /Ignoring invalid LOBSTER_LLM_PRICING_JSON/);
 });
 
 test("CostTracker supports custom pricing from env json", () => {
@@ -78,7 +150,7 @@ async function runWorkflow(workflow: unknown, envOverride?: Record<string, strin
       stdin: process.stdin,
       stdout: process.stdout,
       stderr,
-      env: { ...process.env, LOBSTER_STATE_DIR: stateDir, ...(envOverride ?? {}) },
+      env: { ...process.env, LOBSTER_STATE_DIR: stateDir, ...envOverride },
       mode: "tool",
     },
   });
@@ -144,4 +216,68 @@ test("cost_limit stop throws when exceeded", async () => {
       }).then((x) => x.result),
     /Cost limit exceeded/,
   );
+});
+
+test("workflow cost tracking warns for unknown model ids", async () => {
+  const { result, stderrOutput } = await runWorkflow({
+    cost_limit: { max_usd: 0.00001, action: "warn" },
+    steps: [
+      {
+        id: "llm",
+        command:
+          "node -e \"process.stdout.write(JSON.stringify({model:'unknown-model',usage:{inputTokens:1000,outputTokens:1000}}))\"",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "ok");
+  assert.equal(result._meta?.cost?.estimatedCostUsd, 0);
+  assert.match(stderrOutput, /No LLM pricing configured for model "unknown-model"/);
+});
+
+test("workflow cost tracking warns for invalid pricing env json", async () => {
+  const { result, stderrOutput } = await runWorkflow(
+    {
+      steps: [
+        {
+          id: "llm",
+          command:
+            "node -e \"process.stdout.write(JSON.stringify({model:'gpt-4o',usage:{inputTokens:1000,outputTokens:1000}}))\"",
+        },
+      ],
+    },
+    { LOBSTER_LLM_PRICING_JSON: "{not-json" },
+  );
+
+  assert.equal(result.status, "ok");
+  assert.match(stderrOutput, /Ignoring invalid LOBSTER_LLM_PRICING_JSON/);
+});
+
+test("workflow cost tracking warns when usage omits the model id", async () => {
+  const { result, stderrOutput } = await runWorkflow({
+    steps: [
+      {
+        id: "llm",
+        command:
+          'node -e "process.stdout.write(JSON.stringify({usage:{inputTokens:1000,outputTokens:1000}}))"',
+      },
+    ],
+  });
+
+  assert.equal(result.status, "ok");
+  assert.equal(result._meta?.cost?.estimatedCostUsd, 0);
+  assert.match(stderrOutput, /No LLM pricing configured for model "<missing>"/);
+});
+
+test("CostTracker escapes unknown model ids in warnings", () => {
+  const stderr = captureWritable();
+  const tracker = new CostTracker(undefined, stderr.stream);
+  tracker.recordUsage("step1", "bad\n\u001b[31m\u009b31m\u2028next\u2029line", {
+    inputTokens: 1,
+    outputTokens: 1,
+  });
+  assert.ok(stderr.output().includes('"bad\\n\\u001b[31m\\u009b31m\\u2028next\\u2029line"'));
+  assert.equal(stderr.output().includes("\u009b"), false);
+  assert.equal(stderr.output().includes("\u2028"), false);
+  assert.equal(stderr.output().includes("\u2029"), false);
 });


### PR DESCRIPTION
## Summary

- Warn once when LLM usage has an unknown or missing model ID while preserving the existing zero-cost fallback.
- Warn when `LOBSTER_LLM_PRICING_JSON` is invalid or structurally unusable.
- Escape untrusted model IDs before writing warnings to stderr, and document the custom-pricing behavior.

Fixes #107.

## Proof

- `pnpm format && pnpm typecheck && pnpm build >/tmp/lobster-build-107.log && node --test dist/test/cost_tracker.test.js`
- `AGENTS_HOME=/Users/steipete/Projects/agent-skills /Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings
- `pnpm lint && pnpm test` passed; lint command exits 0 and reports only existing warnings outside this focused diff
