### PR TITLE
fix(runtime): cancelled workflows no longer continue external commands

### DIFF
--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -62,6 +62,12 @@ export function runAbortableProcess({
 	notFoundMessage,
 }: RunAbortableProcessOptions): Promise<ProcessResult> {
 	return new Promise((resolve, reject) => {
+		try {
+			signal?.throwIfAborted();
+		} catch (err) {
+			reject(err);
+			return;
+		}
 		const child = spawn(command, argv, {
 			env,
 			cwd,

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -13,7 +13,9 @@ type RunAbortableProcessOptions = {
 	argv: string[];
 	env: NodeJS.ProcessEnv;
 	cwd?: string;
+	stdin?: string | null;
 	signal?: AbortSignal;
+	killSignal?: NodeJS.Signals;
 	notFoundMessage: string;
 };
 
@@ -54,14 +56,16 @@ export function runAbortableProcess({
 	argv,
 	env,
 	cwd,
+	stdin,
 	signal,
+	killSignal,
 	notFoundMessage,
 }: RunAbortableProcessOptions): Promise<ProcessResult> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(command, argv, {
 			env,
 			cwd,
-			stdio: ["ignore", "pipe", "pipe"],
+			stdio: ["pipe", "pipe", "pipe"],
 			// A dedicated POSIX process group lets a cancellation reach helpers
 			// that the CLI spawned and then detached from its own lifecycle.
 			detached: process.platform !== "win32",
@@ -76,6 +80,8 @@ export function runAbortableProcess({
 		let settled = false;
 		child.stdout?.on("data", (data) => (stdout += String(data)));
 		child.stderr?.on("data", (data) => (stderr += String(data)));
+		if (typeof stdin === "string") child.stdin?.write(stdin);
+		child.stdin?.end();
 
 		const cleanup = () => {
 			signal?.removeEventListener("abort", onAbort);
@@ -96,7 +102,15 @@ export function runAbortableProcess({
 		const onAbort = () => {
 			if (settled || cancellation || !signal) return;
 			cancellation = abortError(signal);
-			void terminateProcessTree(child, "SIGTERM");
+			const initialKillSignal = killSignal ?? "SIGTERM";
+			if (initialKillSignal === "SIGKILL") {
+				void terminateProcessTree(child, "SIGKILL").finally(() => {
+					forceKillIssued = true;
+					failCancellationWhenTreeIsStopped();
+				});
+				return;
+			}
+			void terminateProcessTree(child, initialKillSignal);
 			forceKillTimer = setTimeout(() => {
 				forceKillTimer = undefined;
 				void terminateProcessTree(child, "SIGKILL").finally(() => {

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -24,17 +24,21 @@ function abortError(signal: AbortSignal) {
 	return error;
 }
 
-function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals) {
-	if (!child.pid) return;
+function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals): Promise<void> {
+	if (!child.pid) return Promise.resolve();
 
 	if (process.platform === "win32") {
-		const taskkill = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
-			stdio: "ignore",
-			windowsHide: true,
+		return new Promise((resolve) => {
+			const taskkill = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+				stdio: "ignore",
+				windowsHide: true,
+			});
+			taskkill.once("error", () => {
+				child.kill(signal);
+				resolve();
+			});
+			taskkill.once("close", resolve);
 		});
-		taskkill.once("error", () => child.kill(signal));
-		taskkill.unref();
-		return;
 	}
 
 	try {
@@ -42,6 +46,7 @@ function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals) {
 	} catch {
 		child.kill(signal);
 	}
+	return Promise.resolve();
 }
 
 export function runAbortableProcess({
@@ -66,15 +71,21 @@ export function runAbortableProcess({
 		let stderr = "";
 		let cancellation: Error | undefined;
 		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+		let processClosed = false;
+		let forceKillIssued = false;
 		let settled = false;
 		child.stdout?.on("data", (data) => (stdout += String(data)));
 		child.stderr?.on("data", (data) => (stderr += String(data)));
 
 		const cleanup = () => {
 			signal?.removeEventListener("abort", onAbort);
-			// Keep the group-level SIGKILL timer after the direct child has exited:
-			// a descendant may have ignored SIGTERM and still be running.
-			if (!cancellation && forceKillTimer) clearTimeout(forceKillTimer);
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+		};
+		const failCancellationWhenTreeIsStopped = () => {
+			if (!cancellation || !processClosed || !forceKillIssued || settled) return;
+			settled = true;
+			cleanup();
+			reject(cancellation);
 		};
 		const fail = (error: Error) => {
 			if (settled) return;
@@ -85,16 +96,22 @@ export function runAbortableProcess({
 		const onAbort = () => {
 			if (settled || cancellation || !signal) return;
 			cancellation = abortError(signal);
-			terminateProcessTree(child, "SIGTERM");
-			forceKillTimer = setTimeout(
-				() => terminateProcessTree(child, "SIGKILL"),
-				ABORT_FORCE_KILL_AFTER_MS,
-			);
-			forceKillTimer.unref();
+			void terminateProcessTree(child, "SIGTERM");
+			forceKillTimer = setTimeout(() => {
+				forceKillTimer = undefined;
+				void terminateProcessTree(child, "SIGKILL").finally(() => {
+					forceKillIssued = true;
+					failCancellationWhenTreeIsStopped();
+				});
+			}, ABORT_FORCE_KILL_AFTER_MS);
 		};
 
 		child.on("error", (error: NodeJS.ErrnoException) => {
-			if (cancellation) return;
+			if (cancellation) {
+				processClosed = true;
+				failCancellationWhenTreeIsStopped();
+				return;
+			}
 			if (error.code === "ENOENT") {
 				fail(new Error(notFoundMessage));
 				return;
@@ -103,12 +120,13 @@ export function runAbortableProcess({
 		});
 		child.on("close", (code) => {
 			if (settled) return;
-			settled = true;
-			cleanup();
+			processClosed = true;
 			if (cancellation) {
-				reject(cancellation);
+				failCancellationWhenTreeIsStopped();
 				return;
 			}
+			settled = true;
+			cleanup();
 			resolve({ stdout, stderr, code });
 		});
 

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -1,0 +1,120 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+const ABORT_FORCE_KILL_AFTER_MS = 250;
+
+type ProcessResult = {
+	stdout: string;
+	stderr: string;
+	code: number | null;
+};
+
+type RunAbortableProcessOptions = {
+	command: string;
+	argv: string[];
+	env: NodeJS.ProcessEnv;
+	cwd?: string;
+	signal?: AbortSignal;
+	notFoundMessage: string;
+};
+
+function abortError(signal: AbortSignal) {
+	if (signal.reason instanceof Error) return signal.reason;
+	const error = new Error("This operation was aborted");
+	error.name = "AbortError";
+	return error;
+}
+
+function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals) {
+	if (!child.pid) return;
+
+	if (process.platform === "win32") {
+		const taskkill = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		taskkill.once("error", () => child.kill(signal));
+		taskkill.unref();
+		return;
+	}
+
+	try {
+		process.kill(-child.pid, signal);
+	} catch {
+		child.kill(signal);
+	}
+}
+
+export function runAbortableProcess({
+	command,
+	argv,
+	env,
+	cwd,
+	signal,
+	notFoundMessage,
+}: RunAbortableProcessOptions): Promise<ProcessResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, argv, {
+			env,
+			cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+			// A dedicated POSIX process group lets a cancellation reach helpers
+			// that the CLI spawned and then detached from its own lifecycle.
+			detached: process.platform !== "win32",
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let cancellation: Error | undefined;
+		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+		let settled = false;
+		child.stdout?.on("data", (data) => (stdout += String(data)));
+		child.stderr?.on("data", (data) => (stderr += String(data)));
+
+		const cleanup = () => {
+			signal?.removeEventListener("abort", onAbort);
+			// Keep the group-level SIGKILL timer after the direct child has exited:
+			// a descendant may have ignored SIGTERM and still be running.
+			if (!cancellation && forceKillTimer) clearTimeout(forceKillTimer);
+		};
+		const fail = (error: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(error);
+		};
+		const onAbort = () => {
+			if (settled || cancellation || !signal) return;
+			cancellation = abortError(signal);
+			terminateProcessTree(child, "SIGTERM");
+			forceKillTimer = setTimeout(
+				() => terminateProcessTree(child, "SIGKILL"),
+				ABORT_FORCE_KILL_AFTER_MS,
+			);
+			forceKillTimer.unref();
+		};
+
+		child.on("error", (error: NodeJS.ErrnoException) => {
+			if (cancellation) return;
+			if (error.code === "ENOENT") {
+				fail(new Error(notFoundMessage));
+				return;
+			}
+			fail(error);
+		});
+		child.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			if (cancellation) {
+				reject(cancellation);
+				return;
+			}
+			resolve({ stdout, stderr, code });
+		});
+
+		if (signal) {
+			signal.addEventListener("abort", onAbort, { once: true });
+			if (signal.aborted) onAbort();
+		}
+	});
+}

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -78,8 +78,10 @@ export function runAbortableProcess({
 		let processClosed = false;
 		let forceKillIssued = false;
 		let settled = false;
-		child.stdout?.on("data", (data) => (stdout += String(data)));
-		child.stderr?.on("data", (data) => (stderr += String(data)));
+		child.stdout?.setEncoding("utf8");
+		child.stderr?.setEncoding("utf8");
+		child.stdout?.on("data", (data) => (stdout += data));
+		child.stderr?.on("data", (data) => (stderr += data));
 		if (typeof stdin === "string") child.stdin?.write(stdin);
 		child.stdin?.end();
 

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -16,6 +16,8 @@ type RunAbortableProcessOptions = {
 	stdin?: string | null;
 	signal?: AbortSignal;
 	killSignal?: NodeJS.Signals;
+	maxOutputBytes?: number;
+	outputLimitMessage?: string;
 	notFoundMessage: string;
 };
 
@@ -59,9 +61,18 @@ export function runAbortableProcess({
 	stdin,
 	signal,
 	killSignal,
+	maxOutputBytes,
+	outputLimitMessage,
 	notFoundMessage,
 }: RunAbortableProcessOptions): Promise<ProcessResult> {
 	return new Promise((resolve, reject) => {
+		if (
+			maxOutputBytes !== undefined &&
+			(!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 0)
+		) {
+			reject(new Error("maxOutputBytes must be a non-negative safe integer"));
+			return;
+		}
 		try {
 			signal?.throwIfAborted();
 		} catch (err) {
@@ -72,34 +83,30 @@ export function runAbortableProcess({
 			env,
 			cwd,
 			stdio: ["pipe", "pipe", "pipe"],
-			// A dedicated POSIX process group lets a cancellation reach helpers
-			// that the CLI spawned and then detached from its own lifecycle.
-			detached: process.platform !== "win32",
+			// Create a dedicated POSIX process group only when this runner owns a
+			// cancellation signal for it. Direct APIs without one must retain the
+			// caller's terminal process group so Ctrl-C still reaches their child.
+			detached: process.platform !== "win32" && signal !== undefined,
 		});
 
 		let stdout = "";
 		let stderr = "";
-		let cancellation: Error | undefined;
+		let stdoutBytes = 0;
+		let stderrBytes = 0;
+		let terminationError: Error | undefined;
 		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 		let processClosed = false;
 		let forceKillIssued = false;
 		let settled = false;
-		child.stdout?.setEncoding("utf8");
-		child.stderr?.setEncoding("utf8");
-		child.stdout?.on("data", (data) => (stdout += data));
-		child.stderr?.on("data", (data) => (stderr += data));
-		if (typeof stdin === "string") child.stdin?.write(stdin);
-		child.stdin?.end();
-
 		const cleanup = () => {
 			signal?.removeEventListener("abort", onAbort);
 			if (forceKillTimer) clearTimeout(forceKillTimer);
 		};
-		const failCancellationWhenTreeIsStopped = () => {
-			if (!cancellation || !processClosed || !forceKillIssued || settled) return;
+		const failTerminationWhenTreeIsStopped = () => {
+			if (!terminationError || !processClosed || !forceKillIssued || settled) return;
 			settled = true;
 			cleanup();
-			reject(cancellation);
+			reject(terminationError);
 		};
 		const fail = (error: Error) => {
 			if (settled) return;
@@ -107,14 +114,13 @@ export function runAbortableProcess({
 			cleanup();
 			reject(error);
 		};
-		const onAbort = () => {
-			if (settled || cancellation || !signal) return;
-			cancellation = abortError(signal);
-			const initialKillSignal = killSignal ?? "SIGTERM";
+		const startTermination = (error: Error, initialKillSignal = killSignal ?? "SIGTERM") => {
+			if (settled || terminationError) return;
+			terminationError = error;
 			if (initialKillSignal === "SIGKILL") {
 				void terminateProcessTree(child, "SIGKILL").finally(() => {
 					forceKillIssued = true;
-					failCancellationWhenTreeIsStopped();
+					failTerminationWhenTreeIsStopped();
 				});
 				return;
 			}
@@ -123,15 +129,43 @@ export function runAbortableProcess({
 				forceKillTimer = undefined;
 				void terminateProcessTree(child, "SIGKILL").finally(() => {
 					forceKillIssued = true;
-					failCancellationWhenTreeIsStopped();
+					failTerminationWhenTreeIsStopped();
 				});
 			}, ABORT_FORCE_KILL_AFTER_MS);
 		};
+		const onAbort = () => {
+			if (!signal) return;
+			startTermination(abortError(signal));
+		};
+		const appendOutput = (stream: "stdout" | "stderr", data: string) => {
+			const bytes = Buffer.byteLength(data);
+			const total = stream === "stdout" ? stdoutBytes + bytes : stderrBytes + bytes;
+			if (maxOutputBytes !== undefined && total > maxOutputBytes) {
+				startTermination(
+					new Error(outputLimitMessage ?? `Process output exceeded ${maxOutputBytes} bytes`),
+				);
+				return;
+			}
+			if (stream === "stdout") {
+				stdoutBytes = total;
+				stdout += data;
+			} else {
+				stderrBytes = total;
+				stderr += data;
+			}
+		};
+
+		child.stdout?.setEncoding("utf8");
+		child.stderr?.setEncoding("utf8");
+		child.stdout?.on("data", (data: string) => appendOutput("stdout", data));
+		child.stderr?.on("data", (data: string) => appendOutput("stderr", data));
+		if (typeof stdin === "string") child.stdin?.write(stdin);
+		child.stdin?.end();
 
 		child.on("error", (error: NodeJS.ErrnoException) => {
-			if (cancellation) {
+			if (terminationError) {
 				processClosed = true;
-				failCancellationWhenTreeIsStopped();
+				failTerminationWhenTreeIsStopped();
 				return;
 			}
 			if (error.code === "ENOENT") {
@@ -143,8 +177,8 @@ export function runAbortableProcess({
 		child.on("close", (code) => {
 			if (settled) return;
 			processClosed = true;
-			if (cancellation) {
-				failCancellationWhenTreeIsStopped();
+			if (terminationError) {
+				failTerminationWhenTreeIsStopped();
 				return;
 			}
 			settled = true;

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 
 const ABORT_FORCE_KILL_AFTER_MS = 250;
+const forceTerminationCallbacks = new WeakMap<AbortSignal, Set<() => void>>();
 
 type ProcessResult = {
 	stdout: string;
@@ -15,11 +16,15 @@ type RunAbortableProcessOptions = {
 	cwd?: string;
 	stdin?: string | null;
 	signal?: AbortSignal;
-	killSignal?: NodeJS.Signals;
+	killSignal?: NodeJS.Signals | (() => NodeJS.Signals | undefined);
 	maxOutputBytes?: number;
 	outputLimitMessage?: string;
 	notFoundMessage: string;
 };
+
+export function forceTerminateAbortableProcesses(signal: AbortSignal) {
+	for (const terminate of forceTerminationCallbacks.get(signal) ?? []) terminate();
+}
 
 function abortError(signal: AbortSignal) {
 	if (signal.reason instanceof Error) return signal.reason;
@@ -96,11 +101,15 @@ export function runAbortableProcess({
 		let terminationError: Error | undefined;
 		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 		let processClosed = false;
+		let forceKillRequested = false;
 		let forceKillIssued = false;
 		let settled = false;
+		let forceTerminationListeners: Set<() => void> | undefined;
+		let forceTerminate: (() => void) | undefined;
 		const cleanup = () => {
 			signal?.removeEventListener("abort", onAbort);
 			if (forceKillTimer) clearTimeout(forceKillTimer);
+			if (forceTerminate) forceTerminationListeners?.delete(forceTerminate);
 		};
 		const failTerminationWhenTreeIsStopped = () => {
 			if (!terminationError || !processClosed || !forceKillIssued || settled) return;
@@ -114,24 +123,39 @@ export function runAbortableProcess({
 			cleanup();
 			reject(error);
 		};
-		const startTermination = (error: Error, initialKillSignal = killSignal ?? "SIGTERM") => {
+		const forceKill = () => {
+			if (forceKillRequested) return;
+			forceKillRequested = true;
+			void terminateProcessTree(child, "SIGKILL").finally(() => {
+				forceKillIssued = true;
+				failTerminationWhenTreeIsStopped();
+			});
+		};
+		const startTermination = (error: Error) => {
 			if (settled || terminationError) return;
 			terminationError = error;
+			const initialKillSignal =
+				(typeof killSignal === "function" ? killSignal() : killSignal) ?? "SIGTERM";
 			if (initialKillSignal === "SIGKILL") {
-				void terminateProcessTree(child, "SIGKILL").finally(() => {
-					forceKillIssued = true;
-					failTerminationWhenTreeIsStopped();
-				});
+				forceKill();
 				return;
 			}
 			void terminateProcessTree(child, initialKillSignal);
 			forceKillTimer = setTimeout(() => {
 				forceKillTimer = undefined;
-				void terminateProcessTree(child, "SIGKILL").finally(() => {
-					forceKillIssued = true;
-					failTerminationWhenTreeIsStopped();
-				});
+				forceKill();
 			}, ABORT_FORCE_KILL_AFTER_MS);
+		};
+		forceTerminate = () => {
+			if (settled) return;
+			if (!terminationError) {
+				terminationError = signal ? abortError(signal) : new Error("Process termination requested");
+			}
+			if (forceKillTimer) {
+				clearTimeout(forceKillTimer);
+				forceKillTimer = undefined;
+			}
+			forceKill();
 		};
 		const onAbort = () => {
 			if (!signal) return;
@@ -187,6 +211,12 @@ export function runAbortableProcess({
 		});
 
 		if (signal) {
+			forceTerminationListeners = forceTerminationCallbacks.get(signal);
+			if (!forceTerminationListeners) {
+				forceTerminationListeners = new Set();
+				forceTerminationCallbacks.set(signal, forceTerminationListeners);
+			}
+			forceTerminationListeners.add(forceTerminate);
 			signal.addEventListener("abort", onAbort, { once: true });
 			if (signal.aborted) onAbort();
 		}

--- a/src/abortable_process.ts
+++ b/src/abortable_process.ts
@@ -16,6 +16,7 @@ type RunAbortableProcessOptions = {
 	cwd?: string;
 	stdin?: string | null;
 	signal?: AbortSignal;
+	forceTerminationSignal?: AbortSignal;
 	killSignal?: NodeJS.Signals | (() => NodeJS.Signals | undefined);
 	maxOutputBytes?: number;
 	outputLimitMessage?: string;
@@ -65,6 +66,7 @@ export function runAbortableProcess({
 	cwd,
 	stdin,
 	signal,
+	forceTerminationSignal,
 	killSignal,
 	maxOutputBytes,
 	outputLimitMessage,
@@ -104,12 +106,14 @@ export function runAbortableProcess({
 		let forceKillRequested = false;
 		let forceKillIssued = false;
 		let settled = false;
-		let forceTerminationListeners: Set<() => void> | undefined;
+		const forceTerminationRegistrations: Set<() => void>[] = [];
 		let forceTerminate: (() => void) | undefined;
 		const cleanup = () => {
 			signal?.removeEventListener("abort", onAbort);
 			if (forceKillTimer) clearTimeout(forceKillTimer);
-			if (forceTerminate) forceTerminationListeners?.delete(forceTerminate);
+			if (forceTerminate) {
+				for (const listeners of forceTerminationRegistrations) listeners.delete(forceTerminate);
+			}
 		};
 		const failTerminationWhenTreeIsStopped = () => {
 			if (!terminationError || !processClosed || !forceKillIssued || settled) return;
@@ -210,13 +214,21 @@ export function runAbortableProcess({
 			resolve({ stdout, stderr, code });
 		});
 
-		if (signal) {
-			forceTerminationListeners = forceTerminationCallbacks.get(signal);
-			if (!forceTerminationListeners) {
-				forceTerminationListeners = new Set();
-				forceTerminationCallbacks.set(signal, forceTerminationListeners);
+		for (const registrationSignal of new Set(
+			[signal, forceTerminationSignal].filter(
+				(candidate): candidate is AbortSignal => candidate !== undefined,
+			),
+		)) {
+			let listeners = forceTerminationCallbacks.get(registrationSignal);
+			if (!listeners) {
+				listeners = new Set();
+				forceTerminationCallbacks.set(registrationSignal, listeners);
 			}
-			forceTerminationListeners.add(forceTerminate);
+			listeners.add(forceTerminate);
+			forceTerminationRegistrations.push(listeners);
+		}
+
+		if (signal) {
 			signal.addEventListener("abort", onAbort, { once: true });
 			if (signal.aborted) onAbort();
 		}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,19 @@ import {
 } from "./pipeline_resume_state.js";
 
 export async function runCli(argv) {
+	const cancellation = createCliCancellation();
+	try {
+		await runCliWithSignal(argv, cancellation.signal);
+	} finally {
+		cancellation.dispose();
+	}
+
+	if (cancellation.exitCode !== undefined) {
+		process.exitCode = cancellation.exitCode;
+	}
+}
+
+async function runCliWithSignal(argv, signal: AbortSignal) {
 	const registry = createDefaultRegistry();
 
 	if (argv.length === 0 || argv.includes("-h") || argv.includes("--help")) {
@@ -48,7 +61,7 @@ export async function runCli(argv) {
 	}
 
 	if (argv[0] === "doctor") {
-		await handleDoctor({ argv: argv.slice(1), registry });
+		await handleDoctor({ argv: argv.slice(1), registry, signal });
 		return;
 	}
 
@@ -58,17 +71,43 @@ export async function runCli(argv) {
 	}
 
 	if (argv[0] === "run") {
-		await handleRun({ argv: argv.slice(1), registry });
+		await handleRun({ argv: argv.slice(1), registry, signal });
 		return;
 	}
 
 	if (argv[0] === "resume") {
-		await handleResume({ argv: argv.slice(1), registry });
+		await handleResume({ argv: argv.slice(1), registry, signal });
 		return;
 	}
 
 	// Default: treat argv as a pipeline string.
-	await handleRun({ argv, registry });
+	await handleRun({ argv, registry, signal });
+}
+
+function createCliCancellation() {
+	const controller = new AbortController();
+	let received: NodeJS.Signals | undefined;
+	const abort = (receivedSignal: NodeJS.Signals) => {
+		if (received) return;
+		received = receivedSignal;
+		controller.abort(new Error(`Received ${receivedSignal}`));
+	};
+	const onSigint = () => abort("SIGINT");
+	const onSigterm = () => abort("SIGTERM");
+	process.once("SIGINT", onSigint);
+	process.once("SIGTERM", onSigterm);
+
+	return {
+		signal: controller.signal,
+		get exitCode() {
+			if (!received) return undefined;
+			return received === "SIGINT" ? 130 : 143;
+		},
+		dispose() {
+			process.removeListener("SIGINT", onSigint);
+			process.removeListener("SIGTERM", onSigterm);
+		},
+	};
 }
 
 async function handleGraph({ argv }) {
@@ -132,7 +171,7 @@ function isWorkflowGraphFormat(value: string): value is WorkflowGraphFormat {
 	return value === "mermaid" || value === "dot" || value === "ascii";
 }
 
-async function handleRun({ argv, registry }) {
+async function handleRun({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
 	const parsed = parseRunArgs(argv);
 	const { mode, argsJson } = parsed;
 	const normalizedMode = normalizeMode(mode);
@@ -173,6 +212,7 @@ async function handleRun({ argv, registry }) {
 					mode: normalizedMode,
 					registry,
 					dryRun,
+					signal,
 				},
 			});
 
@@ -276,6 +316,7 @@ async function handleRun({ argv, registry }) {
 			env: process.env,
 			mode: normalizedMode,
 			dryRun,
+			signal,
 		});
 
 		if (normalizedMode === "tool") {
@@ -283,6 +324,7 @@ async function handleRun({ argv, registry }) {
 				env: process.env,
 				pipeline,
 				output,
+				signal,
 			});
 			writeToolEnvelope({
 				ok: true,
@@ -504,7 +546,7 @@ async function resolveWorkflowFile(candidate) {
 	return resolved;
 }
 
-async function handleResume({ argv, registry }) {
+async function handleResume({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
 	const mode = "tool";
 	let approved: boolean | undefined;
 	let response: unknown = undefined;
@@ -573,6 +615,7 @@ async function handleResume({ argv, registry }) {
 					env: process.env,
 					mode: "tool",
 					registry,
+					signal,
 				},
 				resume: payload,
 				approved,
@@ -737,13 +780,14 @@ async function handleResume({ argv, registry }) {
 			mode,
 			input,
 			requestInputResume,
+			signal,
 		});
-		await cleanupIndex();
 		const finalized = await finalizePipelineToolRun({
 			env: process.env,
 			pipeline: remaining,
 			output,
 			previousStateKey,
+			signal,
 		});
 		writeToolEnvelope({
 			ok: true,
@@ -773,7 +817,7 @@ async function readVersion() {
 	return pkg.version ?? "0.0.0";
 }
 
-async function handleDoctor({ argv, registry }) {
+async function handleDoctor({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
 	const mode = "tool";
 	const pipeline = "exec --json --shell 'echo [1]'";
 	const output: any = await (async () => {
@@ -788,6 +832,7 @@ async function handleDoctor({ argv, registry }) {
 				stderr: process.stderr,
 				env: process.env,
 				mode,
+				signal,
 			});
 		} catch (err: any) {
 			return { error: err };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { loadWorkflowFile, resolveWorkflowArgs, runWorkflowFile } from "./workfl
 import { renderWorkflowGraph } from "./workflows/graph.js";
 import type { WorkflowGraphFormat } from "./workflows/graph.js";
 import { finalizePipelineToolRun } from "./pipeline_resume_state.js";
+import { forceTerminateAbortableProcesses } from "./abortable_process.js";
 
 export async function runCli(argv) {
 	const cancellation = createCliCancellation();
@@ -76,25 +77,39 @@ async function runCliWithSignal(argv, signal: AbortSignal) {
 function createCliCancellation() {
 	const controller = new AbortController();
 	let received: NodeJS.Signals | undefined;
+	const terminatingSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"];
 	const abort = (receivedSignal: NodeJS.Signals) => {
-		if (received) return;
+		if (received) {
+			forceTerminateAbortableProcesses(controller.signal);
+			return;
+		}
 		received = receivedSignal;
 		controller.abort(new Error(`Received ${receivedSignal}`));
 	};
-	const onSigint = () => abort("SIGINT");
-	const onSigterm = () => abort("SIGTERM");
-	process.once("SIGINT", onSigint);
-	process.once("SIGTERM", onSigterm);
+	const listeners = new Map<NodeJS.Signals, () => void>();
+	for (const terminatingSignal of terminatingSignals) {
+		const listener = () => abort(terminatingSignal);
+		listeners.set(terminatingSignal, listener);
+		process.on(terminatingSignal, listener);
+	}
 
 	return {
 		signal: controller.signal,
 		get exitCode() {
 			if (!received) return undefined;
-			return received === "SIGINT" ? 130 : 143;
+			return (
+				{
+					SIGINT: 130,
+					SIGHUP: 129,
+					SIGQUIT: 131,
+					SIGTERM: 143,
+				} as const
+			)[received];
 		},
 		dispose() {
-			process.removeListener("SIGINT", onSigint);
-			process.removeListener("SIGTERM", onSigterm);
+			for (const [terminatingSignal, listener] of listeners) {
+				process.removeListener(terminatingSignal, listener);
+			}
 		},
 	};
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { forceTerminateAbortableProcesses } from "./abortable_process.js";
 export async function runCli(argv) {
 	const cancellation = createCliCancellation();
 	try {
-		await runCliWithSignal(argv, cancellation.signal);
+		await runCliWithSignal(argv, cancellation.signal, cancellation.signal);
 	} finally {
 		if (cancellation.exitCode !== undefined) {
 			process.exitCode = cancellation.exitCode;
@@ -21,7 +21,11 @@ export async function runCli(argv) {
 	}
 }
 
-async function runCliWithSignal(argv, signal: AbortSignal) {
+async function runCliWithSignal(
+	argv,
+	signal: AbortSignal,
+	forceTerminationSignal: AbortSignal = signal,
+) {
 	const registry = createDefaultRegistry();
 
 	if (argv.length === 0 || argv.includes("-h") || argv.includes("--help")) {
@@ -51,7 +55,7 @@ async function runCliWithSignal(argv, signal: AbortSignal) {
 	}
 
 	if (argv[0] === "doctor") {
-		await handleDoctor({ argv: argv.slice(1), registry, signal });
+		await handleDoctor({ argv: argv.slice(1), registry, signal, forceTerminationSignal });
 		return;
 	}
 
@@ -61,17 +65,17 @@ async function runCliWithSignal(argv, signal: AbortSignal) {
 	}
 
 	if (argv[0] === "run") {
-		await handleRun({ argv: argv.slice(1), registry, signal });
+		await handleRun({ argv: argv.slice(1), registry, signal, forceTerminationSignal });
 		return;
 	}
 
 	if (argv[0] === "resume") {
-		await handleResume({ argv: argv.slice(1), registry, signal });
+		await handleResume({ argv: argv.slice(1), registry, signal, forceTerminationSignal });
 		return;
 	}
 
 	// Default: treat argv as a pipeline string.
-	await handleRun({ argv, registry, signal });
+	await handleRun({ argv, registry, signal, forceTerminationSignal });
 }
 
 function createCliCancellation() {
@@ -175,7 +179,17 @@ function isWorkflowGraphFormat(value: string): value is WorkflowGraphFormat {
 	return value === "mermaid" || value === "dot" || value === "ascii";
 }
 
-async function handleRun({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
+async function handleRun({
+	argv,
+	registry,
+	signal,
+	forceTerminationSignal,
+}: {
+	argv;
+	registry;
+	signal: AbortSignal;
+	forceTerminationSignal: AbortSignal;
+}) {
 	const parsed = parseRunArgs(argv);
 	const { mode, argsJson } = parsed;
 	const normalizedMode = normalizeMode(mode);
@@ -217,6 +231,7 @@ async function handleRun({ argv, registry, signal }: { argv; registry; signal: A
 					registry,
 					dryRun,
 					signal,
+					forceTerminationSignal,
 				},
 			});
 
@@ -321,6 +336,7 @@ async function handleRun({ argv, registry, signal }: { argv; registry; signal: A
 			mode: normalizedMode,
 			dryRun,
 			signal,
+			forceTerminationSignal,
 			haltAfterStageOnAbort: true,
 		});
 
@@ -551,7 +567,17 @@ async function resolveWorkflowFile(candidate) {
 	return resolved;
 }
 
-async function handleResume({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
+async function handleResume({
+	argv,
+	registry,
+	signal,
+	forceTerminationSignal,
+}: {
+	argv;
+	registry;
+	signal: AbortSignal;
+	forceTerminationSignal: AbortSignal;
+}) {
 	let parsed;
 	try {
 		parsed = parseResumeArgs(argv);
@@ -581,6 +607,7 @@ async function handleResume({ argv, registry, signal }: { argv; registry; signal
 				stderr: process.stderr,
 				registry,
 				signal,
+				forceTerminationSignal,
 			},
 		});
 	} catch (err: any) {
@@ -606,7 +633,17 @@ async function readVersion() {
 	return pkg.version ?? "0.0.0";
 }
 
-async function handleDoctor({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
+async function handleDoctor({
+	argv,
+	registry,
+	signal,
+	forceTerminationSignal,
+}: {
+	argv;
+	registry;
+	signal: AbortSignal;
+	forceTerminationSignal: AbortSignal;
+}) {
 	const mode = "tool";
 	const pipeline = "exec --json --shell 'echo [1]'";
 	const output: any = await (async () => {
@@ -622,6 +659,7 @@ async function handleDoctor({ argv, registry, signal }: { argv; registry; signal
 				env: process.env,
 				mode,
 				signal,
+				forceTerminationSignal,
 				haltAfterStageOnAbort: true,
 			});
 		} catch (err: any) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,11 +13,10 @@ export async function runCli(argv) {
 	try {
 		await runCliWithSignal(argv, cancellation.signal);
 	} finally {
+		if (cancellation.exitCode !== undefined) {
+			process.exitCode = cancellation.exitCode;
+		}
 		cancellation.dispose();
-	}
-
-	if (cancellation.exitCode !== undefined) {
-		process.exitCode = cancellation.exitCode;
 	}
 }
 
@@ -550,23 +549,31 @@ async function handleResume({ argv, registry, signal }: { argv; registry; signal
 		return;
 	}
 
-	const envelope = await resumeToolRequest({
-		token: parsed.token ?? undefined,
-		approvalId: parsed.approvalId ?? undefined,
-		approved: parsed.approved,
-		response: parsed.response,
-		cancel: parsed.cancel,
-		ctx: {
-			cwd: process.cwd(),
-			env: process.env,
-			mode: "tool",
-			stdin: process.stdin,
-			stdout: process.stdout,
-			stderr: process.stderr,
-			registry,
-			signal,
-		},
-	});
+	let envelope;
+	try {
+		envelope = await resumeToolRequest({
+			token: parsed.token ?? undefined,
+			approvalId: parsed.approvalId ?? undefined,
+			approved: parsed.approved,
+			response: parsed.response,
+			cancel: parsed.cancel,
+			ctx: {
+				cwd: process.cwd(),
+				env: process.env,
+				mode: "tool",
+				stdin: process.stdin,
+				stdout: process.stdout,
+				stderr: process.stderr,
+				registry,
+				signal,
+			},
+		});
+	} catch (err: any) {
+		envelope = {
+			ok: false,
+			error: { type: "runtime_error", message: err?.message ?? String(err) },
+		};
+	}
 	writeToolEnvelope(envelope);
 	if (!envelope.ok) {
 		process.exitCode = envelope.error?.type === "parse_error" ? 2 : 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,22 +1,12 @@
 import { parsePipeline } from "./parser.js";
 import { createDefaultRegistry } from "./commands/registry.js";
 import { runPipeline } from "./runtime.js";
-import { decodeResumeToken, parseResumeArgs, resolveApprovalId } from "./resume.js";
-import { cleanupApprovalIndexByStateKey, deleteApprovalId } from "./state/store.js";
-import {
-	WorkflowResumeArgumentError,
-	loadWorkflowFile,
-	resolveWorkflowArgs,
-	runWorkflowFile,
-} from "./workflows/file.js";
+import { parseResumeArgs } from "./resume.js";
+import { resumeToolRequest } from "./core/tool_runtime.js";
+import { loadWorkflowFile, resolveWorkflowArgs, runWorkflowFile } from "./workflows/file.js";
 import { renderWorkflowGraph } from "./workflows/graph.js";
 import type { WorkflowGraphFormat } from "./workflows/graph.js";
-import { deleteStateJson } from "./state/store.js";
-import {
-	finalizePipelineToolRun,
-	loadPipelineResumeState,
-	validatePipelineInputResponse,
-} from "./pipeline_resume_state.js";
+import { finalizePipelineToolRun } from "./pipeline_resume_state.js";
 
 export async function runCli(argv) {
 	const cancellation = createCliCancellation();
@@ -317,6 +307,7 @@ async function handleRun({ argv, registry, signal }: { argv; registry; signal: A
 			mode: normalizedMode,
 			dryRun,
 			signal,
+			haltAfterStageOnAbort: true,
 		});
 
 		if (normalizedMode === "tool") {
@@ -547,27 +538,9 @@ async function resolveWorkflowFile(candidate) {
 }
 
 async function handleResume({ argv, registry, signal }: { argv; registry; signal: AbortSignal }) {
-	const mode = "tool";
-	let approved: boolean | undefined;
-	let response: unknown = undefined;
-	let cancel = false;
-	let payload: any;
-	let resolvedApprovalId: string | null = null;
+	let parsed;
 	try {
-		const parsed = parseResumeArgs(argv);
-		approved = parsed.approved;
-		response = parsed.response;
-		cancel = parsed.cancel === true;
-		resolvedApprovalId = parsed.approvalId;
-
-		// Resolve short approval ID to token if provided
-		let token: string;
-		if (parsed.approvalId) {
-			token = await resolveApprovalId(parsed.approvalId, process.env);
-		} else {
-			token = parsed.token!;
-		}
-		payload = decodeResumeToken(token);
+		parsed = parseResumeArgs(argv);
 	} catch (err) {
 		writeToolEnvelope({
 			ok: false,
@@ -577,232 +550,26 @@ async function handleResume({ argv, registry, signal }: { argv; registry; signal
 		return;
 	}
 
-	// Helper: clean up approval ID index after successful use
-	const cleanupIndex = async () => {
-		if (resolvedApprovalId) {
-			await deleteApprovalId({ env: process.env, approvalId: resolvedApprovalId });
-		} else if (payload.stateKey) {
-			await cleanupApprovalIndexByStateKey({ env: process.env, stateKey: payload.stateKey });
-		}
-	};
-
-	if (cancel === true) {
-		await cleanupIndex();
-		if (payload.kind === "workflow-file" && payload.stateKey) {
-			await deleteStateJson({ env: process.env, key: payload.stateKey });
-		}
-		if (payload.kind === "pipeline-resume" && payload.stateKey) {
-			await deleteStateJson({ env: process.env, key: payload.stateKey });
-		}
-		writeToolEnvelope({
-			ok: true,
-			status: "cancelled",
-			output: [],
-			requiresApproval: null,
-			requiresInput: null,
-		});
-		return;
-	}
-
-	if (payload.kind === "workflow-file") {
-		try {
-			const output = await runWorkflowFile({
-				filePath: payload.filePath,
-				ctx: {
-					stdin: process.stdin,
-					stdout: process.stdout,
-					stderr: process.stderr,
-					env: process.env,
-					mode: "tool",
-					registry,
-					signal,
-				},
-				resume: payload,
-				approved,
-				response,
-				cancel,
-			});
-
-			if (output.status === "needs_approval") {
-				writeToolEnvelope({
-					ok: true,
-					status: "needs_approval",
-					output: [],
-					requiresApproval: output.requiresApproval ?? null,
-					requiresInput: null,
-				});
-				return;
-			}
-
-			if (output.status === "needs_input") {
-				writeToolEnvelope({
-					ok: true,
-					status: "needs_input",
-					output: [],
-					requiresApproval: null,
-					requiresInput: output.requiresInput ?? null,
-				});
-				return;
-			}
-
-			await cleanupIndex();
-			if (output.status === "cancelled") {
-				writeToolEnvelope({
-					ok: true,
-					status: "cancelled",
-					output: [],
-					requiresApproval: null,
-					requiresInput: null,
-				});
-				return;
-			}
-			writeToolEnvelope({
-				ok: true,
-				status: "ok",
-				output: output.output,
-				requiresApproval: null,
-				requiresInput: null,
-			});
-			return;
-		} catch (err) {
-			if (err instanceof WorkflowResumeArgumentError) {
-				writeToolEnvelope({ ok: false, error: { type: "parse_error", message: err.message } });
-				process.exitCode = 2;
-				return;
-			}
-			// Don't clean up index on error — allow retry by --id
-			writeToolEnvelope({
-				ok: false,
-				error: { type: "runtime_error", message: err?.message ?? String(err) },
-			});
-			process.exitCode = 1;
-			return;
-		}
-	}
-	const previousStateKey = payload.stateKey;
-	let resumeState;
-	try {
-		resumeState = await loadPipelineResumeState(process.env, previousStateKey);
-	} catch (err) {
-		writeToolEnvelope({
-			ok: false,
-			error: { type: "runtime_error", message: err?.message ?? String(err) },
-		});
-		process.exitCode = 1;
-		return;
-	}
-	if (resumeState.haltType === "input_request") {
-		if (approved !== undefined) {
-			writeToolEnvelope({
-				ok: false,
-				error: {
-					type: "parse_error",
-					message: "pipeline input resumes require --response-json <json>",
-				},
-			});
-			process.exitCode = 2;
-			return;
-		}
-		if (response === undefined) {
-			writeToolEnvelope({
-				ok: false,
-				error: {
-					type: "parse_error",
-					message: "pipeline input resumes require --response-json <json>",
-				},
-			});
-			process.exitCode = 2;
-			return;
-		}
-		try {
-			validatePipelineInputResponse(resumeState.inputSchema, response);
-		} catch (err) {
-			writeToolEnvelope({
-				ok: false,
-				error: { type: "parse_error", message: err?.message ?? String(err) },
-			});
-			process.exitCode = 2;
-			return;
-		}
-	} else {
-		if (response !== undefined) {
-			writeToolEnvelope({
-				ok: false,
-				error: {
-					type: "parse_error",
-					message: "approval resumes require --approve yes|no, not --response-json",
-				},
-			});
-			process.exitCode = 2;
-			return;
-		}
-		if (approved !== true) {
-			await cleanupIndex();
-			await deleteStateJson({ env: process.env, key: previousStateKey });
-			writeToolEnvelope({
-				ok: true,
-				status: "cancelled",
-				output: [],
-				requiresApproval: null,
-				requiresInput: null,
-			});
-			return;
-		}
-	}
-
-	const isSameStageInput =
-		resumeState.haltType === "input_request" && resumeState.resumeMode === "same_stage";
-	const remaining = resumeState.pipeline.slice(resumeState.resumeAtIndex);
-	const input = isSameStageInput
-		? resumeState.items
-		: resumeState.haltType === "input_request"
-			? [response]
-			: resumeState.items;
-	const requestInputResume = isSameStageInput
-		? {
-				state: resumeState.commandInput!,
-				response,
-				onConsumed: async () => {
-					await cleanupIndex();
-					await deleteStateJson({ env: process.env, key: previousStateKey });
-				},
-			}
-		: undefined;
-
-	try {
-		const output = await runPipeline({
-			pipeline: remaining,
-			registry,
+	const envelope = await resumeToolRequest({
+		token: parsed.token ?? undefined,
+		approvalId: parsed.approvalId ?? undefined,
+		approved: parsed.approved,
+		response: parsed.response,
+		cancel: parsed.cancel,
+		ctx: {
+			cwd: process.cwd(),
+			env: process.env,
+			mode: "tool",
 			stdin: process.stdin,
 			stdout: process.stdout,
 			stderr: process.stderr,
-			env: process.env,
-			mode,
-			input,
-			requestInputResume,
+			registry,
 			signal,
-		});
-		const finalized = await finalizePipelineToolRun({
-			env: process.env,
-			pipeline: remaining,
-			output,
-			previousStateKey,
-			signal,
-		});
-		writeToolEnvelope({
-			ok: true,
-			status: finalized.status,
-			output: finalized.output,
-			requiresApproval: finalized.requiresApproval,
-			requiresInput: finalized.requiresInput,
-		});
-	} catch (err) {
-		// Don't clean up index on error — allow retry by --id
-		writeToolEnvelope({
-			ok: false,
-			error: { type: "runtime_error", message: err?.message ?? String(err) },
-		});
-		process.exitCode = 1;
+		},
+	});
+	writeToolEnvelope(envelope);
+	if (!envelope.ok) {
+		process.exitCode = envelope.error?.type === "parse_error" ? 2 : 1;
 	}
 }
 
@@ -833,6 +600,7 @@ async function handleDoctor({ argv, registry, signal }: { argv; registry; signal
 				env: process.env,
 				mode,
 				signal,
+				haltAfterStageOnAbort: true,
 			});
 		} catch (err: any) {
 			return { error: err };

--- a/src/commands/stdlib/approve.ts
+++ b/src/commands/stdlib/approve.ts
@@ -18,6 +18,7 @@ export const approveCommand = {
 			required: [],
 		},
 		sideEffects: [],
+		resumeSafeBeforeInput: true,
 	},
 	help() {
 		return `approve — require confirmation to continue\n\nUsage:\n  ... | approve --prompt "Send these emails?"\n  ... | approve --emit --prompt "Send these emails?"\n  ... | approve --emit --preview-from-stdin --limit 5 --prompt "Proceed?"\n\nModes:\n  - Interactive (default): prompts on TTY and passes items through if approved.\n  - Emit (--emit): returns an approval request object and stops the pipeline.\n\nNotes:\n  - In tool mode (or non-interactive), this emits an approval request and halts.\n`;

--- a/src/commands/stdlib/approve.ts
+++ b/src/commands/stdlib/approve.ts
@@ -53,6 +53,7 @@ export const approveCommand = {
 		ctx.stdout.write(`${prompt} [y/N] `);
 		const answer = await readLineFromStream(ctx.stdin, {
 			timeoutMs: parseApprovalTimeoutMs(ctx.env),
+			signal: ctx.signal,
 		});
 
 		if (!/^y(es)?$/i.test(String(answer).trim())) {

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -57,6 +57,7 @@ export const askCommand = {
 			required: [],
 		},
 		sideEffects: [],
+		resumeSafeBeforeInput: true,
 	},
 	help() {
 		return [

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -58,6 +58,7 @@ export const askCommand = {
 		},
 		sideEffects: [],
 		resumeSafeBeforeInput: true,
+		resumeSafeAfterInput: true,
 	},
 	help() {
 		return [

--- a/src/commands/stdlib/ask.ts
+++ b/src/commands/stdlib/ask.ts
@@ -154,7 +154,7 @@ export const askCommand = {
 
 		ctx.stdout.write(`${prompt}\n> `);
 		const { readLineFromStream } = await import("../../read_line.js");
-		const raw = await readLineFromStream(ctx.stdin, { timeoutMs: 0 });
+		const raw = await readLineFromStream(ctx.stdin, { timeoutMs: 0, signal: ctx.signal });
 		const text = String(raw ?? "").trim();
 
 		let lastError;

--- a/src/commands/stdlib/diff_last.ts
+++ b/src/commands/stdlib/diff_last.ts
@@ -25,7 +25,12 @@ export const diffLastCommand = {
 		for await (const item of input) afterItems.push(item);
 
 		const after = afterItems.length === 1 ? afterItems[0] : afterItems;
-		const { before, changed } = await diffAndStore({ env: ctx.env, key, value: after });
+		const { before, changed } = await diffAndStore({
+			env: ctx.env,
+			key,
+			value: after,
+			signal: ctx.signal,
+		});
 
 		return {
 			output: (async function* () {

--- a/src/commands/stdlib/exec.ts
+++ b/src/commands/stdlib/exec.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { runAbortableProcess } from "../../abortable_process.js";
 import { resolveInlineShellCommand } from "../../shell.js";
 
 export const execCommand = {
@@ -86,40 +86,18 @@ export const execCommand = {
 	},
 };
 
-function runProcess(command, argv, { env, cwd, stdin, signal }) {
-	return new Promise<any>((resolve, reject) => {
-		const child = spawn(command, argv, {
-			env,
-			cwd,
-			signal,
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-
-		let stdout = "";
-		let stderr = "";
-
-		child.stdout.setEncoding("utf8");
-		child.stderr.setEncoding("utf8");
-
-		child.stdout.on("data", (d) => {
-			stdout += d;
-		});
-		child.stderr.on("data", (d) => {
-			stderr += d;
-		});
-
-		if (typeof stdin === "string") {
-			child.stdin.setDefaultEncoding("utf8");
-			child.stdin.write(stdin);
-		}
-		child.stdin.end();
-
-		child.on("error", reject);
-		child.on("close", (code) => {
-			if (code === 0) return resolve({ stdout, stderr });
-			reject(new Error(`exec failed (${code}): ${stderr.trim() || stdout.trim() || command}`));
-		});
+async function runProcess(command, argv, { env, cwd, stdin, signal }) {
+	const { stdout, stderr, code } = await runAbortableProcess({
+		command,
+		argv,
+		env,
+		cwd,
+		stdin,
+		signal,
+		notFoundMessage: `exec command not found: ${command}`,
 	});
+	if (code === 0) return { stdout, stderr };
+	throw new Error(`exec failed (${code}): ${stderr.trim() || stdout.trim() || command}`);
 }
 
 function runShellLine(commandLine, { env, cwd, stdin, signal }) {

--- a/src/commands/stdlib/exec.ts
+++ b/src/commands/stdlib/exec.ts
@@ -58,12 +58,14 @@ export const execCommand = {
 					cwd,
 					stdin: stdinPayload,
 					signal: ctx.signal,
+					forceTerminationSignal: ctx.forceTerminationSignal,
 				})
 			: await runProcess(cmd[0], cmd.slice(1), {
 					env: ctx.env,
 					cwd,
 					stdin: stdinPayload,
 					signal: ctx.signal,
+					forceTerminationSignal: ctx.forceTerminationSignal,
 				});
 
 		if (args.json) {
@@ -86,7 +88,7 @@ export const execCommand = {
 	},
 };
 
-async function runProcess(command, argv, { env, cwd, stdin, signal }) {
+async function runProcess(command, argv, { env, cwd, stdin, signal, forceTerminationSignal }) {
 	const { stdout, stderr, code } = await runAbortableProcess({
 		command,
 		argv,
@@ -94,15 +96,16 @@ async function runProcess(command, argv, { env, cwd, stdin, signal }) {
 		cwd,
 		stdin,
 		signal,
+		forceTerminationSignal,
 		notFoundMessage: `exec command not found: ${command}`,
 	});
 	if (code === 0) return { stdout, stderr };
 	throw new Error(`exec failed (${code}): ${stderr.trim() || stdout.trim() || command}`);
 }
 
-function runShellLine(commandLine, { env, cwd, stdin, signal }) {
+function runShellLine(commandLine, { env, cwd, stdin, signal, forceTerminationSignal }) {
 	const shell = resolveInlineShellCommand({ command: commandLine, env });
-	return runProcess(shell.command, shell.argv, { env, cwd, stdin, signal });
+	return runProcess(shell.command, shell.argv, { env, cwd, stdin, signal, forceTerminationSignal });
 }
 
 function encodeStdin(items, mode) {

--- a/src/commands/stdlib/gog_gmail_search.ts
+++ b/src/commands/stdlib/gog_gmail_search.ts
@@ -1,10 +1,17 @@
 import { spawn } from "node:child_process";
 
-function run(cmd: string, argv: string[], env: Record<string, string | undefined>, cwd?: string) {
+function run(
+	cmd: string,
+	argv: string[],
+	env: Record<string, string | undefined>,
+	cwd?: string,
+	signal?: AbortSignal,
+) {
 	return new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve, reject) => {
 		const child = spawn(cmd, argv, {
 			env: { ...process.env, ...env },
 			cwd,
+			signal,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 
@@ -55,10 +62,12 @@ export const gogGmailSearchCommand = {
 		);
 	},
 	async run({ input, args, ctx }) {
+		ctx.signal?.throwIfAborted();
 		// Drain input
 		for await (const _item of input) {
 			// no-op
 		}
+		ctx.signal?.throwIfAborted();
 
 		const query = String(args.query ?? "newer_than:1d");
 		const max = Number(args.max ?? args.limit ?? 20);
@@ -75,7 +84,7 @@ export const gogGmailSearchCommand = {
 		const gogBin = isScript ? process.execPath : gogBinRaw;
 		const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
 
-		const res = await run(gogBin, argv, ctx.env, process.cwd());
+		const res = await run(gogBin, argv, ctx.env, process.cwd(), ctx.signal);
 		if (res.code !== 0) {
 			throw new Error(`gog.gmail.search failed (${res.code ?? "?"}): ${res.stderr.slice(0, 400)}`);
 		}

--- a/src/commands/stdlib/gog_gmail_search.ts
+++ b/src/commands/stdlib/gog_gmail_search.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 
+const ABORT_FORCE_KILL_AFTER_MS = 250;
+
 function run(
 	cmd: string,
 	argv: string[],
@@ -17,18 +19,38 @@ function run(
 
 		let stdout = "";
 		let stderr = "";
+		let abortError: Error | undefined;
+		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+		let settled = false;
 		child.stdout?.on("data", (d) => (stdout += String(d)));
 		child.stderr?.on("data", (d) => (stderr += String(d)));
 
 		child.on("error", (err: any) => {
+			if (err?.name === "AbortError") {
+				abortError = err;
+				forceKillTimer = setTimeout(() => {
+					if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+				}, ABORT_FORCE_KILL_AFTER_MS);
+				forceKillTimer.unref();
+				return;
+			}
 			if (err?.code === "ENOENT") {
+				settled = true;
 				reject(new Error("gog not found on PATH (install: https://github.com/steipete/gogcli)"));
 				return;
 			}
+			settled = true;
 			reject(err);
 		});
 
 		child.on("close", (code) => {
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+			if (settled) return;
+			settled = true;
+			if (abortError) {
+				reject(abortError);
+				return;
+			}
 			resolve({ stdout, stderr, code });
 		});
 	});

--- a/src/commands/stdlib/gog_gmail_search.ts
+++ b/src/commands/stdlib/gog_gmail_search.ts
@@ -107,6 +107,7 @@ export const gogGmailSearchCommand = {
 		const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
 
 		const res = await run(gogBin, argv, ctx.env, process.cwd(), ctx.signal);
+		ctx.signal?.throwIfAborted();
 		if (res.code !== 0) {
 			throw new Error(`gog.gmail.search failed (${res.code ?? "?"}): ${res.stderr.slice(0, 400)}`);
 		}

--- a/src/commands/stdlib/gog_gmail_search.ts
+++ b/src/commands/stdlib/gog_gmail_search.ts
@@ -56,6 +56,7 @@ export const gogGmailSearchCommand = {
 			env: { ...process.env, ...ctx.env },
 			cwd: process.cwd(),
 			signal: ctx.signal,
+			forceTerminationSignal: ctx.forceTerminationSignal,
 			notFoundMessage: "gog not found on PATH (install: https://github.com/steipete/gogcli)",
 		});
 		if (res.code !== 0) {

--- a/src/commands/stdlib/gog_gmail_search.ts
+++ b/src/commands/stdlib/gog_gmail_search.ts
@@ -1,60 +1,4 @@
-import { spawn } from "node:child_process";
-
-const ABORT_FORCE_KILL_AFTER_MS = 250;
-
-function run(
-	cmd: string,
-	argv: string[],
-	env: Record<string, string | undefined>,
-	cwd?: string,
-	signal?: AbortSignal,
-) {
-	return new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve, reject) => {
-		const child = spawn(cmd, argv, {
-			env: { ...process.env, ...env },
-			cwd,
-			signal,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-
-		let stdout = "";
-		let stderr = "";
-		let abortError: Error | undefined;
-		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
-		let settled = false;
-		child.stdout?.on("data", (d) => (stdout += String(d)));
-		child.stderr?.on("data", (d) => (stderr += String(d)));
-
-		child.on("error", (err: any) => {
-			if (err?.name === "AbortError") {
-				abortError = err;
-				forceKillTimer = setTimeout(() => {
-					if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
-				}, ABORT_FORCE_KILL_AFTER_MS);
-				forceKillTimer.unref();
-				return;
-			}
-			if (err?.code === "ENOENT") {
-				settled = true;
-				reject(new Error("gog not found on PATH (install: https://github.com/steipete/gogcli)"));
-				return;
-			}
-			settled = true;
-			reject(err);
-		});
-
-		child.on("close", (code) => {
-			if (forceKillTimer) clearTimeout(forceKillTimer);
-			if (settled) return;
-			settled = true;
-			if (abortError) {
-				reject(abortError);
-				return;
-			}
-			resolve({ stdout, stderr, code });
-		});
-	});
-}
+import { runAbortableProcess } from "../../abortable_process.js";
 
 export const gogGmailSearchCommand = {
 	name: "gog.gmail.search",
@@ -106,8 +50,14 @@ export const gogGmailSearchCommand = {
 		const gogBin = isScript ? process.execPath : gogBinRaw;
 		const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
 
-		const res = await run(gogBin, argv, ctx.env, process.cwd(), ctx.signal);
-		ctx.signal?.throwIfAborted();
+		const res = await runAbortableProcess({
+			command: gogBin,
+			argv,
+			env: { ...process.env, ...ctx.env },
+			cwd: process.cwd(),
+			signal: ctx.signal,
+			notFoundMessage: "gog not found on PATH (install: https://github.com/steipete/gogcli)",
+		});
 		if (res.code !== 0) {
 			throw new Error(`gog.gmail.search failed (${res.code ?? "?"}): ${res.stderr.slice(0, 400)}`);
 		}

--- a/src/commands/stdlib/gog_gmail_send.ts
+++ b/src/commands/stdlib/gog_gmail_send.ts
@@ -1,17 +1,10 @@
 import { spawn } from "node:child_process";
 
-function run(
-	cmd: string,
-	argv: string[],
-	env: Record<string, string | undefined>,
-	cwd?: string,
-	signal?: AbortSignal,
-) {
+function run(cmd: string, argv: string[], env: Record<string, string | undefined>, cwd?: string) {
 	return new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve, reject) => {
 		const child = spawn(cmd, argv, {
 			env: { ...process.env, ...env },
 			cwd,
-			signal,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 
@@ -88,7 +81,10 @@ export const gogGmailSendCommand = {
 		const results: any[] = [];
 
 		for await (const item of input) {
-			ctx.signal?.throwIfAborted();
+			if (ctx.signal?.aborted) {
+				if (results.length > 0) break;
+				ctx.signal.throwIfAborted();
+			}
 			const draft = parseDraft(item);
 
 			if (dryRun) {
@@ -107,7 +103,7 @@ export const gogGmailSendCommand = {
 			];
 
 			const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
-			const res = await run(gogBin, argv, ctx.env, process.cwd(), ctx.signal);
+			const res = await run(gogBin, argv, ctx.env, process.cwd());
 			if (res.code !== 0) {
 				throw new Error(`gog.gmail.send failed (${res.code ?? "?"}): ${res.stderr.slice(0, 400)}`);
 			}
@@ -120,6 +116,7 @@ export const gogGmailSendCommand = {
 			}
 
 			results.push(parsed);
+			if (ctx.signal?.aborted) break;
 		}
 
 		return {

--- a/src/commands/stdlib/gog_gmail_send.ts
+++ b/src/commands/stdlib/gog_gmail_send.ts
@@ -1,10 +1,17 @@
 import { spawn } from "node:child_process";
 
-function run(cmd: string, argv: string[], env: Record<string, string | undefined>, cwd?: string) {
+function run(
+	cmd: string,
+	argv: string[],
+	env: Record<string, string | undefined>,
+	cwd?: string,
+	signal?: AbortSignal,
+) {
 	return new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve, reject) => {
 		const child = spawn(cmd, argv, {
 			env: { ...process.env, ...env },
 			cwd,
+			signal,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 
@@ -72,6 +79,7 @@ export const gogGmailSendCommand = {
 		);
 	},
 	async run({ input, args, ctx }) {
+		ctx.signal?.throwIfAborted();
 		const dryRun = Boolean(args.dryRun ?? args["dry-run"] ?? false);
 		const gogBinRaw = String(ctx.env.GOG_BIN ?? "gog");
 		const isScript = /\.(mjs|cjs|js|ts)$/i.test(gogBinRaw);
@@ -80,6 +88,7 @@ export const gogGmailSendCommand = {
 		const results: any[] = [];
 
 		for await (const item of input) {
+			ctx.signal?.throwIfAborted();
 			const draft = parseDraft(item);
 
 			if (dryRun) {
@@ -98,7 +107,7 @@ export const gogGmailSendCommand = {
 			];
 
 			const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
-			const res = await run(gogBin, argv, ctx.env, process.cwd());
+			const res = await run(gogBin, argv, ctx.env, process.cwd(), ctx.signal);
 			if (res.code !== 0) {
 				throw new Error(`gog.gmail.send failed (${res.code ?? "?"}): ${res.stderr.slice(0, 400)}`);
 			}

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -178,6 +178,7 @@ type Adapter = {
 		env: any;
 		args: any;
 		payload: Record<string, any>;
+		signal?: AbortSignal;
 	}) => Promise<LlmResponseEnvelope>;
 };
 
@@ -187,6 +188,7 @@ type DirectAdapter =
 			args: any;
 			payload: Record<string, any>;
 			ctx: any;
+			signal?: AbortSignal;
 	  }) => Promise<LlmResponseEnvelope>)
 	| {
 			source?: string;
@@ -195,6 +197,7 @@ type DirectAdapter =
 				args: any;
 				payload: Record<string, any>;
 				ctx: any;
+				signal?: AbortSignal;
 			}) => Promise<LlmResponseEnvelope>;
 	  };
 
@@ -438,7 +441,7 @@ async function runLlmInvoke({
 
 		let responseEnvelope: LlmResponseEnvelope;
 		try {
-			responseEnvelope = await adapter.invoke({ env, args, payload });
+			responseEnvelope = await adapter.invoke({ env, args, payload, signal: ctx.signal });
 		} catch (err: any) {
 			throw new Error(`${config.name} request failed: ${err?.message ?? String(err)}`);
 		}
@@ -547,8 +550,8 @@ function resolveAdapter({
 		return {
 			provider,
 			source: typeof direct === "function" ? provider : (direct.source ?? provider),
-			async invoke({ payload }) {
-				return invoke({ env, args, payload, ctx });
+			async invoke({ payload, signal }) {
+				return invoke({ env, args, payload, ctx, signal });
 			},
 		};
 	}
@@ -563,8 +566,8 @@ function resolveAdapter({
 		return {
 			provider,
 			source: config.sourceForProvider?.(provider) ?? "openclaw",
-			async invoke({ payload }) {
-				return invokeOpenClawAdapter({ endpoint, token, payload });
+			async invoke({ payload, signal }) {
+				return invokeOpenClawAdapter({ endpoint, token, payload, signal });
 			},
 		};
 	}
@@ -578,8 +581,13 @@ function resolveAdapter({
 		return {
 			provider,
 			source: config.sourceForProvider?.(provider) ?? "pi",
-			async invoke({ payload }) {
-				return invokeHttpAdapter({ endpoint: buildAdapterEndpoint(adapterUrl), token, payload });
+			async invoke({ payload, signal }) {
+				return invokeHttpAdapter({
+					endpoint: buildAdapterEndpoint(adapterUrl),
+					token,
+					payload,
+					signal,
+				});
 			},
 		};
 	}
@@ -592,8 +600,13 @@ function resolveAdapter({
 	return {
 		provider,
 		source: config.sourceForProvider?.(provider) ?? "http",
-		async invoke({ payload }) {
-			return invokeHttpAdapter({ endpoint: buildAdapterEndpoint(adapterUrl), token, payload });
+		async invoke({ payload, signal }) {
+			return invokeHttpAdapter({
+				endpoint: buildAdapterEndpoint(adapterUrl),
+				token,
+				payload,
+				signal,
+			});
 		},
 	};
 }
@@ -621,13 +634,16 @@ async function invokeOpenClawAdapter({
 	endpoint,
 	token,
 	payload,
+	signal,
 }: {
 	endpoint: URL;
 	token: string;
 	payload: any;
+	signal?: AbortSignal;
 }) {
 	const res = await fetch(endpoint, {
 		method: "POST",
+		signal,
 		headers: {
 			"content-type": "application/json",
 			...(token ? { authorization: `Bearer ${token}` } : null),
@@ -670,13 +686,16 @@ async function invokeHttpAdapter({
 	endpoint,
 	token,
 	payload,
+	signal,
 }: {
 	endpoint: URL;
 	token: string;
 	payload: any;
+	signal?: AbortSignal;
 }) {
 	const res = await fetch(endpoint, {
 		method: "POST",
+		signal,
 		headers: {
 			"content-type": "application/json",
 			...(token ? { authorization: `Bearer ${token}` } : null),

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -9,6 +9,7 @@ import {
 	isJsonSyntaxError,
 	readStateJson,
 	stableStringify,
+	withFileLock,
 	writeFileAtomic,
 	writeStateJson,
 } from "../../state/store.js";
@@ -400,7 +401,7 @@ async function runLlmInvoke({
 	}
 
 	if (!disableCache && !forceRefresh) {
-		const cache = await readCacheEntry(env, cacheKey, config.cacheNamespace);
+		const cache = await readCacheEntry(env, cacheKey, config.cacheNamespace, ctx.signal);
 		if (cache) {
 			return {
 				output: streamOf(cache.items.map((item) => ({ ...item, source: "cache", cached: true }))),
@@ -478,7 +479,8 @@ async function runLlmInvoke({
 				signal: ctx.signal,
 			});
 			ctx.signal?.throwIfAborted();
-			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
+			if (!disableCache)
+				await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace, ctx.signal);
 			return { output: streamOf(normalized) };
 		}
 
@@ -494,7 +496,8 @@ async function runLlmInvoke({
 				signal: ctx.signal,
 			});
 			ctx.signal?.throwIfAborted();
-			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
+			if (!disableCache)
+				await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace, ctx.signal);
 			return { output: streamOf(normalized) };
 		}
 
@@ -949,18 +952,25 @@ async function readCacheEntry(
 	env: any,
 	key: string,
 	cacheNamespace: string,
+	signal?: AbortSignal,
 ): Promise<CacheEntry | null> {
 	const filePath = path.join(getCacheDir(env), cacheNamespace, `${key}.json`);
-	try {
-		const text = await fsp.readFile(filePath, "utf8");
-		const parsed = JSON.parse(text) as Partial<CacheEntry>;
-		if (parsed?.cacheKey !== key || !Array.isArray(parsed.items)) return null;
-		return parsed as CacheEntry;
-	} catch (err: any) {
-		if (err?.code === "ENOENT") return null;
-		if (isJsonSyntaxError(err)) return null;
-		throw err;
-	}
+	return withFileLock({
+		filePath,
+		signal,
+		task: async () => {
+			try {
+				const text = await fsp.readFile(filePath, "utf8");
+				const parsed = JSON.parse(text) as Partial<CacheEntry>;
+				if (parsed?.cacheKey !== key || !Array.isArray(parsed.items)) return null;
+				return parsed as CacheEntry;
+			} catch (err: any) {
+				if (err?.code === "ENOENT") return null;
+				if (isJsonSyntaxError(err)) return null;
+				throw err;
+			}
+		},
+	});
 }
 
 async function writeCacheEntry(
@@ -968,14 +978,30 @@ async function writeCacheEntry(
 	key: string,
 	items: NormalizedInvocationItem[],
 	cacheNamespace: string,
+	signal?: AbortSignal,
 ) {
 	const dir = path.join(getCacheDir(env), cacheNamespace);
+	signal?.throwIfAborted();
 	await ensureDirectory(dir);
 	const filePath = path.join(dir, `${key}.json`);
-	await writeFileAtomic(
+	const content =
+		JSON.stringify({ items, cacheKey: key, storedAt: new Date().toISOString() }, null, 2) + "\n";
+	await withFileLock({
 		filePath,
-		JSON.stringify({ items, cacheKey: key, storedAt: new Date().toISOString() }, null, 2) + "\n",
-	);
+		signal,
+		task: async () => {
+			signal?.throwIfAborted();
+			const result = await writeFileAtomic(filePath, content, { signal });
+			if (result?.signalAbortedAfterCommit || signal?.aborted) {
+				// No cache reader or competing cache writer can observe this entry
+				// until this lock is released, so rollback cannot delete another
+				// invocation's result.
+				await fsp.rm(filePath, { force: true });
+				signal?.throwIfAborted();
+				throw new Error("LLM cache publication cancelled");
+			}
+		},
+	});
 }
 
 function getCacheDir(env: any) {

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -5,13 +5,13 @@ import { Ajv } from "ajv";
 import type { ErrorObject } from "ajv";
 
 import {
+	diffAndStore,
 	ensureDirectory,
 	isJsonSyntaxError,
 	readStateJson,
 	stableStringify,
 	withFileLock,
 	writeFileAtomic,
-	writeStateJson,
 } from "../../state/store.js";
 import { createCompileCached } from "../../validation.js";
 import type { LobsterCommand } from "../types.js";
@@ -923,7 +923,7 @@ async function persistOutputs({
 		items,
 		storedAt: new Date().toISOString(),
 	};
-	await writeStateJson({ env, key: stateKey, value: record, signal });
+	await diffAndStore({ env, key: stateKey, value: record, signal });
 }
 
 async function readReusableLlmState(env: any, stateKey: string) {

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -389,7 +389,7 @@ async function runLlmInvoke({
 	});
 
 	if (stateKey && !forceRefresh) {
-		const stored = await readReusableLlmState(env, stateKey);
+		const stored = await readReusableLlmState(env, stateKey, ctx.signal);
 		const reused = pickReusableState(stored, cacheKey, config.stateType);
 		if (reused) {
 			return {
@@ -937,9 +937,9 @@ async function persistOutputs({
 	});
 }
 
-async function readReusableLlmState(env: any, stateKey: string) {
+async function readReusableLlmState(env: any, stateKey: string, signal?: AbortSignal) {
 	try {
-		return await readStateJsonWithLock({ env, key: stateKey });
+		return await readStateJsonWithLock({ env, key: stateKey, signal });
 	} catch (err: any) {
 		if (isJsonSyntaxError(err)) return null;
 		throw err;

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -7,6 +7,7 @@ import type { ErrorObject } from "ajv";
 import {
 	diffAndStore,
 	ensureDirectory,
+	atomicWriteWasPublished,
 	isJsonSyntaxError,
 	readStateJsonWithLock,
 	stableStringify,
@@ -966,22 +967,27 @@ async function readCacheEntry(
 	signal?: AbortSignal,
 ): Promise<CacheEntry | null> {
 	const filePath = path.join(getCacheDir(env), cacheNamespace, `${key}.json`);
-	return withFileLock({
-		filePath,
-		signal,
-		task: async () => {
-			try {
-				const text = await fsp.readFile(filePath, "utf8");
-				const parsed = JSON.parse(text) as Partial<CacheEntry>;
-				if (parsed?.cacheKey !== key || !Array.isArray(parsed.items)) return null;
-				return parsed as CacheEntry;
-			} catch (err: any) {
-				if (err?.code === "ENOENT") return null;
-				if (isJsonSyntaxError(err)) return null;
-				throw err;
-			}
-		},
-	});
+	const read = async () => {
+		try {
+			const text = await fsp.readFile(filePath, "utf8");
+			const parsed = JSON.parse(text) as Partial<CacheEntry>;
+			if (parsed?.cacheKey !== key || !Array.isArray(parsed.items)) return null;
+			return parsed as CacheEntry;
+		} catch (err: any) {
+			if (err?.code === "ENOENT") return null;
+			if (isJsonSyntaxError(err)) return null;
+			throw err;
+		}
+	};
+	try {
+		return await withFileLock({ filePath, signal, task: read });
+	} catch (err: any) {
+		// A cache mounted read-only cannot have an active local writer because a
+		// writer first creates the same coordination lock. Preserve its reusable
+		// entries instead of requiring a lock-directory write for a read.
+		if (["EACCES", "EPERM", "EROFS"].includes(err?.code)) return read();
+		throw err;
+	}
 }
 
 async function writeCacheEntry(
@@ -1007,16 +1013,29 @@ async function writeCacheEntry(
 			} catch (err: any) {
 				if (err?.code !== "ENOENT") throw err;
 			}
-			signal?.throwIfAborted();
-			const result = await writeFileAtomic(filePath, content, { signal });
-			if (result?.signalAbortedAfterCommit || signal?.aborted) {
+			const restorePreviousContent = async () => {
 				// No cache reader or competing cache writer can observe this entry
 				// until this lock is released. Restore an entry replaced by a refresh;
 				// only remove the just-published file when none existed beforehand.
 				if (previousContent === null) await fsp.rm(filePath, { force: true });
 				else await writeFileAtomic(filePath, previousContent);
+			};
+			let cacheWasPublished = false;
+			try {
 				signal?.throwIfAborted();
-				throw new Error("LLM cache publication cancelled");
+				const result = await writeFileAtomic(filePath, content, { signal });
+				cacheWasPublished = true;
+				if (result?.signalAbortedAfterCommit || signal?.aborted) {
+					await restorePreviousContent();
+					cacheWasPublished = false;
+					signal?.throwIfAborted();
+					throw new Error("LLM cache publication cancelled");
+				}
+			} catch (err) {
+				if (cacheWasPublished || atomicWriteWasPublished(err)) {
+					await restorePreviousContent();
+				}
+				throw err;
 			}
 		},
 	});

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -441,7 +441,9 @@ async function runLlmInvoke({
 
 		let responseEnvelope: LlmResponseEnvelope;
 		try {
+			ctx.signal?.throwIfAborted();
 			responseEnvelope = await adapter.invoke({ env, args, payload, signal: ctx.signal });
+			ctx.signal?.throwIfAborted();
 		} catch (err: any) {
 			throw new Error(`${config.name} request failed: ${err?.message ?? String(err)}`);
 		}
@@ -466,6 +468,7 @@ async function runLlmInvoke({
 		});
 
 		if (!validator) {
+			ctx.signal?.throwIfAborted();
 			await persistOutputs({
 				env,
 				stateKey,
@@ -474,12 +477,14 @@ async function runLlmInvoke({
 				stateType: config.stateType,
 				signal: ctx.signal,
 			});
+			ctx.signal?.throwIfAborted();
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
 			return { output: streamOf(normalized) };
 		}
 
 		const structured = normalized[0]?.output?.data ?? null;
 		if (validator(structured)) {
+			ctx.signal?.throwIfAborted();
 			await persistOutputs({
 				env,
 				stateKey,
@@ -488,6 +493,7 @@ async function runLlmInvoke({
 				stateType: config.stateType,
 				signal: ctx.signal,
 			});
+			ctx.signal?.throwIfAborted();
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
 			return { output: streamOf(normalized) };
 		}

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -8,7 +8,7 @@ import {
 	diffAndStore,
 	ensureDirectory,
 	isJsonSyntaxError,
-	readStateJson,
+	readStateJsonWithLock,
 	stableStringify,
 	withFileLock,
 	writeFileAtomic,
@@ -477,10 +477,10 @@ async function runLlmInvoke({
 				items: normalized,
 				stateType: config.stateType,
 				signal: ctx.signal,
+				afterStore: disableCache
+					? undefined
+					: () => writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace, ctx.signal),
 			});
-			ctx.signal?.throwIfAborted();
-			if (!disableCache)
-				await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace, ctx.signal);
 			return { output: streamOf(normalized) };
 		}
 
@@ -494,10 +494,10 @@ async function runLlmInvoke({
 				items: normalized,
 				stateType: config.stateType,
 				signal: ctx.signal,
+				afterStore: disableCache
+					? undefined
+					: () => writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace, ctx.signal),
 			});
-			ctx.signal?.throwIfAborted();
-			if (!disableCache)
-				await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace, ctx.signal);
 			return { output: streamOf(normalized) };
 		}
 
@@ -907,6 +907,7 @@ async function persistOutputs({
 	items,
 	stateType,
 	signal,
+	afterStore,
 }: {
 	env: any;
 	stateKey: string | null;
@@ -914,8 +915,12 @@ async function persistOutputs({
 	items: NormalizedInvocationItem[];
 	stateType: string;
 	signal?: AbortSignal;
+	afterStore?: () => Promise<void>;
 }) {
-	if (!stateKey) return;
+	if (!stateKey) {
+		await afterStore?.();
+		return;
+	}
 	const record = {
 		type: stateType,
 		version: STATE_VERSION,
@@ -923,12 +928,18 @@ async function persistOutputs({
 		items,
 		storedAt: new Date().toISOString(),
 	};
-	await diffAndStore({ env, key: stateKey, value: record, signal });
+	await diffAndStore({
+		env,
+		key: stateKey,
+		value: record,
+		signal,
+		afterStore: afterStore ? () => afterStore() : undefined,
+	});
 }
 
 async function readReusableLlmState(env: any, stateKey: string) {
 	try {
-		return await readStateJson({ env, key: stateKey });
+		return await readStateJsonWithLock({ env, key: stateKey });
 	} catch (err: any) {
 		if (isJsonSyntaxError(err)) return null;
 		throw err;

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -472,6 +472,7 @@ async function runLlmInvoke({
 				cacheKey,
 				items: normalized,
 				stateType: config.stateType,
+				signal: ctx.signal,
 			});
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
 			return { output: streamOf(normalized) };
@@ -485,6 +486,7 @@ async function runLlmInvoke({
 				cacheKey,
 				items: normalized,
 				stateType: config.stateType,
+				signal: ctx.signal,
 			});
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
 			return { output: streamOf(normalized) };
@@ -895,12 +897,14 @@ async function persistOutputs({
 	cacheKey,
 	items,
 	stateType,
+	signal,
 }: {
 	env: any;
 	stateKey: string | null;
 	cacheKey: string;
 	items: NormalizedInvocationItem[];
 	stateType: string;
+	signal?: AbortSignal;
 }) {
 	if (!stateKey) return;
 	const record = {
@@ -910,7 +914,7 @@ async function persistOutputs({
 		items,
 		storedAt: new Date().toISOString(),
 	};
-	await writeStateJson({ env, key: stateKey, value: record });
+	await writeStateJson({ env, key: stateKey, value: record, signal });
 }
 
 async function readReusableLlmState(env: any, stateKey: string) {

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -990,13 +990,20 @@ async function writeCacheEntry(
 		filePath,
 		signal,
 		task: async () => {
+			let previousContent: Buffer | null = null;
+			try {
+				previousContent = await fsp.readFile(filePath);
+			} catch (err: any) {
+				if (err?.code !== "ENOENT") throw err;
+			}
 			signal?.throwIfAborted();
 			const result = await writeFileAtomic(filePath, content, { signal });
 			if (result?.signalAbortedAfterCommit || signal?.aborted) {
 				// No cache reader or competing cache writer can observe this entry
-				// until this lock is released, so rollback cannot delete another
-				// invocation's result.
-				await fsp.rm(filePath, { force: true });
+				// until this lock is released. Restore an entry replaced by a refresh;
+				// only remove the just-published file when none existed beforehand.
+				if (previousContent === null) await fsp.rm(filePath, { force: true });
+				else await writeFileAtomic(filePath, previousContent);
 				signal?.throwIfAborted();
 				throw new Error("LLM cache publication cancelled");
 			}

--- a/src/commands/stdlib/openclaw_agent.ts
+++ b/src/commands/stdlib/openclaw_agent.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { runAbortableProcess } from "../../abortable_process.js";
 import type { LobsterCommand } from "../types.js";
 
 type AgentCliRunner = (params: {
@@ -105,38 +105,27 @@ export function runOpenClawAgentCli(params: {
 	env: NodeJS.ProcessEnv;
 	signal?: AbortSignal;
 }): Promise<unknown> {
-	return new Promise((resolve, reject) => {
-		execFile(
-			params.executable,
-			params.argv,
-			{
-				cwd: params.cwd,
-				env: params.env,
-				signal: params.signal,
-				encoding: "utf8",
-				maxBuffer: 10 * 1024 * 1024,
-			},
-			(error, stdout, stderr) => {
-				if (error) {
-					if (error.name === "AbortError") {
-						reject(error);
-						return;
-					}
-					const detail = String(stderr || stdout || error.message).trim();
-					reject(new Error(`openclaw.agent failed: ${detail}`));
-					return;
-				}
-				try {
-					const parsed = JSON.parse(String(stdout).trim() || "null");
-					if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-						throw new Error("response must be an object");
-					}
-					resolve(parsed);
-				} catch {
-					reject(new Error("openclaw.agent expected JSON output from `openclaw agent --json`"));
-				}
-			},
-		);
+	return runAbortableProcess({
+		command: params.executable,
+		argv: params.argv,
+		cwd: params.cwd,
+		env: params.env,
+		signal: params.signal,
+		notFoundMessage: "openclaw.agent could not find the OpenClaw CLI",
+	}).then(({ code, stdout, stderr }) => {
+		if (code !== 0) {
+			const detail = String(stderr || stdout || `exited with code ${code}`).trim();
+			throw new Error(`openclaw.agent failed: ${detail}`);
+		}
+		try {
+			const parsed = JSON.parse(stdout.trim() || "null");
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				throw new Error("response must be an object");
+			}
+			return parsed;
+		} catch {
+			throw new Error("openclaw.agent expected JSON output from `openclaw agent --json`");
+		}
 	});
 }
 

--- a/src/commands/stdlib/openclaw_agent.ts
+++ b/src/commands/stdlib/openclaw_agent.ts
@@ -9,6 +9,7 @@ type AgentCliRunner = (params: {
 	cwd: string;
 	env: NodeJS.ProcessEnv;
 	signal?: AbortSignal;
+	forceTerminationSignal?: AbortSignal;
 }) => Promise<unknown>;
 
 export const openclawAgentCommand = createOpenClawAgentCommand();
@@ -94,6 +95,7 @@ export function createOpenClawAgentCommand(
 				cwd: ctx?.cwd ?? process.cwd(),
 				env,
 				signal: ctx?.signal,
+				forceTerminationSignal: ctx?.forceTerminationSignal,
 			});
 			return { output: streamOf([response]) };
 		},
@@ -106,6 +108,7 @@ export function runOpenClawAgentCli(params: {
 	cwd: string;
 	env: NodeJS.ProcessEnv;
 	signal?: AbortSignal;
+	forceTerminationSignal?: AbortSignal;
 }): Promise<unknown> {
 	return runAbortableProcess({
 		command: params.executable,
@@ -113,6 +116,7 @@ export function runOpenClawAgentCli(params: {
 		cwd: params.cwd,
 		env: params.env,
 		signal: params.signal,
+		forceTerminationSignal: params.forceTerminationSignal,
 		maxOutputBytes: OPENCLAW_AGENT_MAX_OUTPUT_BYTES,
 		outputLimitMessage: `openclaw.agent output exceeded ${OPENCLAW_AGENT_MAX_OUTPUT_BYTES} bytes`,
 		notFoundMessage: "openclaw.agent could not find the OpenClaw CLI",

--- a/src/commands/stdlib/openclaw_agent.ts
+++ b/src/commands/stdlib/openclaw_agent.ts
@@ -1,6 +1,8 @@
 import { runAbortableProcess } from "../../abortable_process.js";
 import type { LobsterCommand } from "../types.js";
 
+const OPENCLAW_AGENT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
 type AgentCliRunner = (params: {
 	executable: string;
 	argv: string[];
@@ -111,6 +113,8 @@ export function runOpenClawAgentCli(params: {
 		cwd: params.cwd,
 		env: params.env,
 		signal: params.signal,
+		maxOutputBytes: OPENCLAW_AGENT_MAX_OUTPUT_BYTES,
+		outputLimitMessage: `openclaw.agent output exceeded ${OPENCLAW_AGENT_MAX_OUTPUT_BYTES} bytes`,
 		notFoundMessage: "openclaw.agent could not find the OpenClaw CLI",
 	}).then(({ code, stdout, stderr }) => {
 		if (code !== 0) {

--- a/src/commands/stdlib/openclaw_invoke.ts
+++ b/src/commands/stdlib/openclaw_invoke.ts
@@ -91,6 +91,7 @@ function createInvokeCommand(commandName: string) {
 			const invokeOnce = async (argsValue: unknown) => {
 				const res = await fetch(endpoint, {
 					method: "POST",
+					signal: ctx.signal,
 					headers: {
 						"content-type": "application/json",
 						...(token ? { authorization: `Bearer ${token}` } : null),

--- a/src/commands/stdlib/state.ts
+++ b/src/commands/stdlib/state.ts
@@ -66,7 +66,7 @@ export const stateSetCommand = {
 
 		const value = items.length === 1 ? items[0] : items;
 
-		await writeStateJson({ env: ctx.env, key, value });
+		await writeStateJson({ env: ctx.env, key, value, signal: ctx.signal });
 
 		return { output: asStream([value]) };
 	},

--- a/src/commands/stdlib/state.ts
+++ b/src/commands/stdlib/state.ts
@@ -1,6 +1,4 @@
-import { promises as fsp } from "node:fs";
-
-import { defaultStateDir, keyToPath, writeStateJson } from "../../state/store.js";
+import { readStateJsonWithLock, writeStateJson } from "../../state/store.js";
 
 export const stateGetCommand = {
 	name: "state.get",
@@ -22,20 +20,7 @@ export const stateGetCommand = {
 		const key = args._[0];
 		if (!key) throw new Error("state.get requires a key");
 
-		const stateDir = defaultStateDir(ctx.env);
-		const filePath = keyToPath(stateDir, key);
-
-		let value = null;
-		try {
-			const text = await fsp.readFile(filePath, "utf8");
-			value = JSON.parse(text);
-		} catch (err) {
-			if (err?.code === "ENOENT") {
-				value = null;
-			} else {
-				throw err;
-			}
-		}
+		const value = await readStateJsonWithLock({ env: ctx.env, key, signal: ctx.signal });
 
 		return { output: asStream([value]) };
 	},

--- a/src/commands/stdlib/state.ts
+++ b/src/commands/stdlib/state.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 
-import { defaultStateDir, ensureDirectory, keyToPath, writeFileAtomic } from "../../state/store.js";
+import { defaultStateDir, keyToPath, writeStateJson } from "../../state/store.js";
 
 export const stateGetCommand = {
 	name: "state.get",
@@ -66,11 +66,7 @@ export const stateSetCommand = {
 
 		const value = items.length === 1 ? items[0] : items;
 
-		const stateDir = defaultStateDir(ctx.env);
-		const filePath = keyToPath(stateDir, key);
-
-		await ensureDirectory(stateDir);
-		await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n");
+		await writeStateJson({ env: ctx.env, key, value });
 
 		return { output: asStream([value]) };
 	},

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -3,6 +3,12 @@ export type CommandMeta = {
 	argsSchema?: unknown;
 	examples?: Array<{ args: Record<string, unknown>; description?: string }>;
 	sideEffects?: string[];
+	/**
+	 * The command may create an input/approval gate before it begins execution.
+	 * Commands that omit this are treated conservatively when a resumed pipeline
+	 * is cancelled: its original capability cannot be replayed after dispatch.
+	 */
+	resumeSafeBeforeInput?: boolean;
 };
 
 export type LobsterCommand = {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -9,6 +9,12 @@ export type CommandMeta = {
 	 * is cancelled: its original capability cannot be replayed after dispatch.
 	 */
 	resumeSafeBeforeInput?: boolean;
+	/**
+	 * The command remains side-effect-free after returning a resumed input until
+	 * the next pipeline stage dispatches. This is intentionally opt-in so a
+	 * command that acts on a resumed response consumes its capability first.
+	 */
+	resumeSafeAfterInput?: boolean;
 };
 
 export type LobsterCommand = {

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -136,6 +136,7 @@ export async function runToolRequest({
 			env: runtime.env,
 			pipeline: parsed,
 			output,
+			signal: runtime.signal,
 		});
 		return okEnvelope(
 			finalized.status,
@@ -318,6 +319,7 @@ export async function resumeToolRequest({
 			pipeline: remaining,
 			output,
 			previousStateKey: payload.stateKey,
+			signal: runtime.signal,
 		});
 		return okEnvelope(
 			finalized.status,

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -136,7 +136,6 @@ export async function runToolRequest({
 			env: runtime.env,
 			pipeline: parsed,
 			output,
-			signal: runtime.signal,
 		});
 		return okEnvelope(
 			finalized.status,
@@ -319,7 +318,6 @@ export async function resumeToolRequest({
 			pipeline: remaining,
 			output,
 			previousStateKey: payload.stateKey,
-			signal: runtime.signal,
 		});
 		return okEnvelope(
 			finalized.status,

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -328,7 +328,26 @@ export async function resumeToolRequest({
 			finalized.requiresInput,
 		);
 	} catch (err: any) {
-		// Don't clean up index on error — allow retry by --id
+		if (runtime.signal?.aborted) {
+			const cleanupErrors: unknown[] = [];
+			try {
+				await cleanupIndex();
+			} catch (cleanupErr) {
+				cleanupErrors.push(cleanupErr);
+			}
+			try {
+				await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+			} catch (cleanupErr) {
+				cleanupErrors.push(cleanupErr);
+			}
+			if (cleanupErrors.length) {
+				return errorEnvelope(
+					"runtime_error",
+					"Failed to invalidate cancelled pipeline resume state",
+				);
+			}
+		}
+		// Non-cancellation failures retain their state so callers can retry.
 		return errorEnvelope("runtime_error", err?.message ?? String(err));
 	}
 }

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -130,6 +130,7 @@ export async function runToolRequest({
 			cwd: runtime.cwd,
 			llmAdapters: runtime.llmAdapters,
 			signal: runtime.signal,
+			haltAfterStageOnAbort: true,
 		});
 
 		const finalized = await finalizePipelineToolRun({
@@ -308,6 +309,7 @@ export async function resumeToolRequest({
 			cwd: runtime.cwd,
 			llmAdapters: runtime.llmAdapters,
 			signal: runtime.signal,
+			haltAfterStageOnAbort: true,
 			input,
 			requestInputResume,
 		});

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -328,26 +328,7 @@ export async function resumeToolRequest({
 			finalized.requiresInput,
 		);
 	} catch (err: any) {
-		if (runtime.signal?.aborted) {
-			const cleanupErrors: unknown[] = [];
-			try {
-				await cleanupIndex();
-			} catch (cleanupErr) {
-				cleanupErrors.push(cleanupErr);
-			}
-			try {
-				await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-			} catch (cleanupErr) {
-				cleanupErrors.push(cleanupErr);
-			}
-			if (cleanupErrors.length) {
-				return errorEnvelope(
-					"runtime_error",
-					"Failed to invalidate cancelled pipeline resume state",
-				);
-			}
-		}
-		// Non-cancellation failures retain their state so callers can retry.
+		// Don't clean up index on error — allow retry by --id
 		return errorEnvelope("runtime_error", err?.message ?? String(err));
 	}
 }

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -328,7 +328,15 @@ export async function resumeToolRequest({
 			finalized.requiresInput,
 		);
 	} catch (err: any) {
-		// Don't clean up index on error — allow retry by --id
+		const abortedApproval =
+			resumeState.haltType === "approval_request" &&
+			runtime.signal?.aborted &&
+			(err?.name === "AbortError" || err?.code === "ABORT_ERR");
+		if (abortedApproval) {
+			await cleanupIndex();
+			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+		}
+		// Non-abort failures remain retryable by token or approval ID.
 		return errorEnvelope("runtime_error", err?.message ?? String(err));
 	}
 }

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -214,11 +214,16 @@ export async function resumeToolRequest({
 	}
 
 	if (payload.kind === "workflow-file") {
-		const abortedBeforeResume = runtime.signal?.aborted === true;
+		let workflowExecutionStarted = false;
 		try {
 			const output = await runWorkflowFile({
 				filePath: payload.filePath,
-				ctx: runtime,
+				ctx: {
+					...runtime,
+					_onExecutionStart: () => {
+						workflowExecutionStarted = true;
+					},
+				},
 				resume: payload,
 				approved,
 				response,
@@ -242,11 +247,11 @@ export async function resumeToolRequest({
 				return errorEnvelope("parse_error", err.message);
 			}
 			const abortedResume = runtime.signal?.aborted === true;
-			if (abortedResume && !abortedBeforeResume) {
+			if (abortedResume && workflowExecutionStarted) {
 				await cleanupIndex();
 				await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 			}
-			// Non-abort failures and pre-aborted resumes remain retryable by token or approval ID.
+			// Non-abort failures and cancellations before step execution remain retryable.
 			return errorEnvelope("runtime_error", err?.message ?? String(err));
 		}
 	}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -12,7 +12,11 @@ import {
 	findStateKeyByApprovalId,
 	cleanupApprovalIndexByStateKey,
 } from "../state/store.js";
-import { WorkflowResumeArgumentError, runWorkflowFile } from "../workflows/file.js";
+import {
+	WorkflowResumeArgumentError,
+	alternateWorkflowResumeStateKey,
+	runWorkflowFile,
+} from "../workflows/file.js";
 import {
 	finalizePipelineToolRun,
 	loadPipelineResumeState,
@@ -194,27 +198,35 @@ export async function resumeToolRequest({
 	}
 
 	// Helper: clean up approval ID index after successful use
-	const cleanupIndex = async () => {
+	const cleanupIndex = async (stateKey = payload?.stateKey) => {
 		if (resolvedApprovalId) {
 			await deleteApprovalId({ env: runtime.env, approvalId: resolvedApprovalId });
-		} else if (payload?.stateKey) {
-			await cleanupApprovalIndexByStateKey({ env: runtime.env, stateKey: payload.stateKey });
+		} else if (stateKey) {
+			await cleanupApprovalIndexByStateKey({ env: runtime.env, stateKey });
 		}
 	};
 
 	if (cancel === true) {
-		await cleanupIndex();
+		const stateKeys = new Set<string>();
+		if (payload.stateKey) stateKeys.add(payload.stateKey);
 		if (payload.kind === "workflow-file" && payload.stateKey) {
-			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+			const alternateStateKey = alternateWorkflowResumeStateKey(payload.stateKey);
+			if (alternateStateKey) stateKeys.add(alternateStateKey);
 		}
-		if (payload.kind === "pipeline-resume" && payload.stateKey) {
-			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+		if (resolvedApprovalId) {
+			await cleanupIndex();
+		} else {
+			for (const stateKey of stateKeys) await cleanupIndex(stateKey);
+		}
+		for (const stateKey of stateKeys) {
+			await deleteStateJson({ env: runtime.env, key: stateKey });
 		}
 		return okEnvelope("cancelled", [], null, null);
 	}
 
 	if (payload.kind === "workflow-file") {
 		let workflowExecutionStarted = false;
+		let workflowResumeStateKey = payload.stateKey;
 		try {
 			const output = await runWorkflowFile({
 				filePath: payload.filePath,
@@ -222,6 +234,9 @@ export async function resumeToolRequest({
 					...runtime,
 					_onExecutionStart: () => {
 						workflowExecutionStarted = true;
+					},
+					_onResumeStateResolved: (stateKey) => {
+						workflowResumeStateKey = stateKey;
 					},
 				},
 				resume: payload,
@@ -237,7 +252,7 @@ export async function resumeToolRequest({
 			if (output.status === "needs_input") {
 				return okEnvelope("needs_input", [], null, output.requiresInput ?? null);
 			}
-			await cleanupIndex();
+			await cleanupIndex(workflowResumeStateKey);
 			if (output.status === "cancelled") {
 				return okEnvelope("cancelled", [], null, null);
 			}
@@ -248,8 +263,10 @@ export async function resumeToolRequest({
 			}
 			const abortedResume = runtime.signal?.aborted === true;
 			if (abortedResume && workflowExecutionStarted) {
-				await cleanupIndex();
-				await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+				await cleanupIndex(workflowResumeStateKey);
+				if (workflowResumeStateKey) {
+					await deleteStateJson({ env: runtime.env, key: workflowResumeStateKey });
+				}
 			}
 			// Non-abort failures and cancellations before step execution remain retryable.
 			return errorEnvelope("runtime_error", err?.message ?? String(err));

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -240,7 +240,12 @@ export async function resumeToolRequest({
 			if (err instanceof WorkflowResumeArgumentError) {
 				return errorEnvelope("parse_error", err.message);
 			}
-			// Don't clean up index on error — allow retry by --id
+			const abortedResume = runtime.signal?.aborted === true;
+			if (abortedResume) {
+				await cleanupIndex();
+				await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+			}
+			// Non-abort failures remain retryable by token or approval ID.
 			return errorEnvelope("runtime_error", err?.message ?? String(err));
 		}
 	}
@@ -328,11 +333,8 @@ export async function resumeToolRequest({
 			finalized.requiresInput,
 		);
 	} catch (err: any) {
-		const abortedApproval =
-			resumeState.haltType === "approval_request" &&
-			runtime.signal?.aborted &&
-			(err?.name === "AbortError" || err?.code === "ABORT_ERR");
-		if (abortedApproval) {
+		const abortedResume = runtime.signal?.aborted === true;
+		if (abortedResume) {
 			await cleanupIndex();
 			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 		}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -214,6 +214,7 @@ export async function resumeToolRequest({
 	}
 
 	if (payload.kind === "workflow-file") {
+		const abortedBeforeResume = runtime.signal?.aborted === true;
 		try {
 			const output = await runWorkflowFile({
 				filePath: payload.filePath,
@@ -241,11 +242,11 @@ export async function resumeToolRequest({
 				return errorEnvelope("parse_error", err.message);
 			}
 			const abortedResume = runtime.signal?.aborted === true;
-			if (abortedResume) {
+			if (abortedResume && !abortedBeforeResume) {
 				await cleanupIndex();
 				await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 			}
-			// Non-abort failures remain retryable by token or approval ID.
+			// Non-abort failures and pre-aborted resumes remain retryable by token or approval ID.
 			return errorEnvelope("runtime_error", err?.message ?? String(err));
 		}
 	}
@@ -301,6 +302,7 @@ export async function resumeToolRequest({
 				},
 			}
 		: undefined;
+	const abortedBeforeResume = runtime.signal?.aborted === true;
 
 	try {
 		const output = await runPipeline({
@@ -334,11 +336,11 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
-		if (abortedResume) {
+		if (abortedResume && !abortedBeforeResume) {
 			await cleanupIndex();
 			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 		}
-		// Non-abort failures remain retryable by token or approval ID.
+		// Non-abort failures and pre-aborted resumes remain retryable by token or approval ID.
 		return errorEnvelope("runtime_error", err?.message ?? String(err));
 	}
 }

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -11,6 +11,7 @@ import {
 	deleteApprovalId,
 	findStateKeyByApprovalId,
 	cleanupApprovalIndexByStateKey,
+	writeStateJson,
 } from "../state/store.js";
 import {
 	WorkflowResumeArgumentError,
@@ -314,6 +315,10 @@ export async function resumeToolRequest({
 		: resumeState.haltType === "input_request"
 			? [response]
 			: resumeState.items;
+	const abortedBeforeResume = runtime.signal?.aborted === true;
+	let pipelineResumeStateRestored = false;
+	let pipelineExecutionStarted = false;
+	let pipelineInputResponseConsumed = false;
 	const requestInputResume = isSameStageInput
 		? {
 				state: resumeState.commandInput!,
@@ -321,12 +326,10 @@ export async function resumeToolRequest({
 				onConsumed: async () => {
 					await cleanupIndex();
 					await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+					pipelineInputResponseConsumed = true;
 				},
 			}
 		: undefined;
-	const abortedBeforeResume = runtime.signal?.aborted === true;
-	let pipelineResumeStateRestored = false;
-	let pipelineExecutionStarted = false;
 
 	try {
 		const output = await runPipeline({
@@ -368,6 +371,18 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
+		if (
+			abortedResume &&
+			!abortedBeforeResume &&
+			!pipelineExecutionStarted &&
+			!pipelineResumeStateRestored &&
+			pipelineInputResponseConsumed
+		) {
+			// A same-stage input response was consumed, but no command dispatch
+			// occurred. Restore the capability so cancellation cannot burn it.
+			await writeStateJson({ env: runtime.env, key: payload.stateKey, value: resumeState });
+			pipelineResumeStateRestored = true;
+		}
 		if (
 			abortedResume &&
 			!abortedBeforeResume &&

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -307,7 +307,6 @@ export async function resumeToolRequest({
 	const abortedBeforeResume = runtime.signal?.aborted === true;
 	let pipelineResumeStateRestored = false;
 	let pipelineExecutionStarted = false;
-	let pipelineInputResponseConsumed = false;
 	const requestInputResume = isSameStageInput
 		? {
 				state: resumeState.commandInput!,
@@ -315,7 +314,6 @@ export async function resumeToolRequest({
 				onConsumed: async () => {
 					await cleanupIndex();
 					await deleteStateJson({ env: runtime.env, key: payload.stateKey });
-					pipelineInputResponseConsumed = true;
 				},
 			}
 		: undefined;
@@ -346,12 +344,13 @@ export async function resumeToolRequest({
 			output,
 			previousStateKey: payload.stateKey,
 			previousState: resumeState,
-			restorePreviousStateOnAbort: output.halted === true && !pipelineExecutionStarted,
+			restorePreviousStateOnAbort: !pipelineExecutionStarted,
 			onPreviousStateRestored: () => {
 				pipelineResumeStateRestored = true;
 			},
 			signal: runtime.signal,
 		});
+		if (finalized.status === "ok") await cleanupIndex();
 		return okEnvelope(
 			finalized.status,
 			finalized.output,
@@ -364,11 +363,10 @@ export async function resumeToolRequest({
 			abortedResume &&
 			!abortedBeforeResume &&
 			!pipelineExecutionStarted &&
-			!pipelineResumeStateRestored &&
-			pipelineInputResponseConsumed
+			!pipelineResumeStateRestored
 		) {
-			// A same-stage input response was consumed, but no command dispatch
-			// occurred. Restore the capability so cancellation cannot burn it.
+			// No command dispatch occurred, so cancellation must leave the original
+			// approval or input capability retryable.
 			await writeStateJson({ env: runtime.env, key: payload.stateKey, value: resumeState });
 			pipelineResumeStateRestored = true;
 		}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -7,7 +7,7 @@ import { decodeResumeToken, kindFromStateKey } from "../resume.js";
 import { runPipeline } from "../runtime.js";
 import { encodeToken } from "../token.js";
 import {
-	deleteStateJson,
+	deleteStateJsonWithBoundedResumeCleanup,
 	deleteUnconsumedResumeState,
 	deleteApprovalId,
 	findStateKeyByApprovalId,
@@ -436,7 +436,10 @@ export async function resumeToolRequest({
 		}
 		if (pipelineExecutionStarted && !pipelineResumeStateRestored) {
 			if (abortedResume && !abortedBeforeResume) {
-				await deleteStateJson({ env: runtime.env, key: payload.stateKey }).catch(() => {});
+				await deleteStateJsonWithBoundedResumeCleanup({
+					env: runtime.env,
+					key: payload.stateKey,
+				}).catch(() => {});
 			}
 			// Keep the short approval ID through the pre-dispatch claim window. Once
 			// the unsafe stage has actually been entered, the tombstone makes retry

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -215,13 +215,16 @@ export async function resumeToolRequest({
 			const alternateStateKey = alternateWorkflowResumeStateKey(payload.stateKey);
 			if (alternateStateKey) stateKeys.add(alternateStateKey);
 		}
+		// Keep the capability indexed until every state deletion succeeds. A
+		// cancelled request must not orphan a resume state by dropping its
+		// approval ID while waiting on another writer's state lock.
+		for (const stateKey of stateKeys) {
+			await deleteStateJson({ env: runtime.env, key: stateKey, signal: runtime.signal });
+		}
 		if (resolvedApprovalId) {
 			await cleanupIndex();
 		} else {
 			for (const stateKey of stateKeys) await cleanupIndex(stateKey);
-		}
-		for (const stateKey of stateKeys) {
-			await deleteStateJson({ env: runtime.env, key: stateKey });
 		}
 		return okEnvelope("cancelled", [], null, null);
 	}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -13,6 +13,7 @@ import {
 	cleanupApprovalIndexByStateKey,
 	consumeResumeState,
 	readStateJson,
+	restoreConsumedResumeState,
 	stateJsonExists,
 	writeStateJson,
 } from "../state/store.js";
@@ -331,20 +332,11 @@ export async function resumeToolRequest({
 	const abortedBeforeResume = runtime.signal?.aborted === true;
 	let pipelineResumeStateRestored = false;
 	let pipelineExecutionStarted = false;
+	let pipelineResumeStateClaimRejected = false;
 	const requestInputResume = isSameStageInput
 		? {
 				state: resumeState.commandInput!,
 				response,
-				onConsumed: async () => {
-					// Release the old snapshot before a resume-safe command receives its
-					// response. The awaited execution boundary either tombstones it before
-					// an effect or restores this exact snapshot if cancellation wins here.
-					await deleteStateJson({
-						env: runtime.env,
-						key: payload.stateKey,
-						signal: runtime.signal,
-					});
-				},
 			}
 		: undefined;
 
@@ -364,11 +356,30 @@ export async function resumeToolRequest({
 			input,
 			requestInputResume,
 			onExecutionStart: async () => {
-				await consumeResumeState({
+				const consumption = await consumeResumeState({
 					env: runtime.env,
 					key: payload.stateKey,
+					expectedState: resumeState,
 					signal: runtime.signal,
 				});
+				if (!consumption.consumed) {
+					pipelineResumeStateClaimRejected = true;
+					throw new Error("Pipeline resume state not found");
+				}
+				if (consumption.signalAbortedAfterCommit) {
+					const restored = await restoreConsumedResumeState({
+						env: runtime.env,
+						key: payload.stateKey,
+						expectedState: resumeState,
+						claimId: consumption.claimId,
+					});
+					if (restored) {
+						pipelineResumeStateRestored = true;
+					} else {
+						pipelineResumeStateClaimRejected = true;
+					}
+					runtime.signal?.throwIfAborted();
+				}
 				// The durable tombstone blocks raw-token replay even if index cleanup
 				// suffers a storage error, so an index failure cannot re-enable effects.
 				await cleanupIndex().catch(() => {});
@@ -398,16 +409,6 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
-		if (!pipelineExecutionStarted && !pipelineResumeStateRestored) {
-			// No unsafe command dispatch occurred, so a safe-input validation or
-			// cancellation failure must leave the original capability retryable. If
-			// cleanup was interrupted while another writer held its lock, the old
-			// state is already intact; do not immediately contend for that lock again.
-			if ((await readStateJson({ env: runtime.env, key: payload.stateKey })) === null) {
-				await writeStateJson({ env: runtime.env, key: payload.stateKey, value: resumeState });
-			}
-			pipelineResumeStateRestored = true;
-		}
 		if (
 			abortedResume &&
 			!abortedBeforeResume &&

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -35,6 +35,7 @@ type ToolRunContext = {
 	stdout?: NodeJS.WritableStream;
 	stderr?: NodeJS.WritableStream;
 	signal?: AbortSignal;
+	forceTerminationSignal?: AbortSignal;
 	registry?: any;
 	llmAdapters?: Record<string, any>;
 };
@@ -138,6 +139,7 @@ export async function runToolRequest({
 			cwd: runtime.cwd,
 			llmAdapters: runtime.llmAdapters,
 			signal: runtime.signal,
+			forceTerminationSignal: runtime.forceTerminationSignal,
 			haltAfterStageOnAbort: true,
 		});
 
@@ -382,6 +384,7 @@ export async function resumeToolRequest({
 			cwd: runtime.cwd,
 			llmAdapters: runtime.llmAdapters,
 			signal: runtime.signal,
+			forceTerminationSignal: runtime.forceTerminationSignal,
 			haltAfterStageOnAbort: true,
 			input,
 			requestInputResume,
@@ -475,6 +478,7 @@ export function createToolContext(ctx: ToolRunContext = {}) {
 		stdout: ctx.stdout ?? createCaptureStream(),
 		stderr: ctx.stderr ?? createCaptureStream(),
 		signal: ctx.signal,
+		forceTerminationSignal: ctx.forceTerminationSignal,
 		registry: ctx.registry ?? createDefaultRegistry(),
 		llmAdapters: ctx.llmAdapters,
 	};

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -11,7 +11,9 @@ import {
 	deleteApprovalId,
 	findStateKeyByApprovalId,
 	cleanupApprovalIndexByStateKey,
+	consumeResumeState,
 	readStateJson,
+	stateJsonExists,
 	writeStateJson,
 } from "../state/store.js";
 import {
@@ -210,16 +212,27 @@ export async function resumeToolRequest({
 	};
 
 	if (cancel === true) {
-		const stateKeys = new Set<string>();
-		if (payload.stateKey) stateKeys.add(payload.stateKey);
-		if (payload.kind === "workflow-file" && payload.stateKey) {
+		let stateKeys = [payload.stateKey];
+		if (payload.kind === "workflow-file") {
 			const alternateStateKey = alternateWorkflowResumeStateKey(payload.stateKey);
-			if (alternateStateKey) stateKeys.add(alternateStateKey);
+			if (alternateStateKey) {
+				// Delete a non-authoritative spelling first. If cancellation interrupts
+				// its lock wait, the state that makes this capability resumable remains.
+				const [primaryExists, alternateExists] = await Promise.all([
+					stateJsonExists({ env: runtime.env, key: payload.stateKey }),
+					stateJsonExists({ env: runtime.env, key: alternateStateKey }),
+				]);
+				if (primaryExists || !alternateExists) {
+					stateKeys = [alternateStateKey, payload.stateKey];
+				} else {
+					stateKeys = [payload.stateKey, alternateStateKey];
+				}
+			}
 		}
 		// Keep the capability indexed until every state deletion succeeds. A
 		// cancelled request must not orphan a resume state by dropping its
 		// approval ID while waiting on another writer's state lock.
-		for (const stateKey of stateKeys) {
+		for (const stateKey of new Set(stateKeys)) {
 			await deleteStateJson({ env: runtime.env, key: stateKey, signal: runtime.signal });
 		}
 		if (resolvedApprovalId) {
@@ -323,7 +336,9 @@ export async function resumeToolRequest({
 				state: resumeState.commandInput!,
 				response,
 				onConsumed: async () => {
-					await cleanupIndex();
+					// Release the old snapshot before a resume-safe command receives its
+					// response. The awaited execution boundary either tombstones it before
+					// an effect or restores this exact snapshot if cancellation wins here.
 					await deleteStateJson({
 						env: runtime.env,
 						key: payload.stateKey,
@@ -348,7 +363,15 @@ export async function resumeToolRequest({
 			haltAfterStageOnAbort: true,
 			input,
 			requestInputResume,
-			onExecutionStart: () => {
+			onExecutionStart: async () => {
+				await consumeResumeState({
+					env: runtime.env,
+					key: payload.stateKey,
+					signal: runtime.signal,
+				});
+				// The durable tombstone blocks raw-token replay even if index cleanup
+				// suffers a storage error, so an index failure cannot re-enable effects.
+				await cleanupIndex().catch(() => {});
 				pipelineExecutionStarted = true;
 			},
 		});
@@ -359,6 +382,7 @@ export async function resumeToolRequest({
 			output,
 			previousStateKey: payload.stateKey,
 			previousState: resumeState,
+			previousStateConsumed: pipelineExecutionStarted,
 			restorePreviousStateOnAbort: !pipelineExecutionStarted,
 			onPreviousStateRestored: () => {
 				pipelineResumeStateRestored = true;
@@ -374,16 +398,11 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
-		if (
-			abortedResume &&
-			!abortedBeforeResume &&
-			!pipelineExecutionStarted &&
-			!pipelineResumeStateRestored
-		) {
-			// No command dispatch occurred, so cancellation must leave the original
-			// approval or input capability retryable. If cancellation interrupted
-			// the delete while another writer held the state lock, the old state is
-			// already intact; do not immediately contend for that same lock again.
+		if (!pipelineExecutionStarted && !pipelineResumeStateRestored) {
+			// No unsafe command dispatch occurred, so a safe-input validation or
+			// cancellation failure must leave the original capability retryable. If
+			// cleanup was interrupted while another writer held its lock, the old
+			// state is already intact; do not immediately contend for that lock again.
 			if ((await readStateJson({ env: runtime.env, key: payload.stateKey })) === null) {
 				await writeStateJson({ env: runtime.env, key: payload.stateKey, value: resumeState });
 			}
@@ -395,8 +414,7 @@ export async function resumeToolRequest({
 			pipelineExecutionStarted &&
 			!pipelineResumeStateRestored
 		) {
-			await cleanupIndex();
-			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+			await deleteStateJson({ env: runtime.env, key: payload.stateKey }).catch(() => {});
 		}
 		// Non-abort failures and pre-aborted resumes remain retryable by token or approval ID.
 		return errorEnvelope("runtime_error", err?.message ?? String(err));

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -350,7 +350,7 @@ export async function resumeToolRequest({
 			output,
 			previousStateKey: payload.stateKey,
 			previousState: resumeState,
-			restorePreviousStateOnAbort: output.halted === true && (output.haltedAt?.index ?? -1) === 0,
+			restorePreviousStateOnAbort: output.halted === true && output.executionStarted !== true,
 			onPreviousStateRestored: () => {
 				pipelineResumeStateRestored = true;
 			},

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -326,6 +326,7 @@ export async function resumeToolRequest({
 		: undefined;
 	const abortedBeforeResume = runtime.signal?.aborted === true;
 	let pipelineResumeStateRestored = false;
+	let pipelineExecutionStarted = false;
 
 	try {
 		const output = await runPipeline({
@@ -342,6 +343,9 @@ export async function resumeToolRequest({
 			haltAfterStageOnAbort: true,
 			input,
 			requestInputResume,
+			onExecutionStart: () => {
+				pipelineExecutionStarted = true;
+			},
 		});
 
 		const finalized = await finalizePipelineToolRun({
@@ -350,7 +354,7 @@ export async function resumeToolRequest({
 			output,
 			previousStateKey: payload.stateKey,
 			previousState: resumeState,
-			restorePreviousStateOnAbort: output.halted === true && output.executionStarted !== true,
+			restorePreviousStateOnAbort: output.halted === true && !pipelineExecutionStarted,
 			onPreviousStateRestored: () => {
 				pipelineResumeStateRestored = true;
 			},
@@ -364,7 +368,12 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
-		if (abortedResume && !abortedBeforeResume && !pipelineResumeStateRestored) {
+		if (
+			abortedResume &&
+			!abortedBeforeResume &&
+			pipelineExecutionStarted &&
+			!pipelineResumeStateRestored
+		) {
 			await cleanupIndex();
 			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 		}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -293,8 +293,15 @@ export async function resumeToolRequest({
 			);
 		}
 		if (approved !== true) {
+			// Keep the approval ID usable while this may still be waiting on a
+			// concurrent state writer. Dropping the index first would orphan the
+			// capability if cancellation interrupts the deletion.
+			await deleteStateJson({
+				env: runtime.env,
+				key: payload.stateKey,
+				signal: runtime.signal,
+			});
 			await cleanupIndex();
-			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 			return okEnvelope("cancelled", [], null, null);
 		}
 	}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -247,10 +247,13 @@ export async function resumeToolRequest({
 			});
 
 			if (output.status === "needs_approval") {
-				// Don't clean up index — next gate will issue a new approvalId
+				// The next gate owns its own approval ID. Remove any index for the
+				// state that was just replaced so it cannot become a stale capability.
+				await cleanupIndex(workflowResumeStateKey).catch(() => {});
 				return okEnvelope("needs_approval", [], output.requiresApproval ?? null, null);
 			}
 			if (output.status === "needs_input") {
+				await cleanupIndex(workflowResumeStateKey).catch(() => {});
 				return okEnvelope("needs_input", [], null, output.requiresInput ?? null);
 			}
 			await cleanupIndex(workflowResumeStateKey);

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -247,13 +247,9 @@ export async function resumeToolRequest({
 			});
 
 			if (output.status === "needs_approval") {
-				// The next gate owns its own approval ID. Remove any index for the
-				// state that was just replaced so it cannot become a stale capability.
-				await cleanupIndex(workflowResumeStateKey).catch(() => {});
 				return okEnvelope("needs_approval", [], output.requiresApproval ?? null, null);
 			}
 			if (output.status === "needs_input") {
-				await cleanupIndex(workflowResumeStateKey).catch(() => {});
 				return okEnvelope("needs_input", [], null, output.requiresInput ?? null);
 			}
 			await cleanupIndex(workflowResumeStateKey);

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -227,16 +227,12 @@ export async function resumeToolRequest({
 	}
 
 	if (payload.kind === "workflow-file") {
-		let workflowExecutionStarted = false;
 		let workflowResumeStateKey = payload.stateKey;
 		try {
 			const output = await runWorkflowFile({
 				filePath: payload.filePath,
 				ctx: {
 					...runtime,
-					_onExecutionStart: () => {
-						workflowExecutionStarted = true;
-					},
 					_onResumeStateResolved: (stateKey) => {
 						workflowResumeStateKey = stateKey;
 					},
@@ -261,13 +257,6 @@ export async function resumeToolRequest({
 		} catch (err: any) {
 			if (err instanceof WorkflowResumeArgumentError) {
 				return errorEnvelope("parse_error", err.message);
-			}
-			const abortedResume = runtime.signal?.aborted === true;
-			if (abortedResume && workflowExecutionStarted) {
-				await cleanupIndex(workflowResumeStateKey);
-				if (workflowResumeStateKey) {
-					await deleteStateJson({ env: runtime.env, key: workflowResumeStateKey });
-				}
 			}
 			// Non-abort failures and cancellations before step execution remain retryable.
 			return errorEnvelope("runtime_error", err?.message ?? String(err));

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -293,15 +293,20 @@ export async function resumeToolRequest({
 		}
 	}
 
+	if (runtime.signal?.aborted) {
+		return errorEnvelope(
+			"runtime_error",
+			runtime.signal.reason instanceof Error
+				? runtime.signal.reason.message
+				: "This operation was aborted",
+		);
+	}
+
 	let resumeState;
 	try {
-		// A pre-aborted resume must still load its safe snapshot so the normal
-		// pre-execution rollback path can preserve that capability for retry.
-		resumeState = await loadPipelineResumeState(
-			runtime.env,
-			payload.stateKey,
-			runtime.signal?.aborted ? undefined : runtime.signal,
-		);
+		// No state has been claimed yet, so a cancelled resume can return before
+		// touching the lock and leave its capability safely retryable.
+		resumeState = await loadPipelineResumeState(runtime.env, payload.stateKey, runtime.signal);
 	} catch (err: any) {
 		// Approval rejection historically reaches the signal-aware deletion path
 		// below. Keep its direct cancellation propagation while other resume modes

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -394,9 +394,6 @@ export async function resumeToolRequest({
 					}
 					runtime.signal?.throwIfAborted();
 				}
-				// The durable tombstone blocks raw-token replay even if index cleanup
-				// suffers a storage error, so an index failure cannot re-enable effects.
-				await cleanupIndex().catch(() => {});
 				runtime.signal?.throwIfAborted();
 				pipelineExecutionStarted = true;
 			},
@@ -415,7 +412,7 @@ export async function resumeToolRequest({
 			},
 			signal: runtime.signal,
 		});
-		if (finalized.status === "ok") await cleanupIndex();
+		if (finalized.status === "ok" && pipelineExecutionStarted) await cleanupIndex();
 		return okEnvelope(
 			finalized.status,
 			finalized.output,
@@ -437,13 +434,14 @@ export async function resumeToolRequest({
 				claimId: pipelineResumeStateClaimId,
 			}).catch(() => false);
 		}
-		if (
-			abortedResume &&
-			!abortedBeforeResume &&
-			pipelineExecutionStarted &&
-			!pipelineResumeStateRestored
-		) {
-			await deleteStateJson({ env: runtime.env, key: payload.stateKey }).catch(() => {});
+		if (pipelineExecutionStarted && !pipelineResumeStateRestored) {
+			if (abortedResume && !abortedBeforeResume) {
+				await deleteStateJson({ env: runtime.env, key: payload.stateKey }).catch(() => {});
+			}
+			// Keep the short approval ID through the pre-dispatch claim window. Once
+			// the unsafe stage has actually been entered, the tombstone makes retry
+			// unsafe and the old index may be retired just as it was before this fix.
+			await cleanupIndex().catch(() => {});
 		}
 		// Non-abort failures and pre-aborted resumes remain retryable by token or approval ID.
 		return errorEnvelope("runtime_error", err?.message ?? String(err));

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -8,6 +8,7 @@ import { runPipeline } from "../runtime.js";
 import { encodeToken } from "../token.js";
 import {
 	deleteStateJson,
+	deleteUnconsumedResumeState,
 	deleteApprovalId,
 	findStateKeyByApprovalId,
 	cleanupApprovalIndexByStateKey,
@@ -233,8 +234,21 @@ export async function resumeToolRequest({
 		// Keep the capability indexed until every state deletion succeeds. A
 		// cancelled request must not orphan a resume state by dropping its
 		// approval ID while waiting on another writer's state lock.
+		const deletionResults = [];
 		for (const stateKey of new Set(stateKeys)) {
-			await deleteStateJson({ env: runtime.env, key: stateKey, signal: runtime.signal });
+			deletionResults.push(
+				await deleteUnconsumedResumeState({
+					env: runtime.env,
+					key: stateKey,
+					signal: runtime.signal,
+				}),
+			);
+		}
+		if (
+			deletionResults.includes("claimed") ||
+			deletionResults.every((result) => result === "missing")
+		) {
+			return errorEnvelope("runtime_error", "Resume state not found");
 		}
 		if (resolvedApprovalId) {
 			await cleanupIndex();
@@ -311,11 +325,14 @@ export async function resumeToolRequest({
 			// Keep the approval ID usable while this may still be waiting on a
 			// concurrent state writer. Dropping the index first would orphan the
 			// capability if cancellation interrupts the deletion.
-			await deleteStateJson({
+			const deletion = await deleteUnconsumedResumeState({
 				env: runtime.env,
 				key: payload.stateKey,
 				signal: runtime.signal,
 			});
+			if (deletion !== "deleted") {
+				return errorEnvelope("runtime_error", "Pipeline resume state not found");
+			}
 			await cleanupIndex();
 			return okEnvelope("cancelled", [], null, null);
 		}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -141,6 +141,7 @@ export async function runToolRequest({
 			env: runtime.env,
 			pipeline: parsed,
 			output,
+			signal: runtime.signal,
 		});
 		return okEnvelope(
 			finalized.status,
@@ -343,12 +344,12 @@ export async function resumeToolRequest({
 			requestInputResume,
 		});
 
-		await cleanupIndex();
 		const finalized = await finalizePipelineToolRun({
 			env: runtime.env,
 			pipeline: remaining,
 			output,
 			previousStateKey: payload.stateKey,
+			signal: runtime.signal,
 		});
 		return okEnvelope(
 			finalized.status,

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -214,8 +214,8 @@ export async function resumeToolRequest({
 	};
 
 	if (cancel === true) {
-		let stateKeys = [payload.stateKey];
-		if (payload.kind === "workflow-file") {
+		let stateKeys = payload.stateKey ? [payload.stateKey] : [];
+		if (payload.kind === "workflow-file" && payload.stateKey) {
 			const alternateStateKey = alternateWorkflowResumeStateKey(payload.stateKey);
 			if (alternateStateKey) {
 				// Delete a non-authoritative spelling first. If cancellation interrupts
@@ -245,8 +245,9 @@ export async function resumeToolRequest({
 			);
 		}
 		if (
-			deletionResults.includes("claimed") ||
-			deletionResults.every((result) => result === "missing")
+			stateKeys.length > 0 &&
+			(deletionResults.includes("claimed") ||
+				deletionResults.every((result) => result === "missing"))
 		) {
 			return errorEnvelope("runtime_error", "Resume state not found");
 		}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -295,8 +295,18 @@ export async function resumeToolRequest({
 
 	let resumeState;
 	try {
-		resumeState = await loadPipelineResumeState(runtime.env, payload.stateKey);
+		// A pre-aborted resume must still load its safe snapshot so the normal
+		// pre-execution rollback path can preserve that capability for retry.
+		resumeState = await loadPipelineResumeState(
+			runtime.env,
+			payload.stateKey,
+			runtime.signal?.aborted ? undefined : runtime.signal,
+		);
 	} catch (err: any) {
+		// Approval rejection historically reaches the signal-aware deletion path
+		// below. Keep its direct cancellation propagation while other resume modes
+		// retain their structured tool envelope.
+		if (runtime.signal?.aborted && approved === false) throw err;
 		return errorEnvelope("runtime_error", err?.message ?? String(err));
 	}
 

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -325,6 +325,7 @@ export async function resumeToolRequest({
 			}
 		: undefined;
 	const abortedBeforeResume = runtime.signal?.aborted === true;
+	let pipelineResumeStateRestored = false;
 
 	try {
 		const output = await runPipeline({
@@ -348,6 +349,11 @@ export async function resumeToolRequest({
 			pipeline: remaining,
 			output,
 			previousStateKey: payload.stateKey,
+			previousState: resumeState,
+			restorePreviousStateOnAbort: output.halted === true && (output.haltedAt?.index ?? -1) === 0,
+			onPreviousStateRestored: () => {
+				pipelineResumeStateRestored = true;
+			},
 			signal: runtime.signal,
 		});
 		return okEnvelope(
@@ -358,7 +364,7 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
-		if (abortedResume && !abortedBeforeResume) {
+		if (abortedResume && !abortedBeforeResume && !pipelineResumeStateRestored) {
 			await cleanupIndex();
 			await deleteStateJson({ env: runtime.env, key: payload.stateKey });
 		}

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -11,6 +11,7 @@ import {
 	deleteApprovalId,
 	findStateKeyByApprovalId,
 	cleanupApprovalIndexByStateKey,
+	readStateJson,
 	writeStateJson,
 } from "../state/store.js";
 import {
@@ -323,7 +324,11 @@ export async function resumeToolRequest({
 				response,
 				onConsumed: async () => {
 					await cleanupIndex();
-					await deleteStateJson({ env: runtime.env, key: payload.stateKey });
+					await deleteStateJson({
+						env: runtime.env,
+						key: payload.stateKey,
+						signal: runtime.signal,
+					});
 				},
 			}
 		: undefined;
@@ -376,8 +381,12 @@ export async function resumeToolRequest({
 			!pipelineResumeStateRestored
 		) {
 			// No command dispatch occurred, so cancellation must leave the original
-			// approval or input capability retryable.
-			await writeStateJson({ env: runtime.env, key: payload.stateKey, value: resumeState });
+			// approval or input capability retryable. If cancellation interrupted
+			// the delete while another writer held the state lock, the old state is
+			// already intact; do not immediately contend for that same lock again.
+			if ((await readStateJson({ env: runtime.env, key: payload.stateKey })) === null) {
+				await writeStateJson({ env: runtime.env, key: payload.stateKey, value: resumeState });
+			}
 			pipelineResumeStateRestored = true;
 		}
 		if (

--- a/src/core/tool_runtime.ts
+++ b/src/core/tool_runtime.ts
@@ -13,10 +13,8 @@ import {
 	findStateKeyByApprovalId,
 	cleanupApprovalIndexByStateKey,
 	consumeResumeState,
-	readStateJson,
 	restoreConsumedResumeState,
 	stateJsonExists,
-	writeStateJson,
 } from "../state/store.js";
 import {
 	WorkflowResumeArgumentError,
@@ -349,7 +347,7 @@ export async function resumeToolRequest({
 	const abortedBeforeResume = runtime.signal?.aborted === true;
 	let pipelineResumeStateRestored = false;
 	let pipelineExecutionStarted = false;
-	let pipelineResumeStateClaimRejected = false;
+	let pipelineResumeStateClaimId: string | undefined;
 	const requestInputResume = isSameStageInput
 		? {
 				state: resumeState.commandInput!,
@@ -380,9 +378,9 @@ export async function resumeToolRequest({
 					signal: runtime.signal,
 				});
 				if (!consumption.consumed) {
-					pipelineResumeStateClaimRejected = true;
 					throw new Error("Pipeline resume state not found");
 				}
+				pipelineResumeStateClaimId = consumption.claimId;
 				if (consumption.signalAbortedAfterCommit) {
 					const restored = await restoreConsumedResumeState({
 						env: runtime.env,
@@ -392,14 +390,14 @@ export async function resumeToolRequest({
 					});
 					if (restored) {
 						pipelineResumeStateRestored = true;
-					} else {
-						pipelineResumeStateClaimRejected = true;
+						pipelineResumeStateClaimId = undefined;
 					}
 					runtime.signal?.throwIfAborted();
 				}
 				// The durable tombstone blocks raw-token replay even if index cleanup
 				// suffers a storage error, so an index failure cannot re-enable effects.
 				await cleanupIndex().catch(() => {});
+				runtime.signal?.throwIfAborted();
 				pipelineExecutionStarted = true;
 			},
 		});
@@ -426,6 +424,19 @@ export async function resumeToolRequest({
 		);
 	} catch (err: any) {
 		const abortedResume = runtime.signal?.aborted === true;
+		if (
+			abortedResume &&
+			!pipelineExecutionStarted &&
+			!pipelineResumeStateRestored &&
+			pipelineResumeStateClaimId
+		) {
+			pipelineResumeStateRestored = await restoreConsumedResumeState({
+				env: runtime.env,
+				key: payload.stateKey,
+				expectedState: resumeState,
+				claimId: pipelineResumeStateClaimId,
+			}).catch(() => false);
+		}
 		if (
 			abortedResume &&
 			!abortedBeforeResume &&

--- a/src/input_request.ts
+++ b/src/input_request.ts
@@ -177,6 +177,7 @@ export function createStageRequestInput({
 	getInactiveReason,
 	isOutputStarted,
 	resume,
+	onResumedInput,
 }: {
 	ctx: any;
 	stageIndex: number;
@@ -186,6 +187,7 @@ export function createStageRequestInput({
 	getInactiveReason?: () => string | undefined;
 	isOutputStarted: () => boolean;
 	resume?: CommandInputResume;
+	onResumedInput?: () => void;
 }) {
 	let requestIndex = 0;
 	const history: CommandInputHistoryEntry[] = [...(resume?.state.history ?? [])];
@@ -209,6 +211,7 @@ export function createStageRequestInput({
 			const response = snapshotJson(historical.response, "requestInput response");
 			validateRequestInputResponse(metadata.responseSchema, response, "requestInput");
 			requestIndex += 1;
+			onResumedInput?.();
 			return response;
 		}
 
@@ -234,6 +237,7 @@ export function createStageRequestInput({
 				response: historyResponse,
 			});
 			requestIndex += 1;
+			onResumedInput?.();
 			return response;
 		}
 

--- a/src/input_request.ts
+++ b/src/input_request.ts
@@ -187,7 +187,7 @@ export function createStageRequestInput({
 	getInactiveReason?: () => string | undefined;
 	isOutputStarted: () => boolean;
 	resume?: CommandInputResume;
-	onResumedInput?: () => void;
+	onResumedInput?: () => void | Promise<void>;
 }) {
 	let requestIndex = 0;
 	const history: CommandInputHistoryEntry[] = [...(resume?.state.history ?? [])];
@@ -211,7 +211,7 @@ export function createStageRequestInput({
 			const response = snapshotJson(historical.response, "requestInput response");
 			validateRequestInputResponse(metadata.responseSchema, response, "requestInput");
 			requestIndex += 1;
-			onResumedInput?.();
+			await onResumedInput?.();
 			return response;
 		}
 
@@ -237,7 +237,7 @@ export function createStageRequestInput({
 				response: historyResponse,
 			});
 			requestIndex += 1;
-			onResumedInput?.();
+			await onResumedInput?.();
 			return response;
 		}
 

--- a/src/input_request.ts
+++ b/src/input_request.ts
@@ -479,7 +479,7 @@ function assertJsonSerializable(value: unknown, label: string, seen: WeakSet<obj
 async function requestInputInteractively(ctx: any, metadata: RequestInputMetadata) {
 	ctx.stdout.write(`${metadata.prompt}\n> `);
 	const { readLineFromStream } = await import("./read_line.js");
-	const raw = await readLineFromStream(ctx.stdin, { timeoutMs: 0 });
+	const raw = await readLineFromStream(ctx.stdin, { timeoutMs: 0, signal: ctx.signal });
 	let response;
 	try {
 		response = JSON.parse(String(raw ?? "").trim());

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -97,146 +97,97 @@ export async function finalizePipelineToolRun(params: {
 	pipeline: PipelineResumeState["pipeline"];
 	output: PipelineRunOutput;
 	previousStateKey?: string;
-	signal?: AbortSignal;
 }): Promise<PipelineToolRunResolution> {
-	params.signal?.throwIfAborted();
 	const { approval, inputRequest } = extractPipelineHalt(params.output);
 	if (approval) {
-		let nextStateKey: string | undefined;
+		const nextStateKey = await savePipelineResumeState(params.env, {
+			pipeline: params.pipeline,
+			resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
+			items: approval.items,
+			haltType: "approval_request",
+			prompt: approval.prompt,
+			createdAt: new Date().toISOString(),
+		});
+		if (params.previousStateKey) {
+			await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
+			await deleteStateJson({ env: params.env, key: params.previousStateKey });
+		}
+		let approvalId: string | null;
 		try {
-			nextStateKey = await savePipelineResumeState(params.env, {
-				pipeline: params.pipeline,
-				resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
-				items: approval.items,
-				haltType: "approval_request",
-				prompt: approval.prompt,
-				createdAt: new Date().toISOString(),
-			});
-			params.signal?.throwIfAborted();
-			if (params.previousStateKey) {
-				await cleanupApprovalIndexByStateKey({
-					env: params.env,
-					stateKey: params.previousStateKey,
-				});
-				await deleteStateJson({ env: params.env, key: params.previousStateKey });
-				params.signal?.throwIfAborted();
-			}
-			const approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
-			params.signal?.throwIfAborted();
-			const resumeToken = encodeToken({
-				protocolVersion: 1,
-				v: 1,
-				kind: "pipeline-resume",
-				stateKey: nextStateKey,
-			});
-			return {
-				status: "needs_approval",
-				output: [],
-				requiresApproval: {
-					...approval,
-					resumeToken,
-					...(approvalId ? { approvalId } : null),
-				},
-				requiresInput: null,
-			};
+			approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
 		} catch (err) {
-			if (nextStateKey) {
-				await cleanupFailedResumeState(params.env, nextStateKey, err);
-			}
+			await deleteStateJson({ env: params.env, key: nextStateKey }).catch(() => {});
 			throw err;
 		}
+		const resumeToken = encodeToken({
+			protocolVersion: 1,
+			v: 1,
+			kind: "pipeline-resume",
+			stateKey: nextStateKey,
+		});
+		return {
+			status: "needs_approval",
+			output: [],
+			requiresApproval: {
+				...approval,
+				resumeToken,
+				...(approvalId ? { approvalId } : null),
+			},
+			requiresInput: null,
+		};
 	}
 
 	if (inputRequest) {
-		let nextStateKey: string | undefined;
-		try {
-			const resumeMode = inputRequest.commandInput ? "same_stage" : "next_stage";
-			nextStateKey = await savePipelineResumeState(params.env, {
-				pipeline: params.pipeline,
-				resumeAtIndex:
-					resumeMode === "same_stage"
-						? (params.output.haltedAt?.index ?? -1)
-						: (params.output.haltedAt?.index ?? -1) + 1,
-				items: resumeMode === "same_stage" ? (inputRequest.items ?? []) : [],
-				haltType: "input_request",
-				resumeMode,
-				inputSchema: inputRequest.responseSchema,
-				prompt: inputRequest.prompt,
-				...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
-				createdAt: new Date().toISOString(),
-			});
-			params.signal?.throwIfAborted();
-			if (params.previousStateKey) {
-				await cleanupApprovalIndexByStateKey({
-					env: params.env,
-					stateKey: params.previousStateKey,
-				});
-				await deleteStateJson({ env: params.env, key: params.previousStateKey });
-				params.signal?.throwIfAborted();
-			}
-			const resumeToken = encodeToken({
-				protocolVersion: 1,
-				v: 1,
-				kind: "pipeline-resume",
-				stateKey: nextStateKey,
-			});
-			return {
-				status: "needs_input",
-				output: [],
-				requiresApproval: null,
-				requiresInput: {
-					type: "input_request",
-					prompt: inputRequest.prompt,
-					responseSchema: inputRequest.responseSchema,
-					...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : null),
-					...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : null),
-					resumeToken,
-				},
-			};
-		} catch (err) {
-			if (nextStateKey) {
-				await cleanupFailedResumeState(params.env, nextStateKey, err);
-			}
-			throw err;
+		const resumeMode = inputRequest.commandInput ? "same_stage" : "next_stage";
+		const nextStateKey = await savePipelineResumeState(params.env, {
+			pipeline: params.pipeline,
+			resumeAtIndex:
+				resumeMode === "same_stage"
+					? (params.output.haltedAt?.index ?? -1)
+					: (params.output.haltedAt?.index ?? -1) + 1,
+			items: resumeMode === "same_stage" ? (inputRequest.items ?? []) : [],
+			haltType: "input_request",
+			resumeMode,
+			inputSchema: inputRequest.responseSchema,
+			prompt: inputRequest.prompt,
+			...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
+			createdAt: new Date().toISOString(),
+		});
+		if (params.previousStateKey) {
+			await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
+			await deleteStateJson({ env: params.env, key: params.previousStateKey });
 		}
+		const resumeToken = encodeToken({
+			protocolVersion: 1,
+			v: 1,
+			kind: "pipeline-resume",
+			stateKey: nextStateKey,
+		});
+		return {
+			status: "needs_input",
+			output: [],
+			requiresApproval: null,
+			requiresInput: {
+				type: "input_request",
+				prompt: inputRequest.prompt,
+				responseSchema: inputRequest.responseSchema,
+				...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : null),
+				...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : null),
+				resumeToken,
+			},
+		};
 	}
 
 	if (params.previousStateKey) {
 		await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
 		await deleteStateJson({ env: params.env, key: params.previousStateKey });
-		params.signal?.throwIfAborted();
 	}
-	params.signal?.throwIfAborted();
 	return {
 		status: "ok",
 		output: params.output.items,
 		requiresApproval: null,
 		requiresInput: null,
 	};
-}
-
-async function cleanupFailedResumeState(
-	env: Record<string, string | undefined>,
-	stateKey: string,
-	originalError: unknown,
-) {
-	const cleanupErrors: unknown[] = [];
-	try {
-		await cleanupApprovalIndexByStateKey({ env, stateKey });
-	} catch (err) {
-		cleanupErrors.push(err);
-	}
-	try {
-		await deleteStateJson({ env, key: stateKey });
-	} catch (err) {
-		cleanupErrors.push(err);
-	}
-	if (cleanupErrors.length) {
-		throw new AggregateError(
-			[originalError, ...cleanupErrors],
-			"Failed to clean up canceled pipeline resume state",
-		);
-	}
 }
 
 export async function savePipelineResumeState(

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -97,97 +97,146 @@ export async function finalizePipelineToolRun(params: {
 	pipeline: PipelineResumeState["pipeline"];
 	output: PipelineRunOutput;
 	previousStateKey?: string;
+	signal?: AbortSignal;
 }): Promise<PipelineToolRunResolution> {
+	params.signal?.throwIfAborted();
 	const { approval, inputRequest } = extractPipelineHalt(params.output);
 	if (approval) {
-		const nextStateKey = await savePipelineResumeState(params.env, {
-			pipeline: params.pipeline,
-			resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
-			items: approval.items,
-			haltType: "approval_request",
-			prompt: approval.prompt,
-			createdAt: new Date().toISOString(),
-		});
-		if (params.previousStateKey) {
-			await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
-			await deleteStateJson({ env: params.env, key: params.previousStateKey });
-		}
-		let approvalId: string | null;
+		let nextStateKey: string | undefined;
 		try {
-			approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
+			nextStateKey = await savePipelineResumeState(params.env, {
+				pipeline: params.pipeline,
+				resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
+				items: approval.items,
+				haltType: "approval_request",
+				prompt: approval.prompt,
+				createdAt: new Date().toISOString(),
+			});
+			params.signal?.throwIfAborted();
+			if (params.previousStateKey) {
+				await cleanupApprovalIndexByStateKey({
+					env: params.env,
+					stateKey: params.previousStateKey,
+				});
+				await deleteStateJson({ env: params.env, key: params.previousStateKey });
+				params.signal?.throwIfAborted();
+			}
+			const approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
+			params.signal?.throwIfAborted();
+			const resumeToken = encodeToken({
+				protocolVersion: 1,
+				v: 1,
+				kind: "pipeline-resume",
+				stateKey: nextStateKey,
+			});
+			return {
+				status: "needs_approval",
+				output: [],
+				requiresApproval: {
+					...approval,
+					resumeToken,
+					...(approvalId ? { approvalId } : null),
+				},
+				requiresInput: null,
+			};
 		} catch (err) {
-			await deleteStateJson({ env: params.env, key: nextStateKey }).catch(() => {});
+			if (nextStateKey) {
+				await cleanupFailedResumeState(params.env, nextStateKey, err);
+			}
 			throw err;
 		}
-		const resumeToken = encodeToken({
-			protocolVersion: 1,
-			v: 1,
-			kind: "pipeline-resume",
-			stateKey: nextStateKey,
-		});
-		return {
-			status: "needs_approval",
-			output: [],
-			requiresApproval: {
-				...approval,
-				resumeToken,
-				...(approvalId ? { approvalId } : null),
-			},
-			requiresInput: null,
-		};
 	}
 
 	if (inputRequest) {
-		const resumeMode = inputRequest.commandInput ? "same_stage" : "next_stage";
-		const nextStateKey = await savePipelineResumeState(params.env, {
-			pipeline: params.pipeline,
-			resumeAtIndex:
-				resumeMode === "same_stage"
-					? (params.output.haltedAt?.index ?? -1)
-					: (params.output.haltedAt?.index ?? -1) + 1,
-			items: resumeMode === "same_stage" ? (inputRequest.items ?? []) : [],
-			haltType: "input_request",
-			resumeMode,
-			inputSchema: inputRequest.responseSchema,
-			prompt: inputRequest.prompt,
-			...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
-			createdAt: new Date().toISOString(),
-		});
-		if (params.previousStateKey) {
-			await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
-			await deleteStateJson({ env: params.env, key: params.previousStateKey });
-		}
-		const resumeToken = encodeToken({
-			protocolVersion: 1,
-			v: 1,
-			kind: "pipeline-resume",
-			stateKey: nextStateKey,
-		});
-		return {
-			status: "needs_input",
-			output: [],
-			requiresApproval: null,
-			requiresInput: {
-				type: "input_request",
+		let nextStateKey: string | undefined;
+		try {
+			const resumeMode = inputRequest.commandInput ? "same_stage" : "next_stage";
+			nextStateKey = await savePipelineResumeState(params.env, {
+				pipeline: params.pipeline,
+				resumeAtIndex:
+					resumeMode === "same_stage"
+						? (params.output.haltedAt?.index ?? -1)
+						: (params.output.haltedAt?.index ?? -1) + 1,
+				items: resumeMode === "same_stage" ? (inputRequest.items ?? []) : [],
+				haltType: "input_request",
+				resumeMode,
+				inputSchema: inputRequest.responseSchema,
 				prompt: inputRequest.prompt,
-				responseSchema: inputRequest.responseSchema,
-				...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : null),
-				...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : null),
-				resumeToken,
-			},
-		};
+				...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
+				createdAt: new Date().toISOString(),
+			});
+			params.signal?.throwIfAborted();
+			if (params.previousStateKey) {
+				await cleanupApprovalIndexByStateKey({
+					env: params.env,
+					stateKey: params.previousStateKey,
+				});
+				await deleteStateJson({ env: params.env, key: params.previousStateKey });
+				params.signal?.throwIfAborted();
+			}
+			const resumeToken = encodeToken({
+				protocolVersion: 1,
+				v: 1,
+				kind: "pipeline-resume",
+				stateKey: nextStateKey,
+			});
+			return {
+				status: "needs_input",
+				output: [],
+				requiresApproval: null,
+				requiresInput: {
+					type: "input_request",
+					prompt: inputRequest.prompt,
+					responseSchema: inputRequest.responseSchema,
+					...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : null),
+					...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : null),
+					resumeToken,
+				},
+			};
+		} catch (err) {
+			if (nextStateKey) {
+				await cleanupFailedResumeState(params.env, nextStateKey, err);
+			}
+			throw err;
+		}
 	}
 
 	if (params.previousStateKey) {
 		await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
 		await deleteStateJson({ env: params.env, key: params.previousStateKey });
+		params.signal?.throwIfAborted();
 	}
+	params.signal?.throwIfAborted();
 	return {
 		status: "ok",
 		output: params.output.items,
 		requiresApproval: null,
 		requiresInput: null,
 	};
+}
+
+async function cleanupFailedResumeState(
+	env: Record<string, string | undefined>,
+	stateKey: string,
+	originalError: unknown,
+) {
+	const cleanupErrors: unknown[] = [];
+	try {
+		await cleanupApprovalIndexByStateKey({ env, stateKey });
+	} catch (err) {
+		cleanupErrors.push(err);
+	}
+	try {
+		await deleteStateJson({ env, key: stateKey });
+	} catch (err) {
+		cleanupErrors.push(err);
+	}
+	if (cleanupErrors.length) {
+		throw new AggregateError(
+			[originalError, ...cleanupErrors],
+			"Failed to clean up canceled pipeline resume state",
+		);
+	}
 }
 
 export async function savePipelineResumeState(

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -97,91 +97,119 @@ export async function finalizePipelineToolRun(params: {
 	pipeline: PipelineResumeState["pipeline"];
 	output: PipelineRunOutput;
 	previousStateKey?: string;
+	signal?: AbortSignal;
 }): Promise<PipelineToolRunResolution> {
+	params.signal?.throwIfAborted();
 	const { approval, inputRequest } = extractPipelineHalt(params.output);
 	if (approval) {
-		const nextStateKey = await savePipelineResumeState(params.env, {
-			pipeline: params.pipeline,
-			resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
-			items: approval.items,
-			haltType: "approval_request",
-			prompt: approval.prompt,
-			createdAt: new Date().toISOString(),
-		});
-		if (params.previousStateKey) {
-			await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
-			await deleteStateJson({ env: params.env, key: params.previousStateKey });
-		}
-		let approvalId: string | null;
+		let nextStateKey: string | undefined;
 		try {
+			nextStateKey = await savePipelineResumeState(
+				params.env,
+				{
+					pipeline: params.pipeline,
+					resumeAtIndex: (params.output.haltedAt?.index ?? -1) + 1,
+					items: approval.items,
+					haltType: "approval_request",
+					prompt: approval.prompt,
+					createdAt: new Date().toISOString(),
+				},
+				params.signal,
+			);
+			let approvalId: string | null;
 			approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
+			params.signal?.throwIfAborted();
+			if (params.previousStateKey) {
+				await cleanupApprovalIndexByStateKey({
+					env: params.env,
+					stateKey: params.previousStateKey,
+				});
+				await deleteStateJson({ env: params.env, key: params.previousStateKey });
+			}
+			params.signal?.throwIfAborted();
+			const resumeToken = encodeToken({
+				protocolVersion: 1,
+				v: 1,
+				kind: "pipeline-resume",
+				stateKey: nextStateKey,
+			});
+			return {
+				status: "needs_approval",
+				output: [],
+				requiresApproval: {
+					...approval,
+					resumeToken,
+					...(approvalId ? { approvalId } : null),
+				},
+				requiresInput: null,
+			};
 		} catch (err) {
-			await deleteStateJson({ env: params.env, key: nextStateKey }).catch(() => {});
+			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
 			throw err;
 		}
-		const resumeToken = encodeToken({
-			protocolVersion: 1,
-			v: 1,
-			kind: "pipeline-resume",
-			stateKey: nextStateKey,
-		});
-		return {
-			status: "needs_approval",
-			output: [],
-			requiresApproval: {
-				...approval,
-				resumeToken,
-				...(approvalId ? { approvalId } : null),
-			},
-			requiresInput: null,
-		};
 	}
 
 	if (inputRequest) {
 		const resumeMode = inputRequest.commandInput ? "same_stage" : "next_stage";
-		const nextStateKey = await savePipelineResumeState(params.env, {
-			pipeline: params.pipeline,
-			resumeAtIndex:
-				resumeMode === "same_stage"
-					? (params.output.haltedAt?.index ?? -1)
-					: (params.output.haltedAt?.index ?? -1) + 1,
-			items: resumeMode === "same_stage" ? (inputRequest.items ?? []) : [],
-			haltType: "input_request",
-			resumeMode,
-			inputSchema: inputRequest.responseSchema,
-			prompt: inputRequest.prompt,
-			...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
-			createdAt: new Date().toISOString(),
-		});
-		if (params.previousStateKey) {
-			await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
-			await deleteStateJson({ env: params.env, key: params.previousStateKey });
+		let nextStateKey: string | undefined;
+		try {
+			nextStateKey = await savePipelineResumeState(
+				params.env,
+				{
+					pipeline: params.pipeline,
+					resumeAtIndex:
+						resumeMode === "same_stage"
+							? (params.output.haltedAt?.index ?? -1)
+							: (params.output.haltedAt?.index ?? -1) + 1,
+					items: resumeMode === "same_stage" ? (inputRequest.items ?? []) : [],
+					haltType: "input_request",
+					resumeMode,
+					inputSchema: inputRequest.responseSchema,
+					prompt: inputRequest.prompt,
+					...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
+					createdAt: new Date().toISOString(),
+				},
+				params.signal,
+			);
+			if (params.previousStateKey) {
+				await cleanupApprovalIndexByStateKey({
+					env: params.env,
+					stateKey: params.previousStateKey,
+				});
+				await deleteStateJson({ env: params.env, key: params.previousStateKey });
+			}
+			params.signal?.throwIfAborted();
+			const resumeToken = encodeToken({
+				protocolVersion: 1,
+				v: 1,
+				kind: "pipeline-resume",
+				stateKey: nextStateKey,
+			});
+			return {
+				status: "needs_input",
+				output: [],
+				requiresApproval: null,
+				requiresInput: {
+					type: "input_request",
+					prompt: inputRequest.prompt,
+					responseSchema: inputRequest.responseSchema,
+					...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : null),
+					...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : null),
+					resumeToken,
+				},
+			};
+		} catch (err) {
+			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
+			throw err;
 		}
-		const resumeToken = encodeToken({
-			protocolVersion: 1,
-			v: 1,
-			kind: "pipeline-resume",
-			stateKey: nextStateKey,
-		});
-		return {
-			status: "needs_input",
-			output: [],
-			requiresApproval: null,
-			requiresInput: {
-				type: "input_request",
-				prompt: inputRequest.prompt,
-				responseSchema: inputRequest.responseSchema,
-				...(inputRequest.defaults !== undefined ? { defaults: inputRequest.defaults } : null),
-				...(inputRequest.subject !== undefined ? { subject: inputRequest.subject } : null),
-				resumeToken,
-			},
-		};
 	}
 
+	params.signal?.throwIfAborted();
 	if (params.previousStateKey) {
 		await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
 		await deleteStateJson({ env: params.env, key: params.previousStateKey });
 	}
+	params.signal?.throwIfAborted();
 	return {
 		status: "ok",
 		output: params.output.items,
@@ -193,10 +221,26 @@ export async function finalizePipelineToolRun(params: {
 export async function savePipelineResumeState(
 	env: Record<string, string | undefined>,
 	state: PipelineResumeState,
+	signal?: AbortSignal,
 ) {
 	const stateKey = `pipeline_resume_${randomUUID()}`;
-	await writeStateJson({ env, key: stateKey, value: state });
-	return stateKey;
+	try {
+		signal?.throwIfAborted();
+		await writeStateJson({ env, key: stateKey, value: state, signal });
+		signal?.throwIfAborted();
+		return stateKey;
+	} catch (err) {
+		if (signal?.aborted) await discardPipelineResumeState(env, stateKey);
+		throw err;
+	}
+}
+
+async function discardPipelineResumeState(
+	env: Record<string, string | undefined>,
+	stateKey: string,
+) {
+	await cleanupApprovalIndexByStateKey({ env, stateKey }).catch(() => {});
+	await deleteStateJson({ env, key: stateKey }).catch(() => {});
 }
 
 export async function loadPipelineResumeState(

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -44,6 +44,7 @@ export type PipelineRunOutput = {
 	items: unknown[];
 	halted?: boolean;
 	haltedAt?: { index: number } | null;
+	executionStarted?: boolean;
 };
 
 export type PipelineToolRunResolution =
@@ -133,6 +134,7 @@ export async function finalizePipelineToolRun(params: {
 				kind: "pipeline-resume",
 				stateKey: nextStateKey,
 			});
+			await retirePreviousPipelineApprovalIndex(params.env, params.previousStateKey, nextStateKey);
 			return {
 				status: "needs_approval",
 				output: [],
@@ -184,6 +186,7 @@ export async function finalizePipelineToolRun(params: {
 				kind: "pipeline-resume",
 				stateKey: nextStateKey,
 			});
+			await retirePreviousPipelineApprovalIndex(params.env, params.previousStateKey, nextStateKey);
 			return {
 				status: "needs_input",
 				output: [],
@@ -272,6 +275,18 @@ async function restorePreviousPipelineResumeState({
 	}
 	await writeStateJson({ env, key: previousStateKey, value: previousState });
 	onPreviousStateRestored?.();
+}
+
+async function retirePreviousPipelineApprovalIndex(
+	env: Record<string, string | undefined>,
+	previousStateKey: string | undefined,
+	replacementStateKey: string,
+) {
+	if (!previousStateKey || previousStateKey === replacementStateKey) return;
+	// This runs only after replacement deletion has passed its cancellation
+	// checkpoint. Do not add a later cancellation check: the transition is
+	// committed once the old approval capability is retired.
+	await cleanupApprovalIndexByStateKey({ env, stateKey: previousStateKey }).catch(() => {});
 }
 
 async function discardPipelineResumeState(

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -8,7 +8,7 @@ import {
 	deleteResumeStateWithRollback,
 	deleteStateJson,
 	isConsumedResumeState,
-	readStateJson,
+	readStateJsonWithLock,
 	restoreConsumedResumeState,
 	writeStateJson,
 } from "./state/store.js";
@@ -360,7 +360,7 @@ async function restorePreviousPipelineResumeState({
 	// Safe terminal cleanup restores its own claimed marker while still holding
 	// the state lock. Never recreate a missing snapshot here: this caller may
 	// have only observed it before another resume completed.
-	if ((await readStateJson({ env, key: previousStateKey })) !== null) {
+	if ((await readStateJsonWithLock({ env, key: previousStateKey, signal })) !== null) {
 		onPreviousStateRestored?.();
 	}
 }
@@ -395,7 +395,7 @@ async function cleanupSupersededPipelineResumeStates(
 		try {
 			// Retire only a non-executable marker after the successor itself has
 			// committed. A restored state must remain available for retry.
-			if (isConsumedResumeState(await readStateJson({ env, key: stateKey }))) {
+			if (isConsumedResumeState(await readStateJsonWithLock({ env, key: stateKey }))) {
 				await deleteStateJson({ env, key: stateKey });
 			}
 		} catch {
@@ -415,8 +415,9 @@ async function discardPipelineResumeState(
 export async function loadPipelineResumeState(
 	env: Record<string, string | undefined>,
 	stateKey: string,
+	signal?: AbortSignal,
 ) {
-	const stored = await readStateJson({ env, key: stateKey });
+	const stored = await readStateJsonWithLock({ env, key: stateKey, signal });
 	if (!stored || typeof stored !== "object" || isConsumedResumeState(stored)) {
 		throw new Error("Pipeline resume state not found");
 	}

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -5,6 +5,7 @@ import {
 	cleanupApprovalIndexByStateKey,
 	consumeResumeState,
 	createApprovalIndex,
+	deleteResumeStateWithRollback,
 	deleteStateJson,
 	isConsumedResumeState,
 	readStateJson,
@@ -229,12 +230,22 @@ export async function finalizePipelineToolRun(params: {
 	params.signal?.throwIfAborted();
 	if (params.previousStateKey) {
 		try {
-			await deleteStateJson({
-				env: params.env,
-				key: params.previousStateKey,
-				signal: params.signal,
-			});
-			params.signal?.throwIfAborted();
+			if (params.previousStateConsumed) {
+				await deleteStateJson({
+					env: params.env,
+					key: params.previousStateKey,
+					signal: params.signal,
+				});
+				params.signal?.throwIfAborted();
+			} else {
+				const deleted = await deleteResumeStateWithRollback({
+					env: params.env,
+					key: params.previousStateKey,
+					expectedState: params.previousState,
+					signal: params.signal,
+				});
+				if (!deleted) throw new Error("Pipeline resume state not found");
+			}
 			await cleanupSupersededPipelineResumeStates(
 				params.env,
 				params.previousState?.supersededResumeStateKeys,
@@ -346,12 +357,12 @@ async function restorePreviousPipelineResumeState({
 	if (!signal?.aborted || !restorePreviousStateOnAbort || !previousStateKey || !previousState) {
 		return;
 	}
+	// Safe terminal cleanup restores its own claimed marker while still holding
+	// the state lock. Never recreate a missing snapshot here: this caller may
+	// have only observed it before another resume completed.
 	if ((await readStateJson({ env, key: previousStateKey })) !== null) {
 		onPreviousStateRestored?.();
-		return;
 	}
-	await writeStateJson({ env, key: previousStateKey, value: previousState });
-	onPreviousStateRestored?.();
 }
 
 async function retirePreviousPipelineApprovalIndex(

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -3,10 +3,12 @@ import { randomUUID } from "node:crypto";
 import { encodeToken } from "./token.js";
 import {
 	cleanupApprovalIndexByStateKey,
+	consumeResumeState,
 	createApprovalIndex,
 	deleteStateJson,
 	isConsumedResumeState,
 	readStateJson,
+	restoreConsumedResumeState,
 	writeStateJson,
 } from "./state/store.js";
 import { compileCached } from "./validation.js";
@@ -21,6 +23,7 @@ export type PipelineResumeState = {
 	inputSchema?: unknown;
 	prompt?: string;
 	commandInput?: CommandInputState;
+	supersededResumeStateKeys?: string[];
 	createdAt: string;
 };
 
@@ -118,18 +121,25 @@ export async function finalizePipelineToolRun(params: {
 					items: approval.items,
 					haltType: "approval_request",
 					prompt: approval.prompt,
+					supersededResumeStateKeys: collectSupersededPipelineResumeStateKeys(
+						params.previousStateKey,
+						params.previousState,
+					),
 					createdAt: new Date().toISOString(),
 				},
 				params.signal,
 			);
 			let approvalId: string | null;
 			approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
-			await replacePipelineResumeState({
+			const replaced = await replacePipelineResumeState({
 				env: params.env,
 				previousStateKey: params.previousStateKey,
+				expectedPreviousState: params.previousState,
+				previousStateConsumed: params.previousStateConsumed,
 				replacementStateKey: nextStateKey,
 				signal: params.signal,
 			});
+			if (!replaced) throw new Error("Pipeline resume state not found");
 			const resumeToken = encodeToken({
 				protocolVersion: 1,
 				v: 1,
@@ -172,16 +182,23 @@ export async function finalizePipelineToolRun(params: {
 					inputSchema: inputRequest.responseSchema,
 					prompt: inputRequest.prompt,
 					...(inputRequest.commandInput ? { commandInput: inputRequest.commandInput } : null),
+					supersededResumeStateKeys: collectSupersededPipelineResumeStateKeys(
+						params.previousStateKey,
+						params.previousState,
+					),
 					createdAt: new Date().toISOString(),
 				},
 				params.signal,
 			);
-			await replacePipelineResumeState({
+			const replaced = await replacePipelineResumeState({
 				env: params.env,
 				previousStateKey: params.previousStateKey,
+				expectedPreviousState: params.previousState,
+				previousStateConsumed: params.previousStateConsumed,
 				replacementStateKey: nextStateKey,
 				signal: params.signal,
 			});
+			if (!replaced) throw new Error("Pipeline resume state not found");
 			const resumeToken = encodeToken({
 				protocolVersion: 1,
 				v: 1,
@@ -218,6 +235,10 @@ export async function finalizePipelineToolRun(params: {
 				signal: params.signal,
 			});
 			params.signal?.throwIfAborted();
+			await cleanupSupersededPipelineResumeStates(
+				params.env,
+				params.previousState?.supersededResumeStateKeys,
+			);
 		} catch (err) {
 			if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
 			throw err;
@@ -251,18 +272,60 @@ export async function savePipelineResumeState(
 async function replacePipelineResumeState({
 	env,
 	previousStateKey,
+	expectedPreviousState,
+	previousStateConsumed,
 	replacementStateKey,
 	signal,
 }: {
 	env: Record<string, string | undefined>;
 	previousStateKey?: string;
+	expectedPreviousState?: PipelineResumeState;
+	previousStateConsumed?: boolean;
 	replacementStateKey: string;
 	signal?: AbortSignal;
 }) {
-	if (previousStateKey && previousStateKey !== replacementStateKey) {
-		await deleteStateJson({ env, key: previousStateKey, signal });
+	if (!previousStateKey || previousStateKey === replacementStateKey) {
+		signal?.throwIfAborted();
+		return true;
 	}
-	signal?.throwIfAborted();
+	// The current resume has already crossed an unsafe boundary and owns the
+	// predecessor's consumed marker. It may safely publish the next gate, but
+	// must retain that marker rather than attempting a stale snapshot CAS.
+	if (previousStateConsumed) {
+		signal?.throwIfAborted();
+		return true;
+	}
+	if (!expectedPreviousState) return false;
+
+	let claimId: string | undefined;
+	try {
+		const consumption = await consumeResumeState({
+			env,
+			key: previousStateKey,
+			expectedState: expectedPreviousState,
+			signal,
+		});
+		if (!consumption.consumed) return false;
+		claimId = consumption.claimId;
+		// The predecessor remains as a durable tombstone until terminal cleanup.
+		// A concurrent caller can therefore never turn the same approval into a
+		// second successor capability.
+		signal?.throwIfAborted();
+		return true;
+	} catch (err) {
+		// A cancellation after the atomic marker publication has not exposed the
+		// successor token yet. Restore only the marker created by this caller so a
+		// competing transition can never be overwritten.
+		if (claimId && signal?.aborted) {
+			await restoreConsumedResumeState({
+				env,
+				key: previousStateKey,
+				expectedState: expectedPreviousState,
+				claimId,
+			}).catch(() => {});
+		}
+		throw err;
+	}
 }
 
 async function restorePreviousPipelineResumeState({
@@ -303,6 +366,33 @@ async function retirePreviousPipelineApprovalIndex(
 	await cleanupApprovalIndexByStateKey({ env, stateKey: previousStateKey }).catch(() => {});
 }
 
+function collectSupersededPipelineResumeStateKeys(
+	previousStateKey: string | undefined,
+	previousState: PipelineResumeState | undefined,
+) {
+	return [
+		...(previousState?.supersededResumeStateKeys ?? []),
+		...(previousStateKey ? [previousStateKey] : []),
+	].filter((stateKey, index, all) => stateKey && all.indexOf(stateKey) === index);
+}
+
+async function cleanupSupersededPipelineResumeStates(
+	env: Record<string, string | undefined>,
+	stateKeys: string[] | undefined,
+) {
+	for (const stateKey of stateKeys ?? []) {
+		try {
+			// Retire only a non-executable marker after the successor itself has
+			// committed. A restored state must remain available for retry.
+			if (isConsumedResumeState(await readStateJson({ env, key: stateKey }))) {
+				await deleteStateJson({ env, key: stateKey });
+			}
+		} catch {
+			// Leaving a tombstone is safe if best-effort cleanup cannot complete.
+		}
+	}
+}
+
 async function discardPipelineResumeState(
 	env: Record<string, string | undefined>,
 	stateKey: string,
@@ -331,6 +421,13 @@ export async function loadPipelineResumeState(
 		throw new Error("Invalid pipeline resume state");
 	}
 	if (!Array.isArray(data.items)) throw new Error("Invalid pipeline resume state");
+	if (
+		data.supersededResumeStateKeys !== undefined &&
+		(!Array.isArray(data.supersededResumeStateKeys) ||
+			data.supersededResumeStateKeys.some((stateKey) => typeof stateKey !== "string"))
+	) {
+		throw new Error("Invalid pipeline resume state");
+	}
 	if (
 		data.haltType !== undefined &&
 		!["approval_request", "input_request"].includes(data.haltType)

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -210,7 +210,11 @@ export async function finalizePipelineToolRun(params: {
 	params.signal?.throwIfAborted();
 	if (params.previousStateKey) {
 		try {
-			await deleteStateJson({ env: params.env, key: params.previousStateKey });
+			await deleteStateJson({
+				env: params.env,
+				key: params.previousStateKey,
+				signal: params.signal,
+			});
 			params.signal?.throwIfAborted();
 		} catch (err) {
 			await restorePreviousPipelineResumeState(params);
@@ -254,7 +258,7 @@ async function replacePipelineResumeState({
 	signal?: AbortSignal;
 }) {
 	if (previousStateKey && previousStateKey !== replacementStateKey) {
-		await deleteStateJson({ env, key: previousStateKey });
+		await deleteStateJson({ env, key: previousStateKey, signal });
 	}
 	signal?.throwIfAborted();
 }
@@ -275,6 +279,10 @@ async function restorePreviousPipelineResumeState({
 	signal?: AbortSignal;
 }) {
 	if (!signal?.aborted || !restorePreviousStateOnAbort || !previousStateKey || !previousState) {
+		return;
+	}
+	if ((await readStateJson({ env, key: previousStateKey })) !== null) {
+		onPreviousStateRestored?.();
 		return;
 	}
 	await writeStateJson({ env, key: previousStateKey, value: previousState });

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -5,6 +5,7 @@ import {
 	cleanupApprovalIndexByStateKey,
 	createApprovalIndex,
 	deleteStateJson,
+	isConsumedResumeState,
 	readStateJson,
 	writeStateJson,
 } from "./state/store.js";
@@ -99,6 +100,7 @@ export async function finalizePipelineToolRun(params: {
 	output: PipelineRunOutput;
 	previousStateKey?: string;
 	previousState?: PipelineResumeState;
+	previousStateConsumed?: boolean;
 	restorePreviousStateOnAbort?: boolean;
 	onPreviousStateRestored?: () => void;
 	signal?: AbortSignal;
@@ -146,7 +148,7 @@ export async function finalizePipelineToolRun(params: {
 				requiresInput: null,
 			};
 		} catch (err) {
-			await restorePreviousPipelineResumeState(params);
+			if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
 			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
 			throw err;
 		}
@@ -201,7 +203,7 @@ export async function finalizePipelineToolRun(params: {
 				},
 			};
 		} catch (err) {
-			await restorePreviousPipelineResumeState(params);
+			if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
 			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
 			throw err;
 		}
@@ -217,7 +219,7 @@ export async function finalizePipelineToolRun(params: {
 			});
 			params.signal?.throwIfAborted();
 		} catch (err) {
-			await restorePreviousPipelineResumeState(params);
+			if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
 			throw err;
 		}
 	}
@@ -314,7 +316,7 @@ export async function loadPipelineResumeState(
 	stateKey: string,
 ) {
 	const stored = await readStateJson({ env, key: stateKey });
-	if (!stored || typeof stored !== "object") {
+	if (!stored || typeof stored !== "object" || isConsumedResumeState(stored)) {
 		throw new Error("Pipeline resume state not found");
 	}
 	const data = stored as Partial<PipelineResumeState>;

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -209,10 +209,14 @@ export async function finalizePipelineToolRun(params: {
 
 	params.signal?.throwIfAborted();
 	if (params.previousStateKey) {
-		await cleanupApprovalIndexByStateKey({ env: params.env, stateKey: params.previousStateKey });
-		await deleteStateJson({ env: params.env, key: params.previousStateKey });
+		try {
+			await deleteStateJson({ env: params.env, key: params.previousStateKey });
+			params.signal?.throwIfAborted();
+		} catch (err) {
+			await restorePreviousPipelineResumeState(params);
+			throw err;
+		}
 	}
-	params.signal?.throwIfAborted();
 	return {
 		status: "ok",
 		output: params.output.items,

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -159,8 +159,11 @@ export async function finalizePipelineToolRun(params: {
 				requiresInput: null,
 			};
 		} catch (err) {
-			if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
-			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
+			try {
+				if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
+			} finally {
+				if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
+			}
 			throw err;
 		}
 	}
@@ -221,8 +224,11 @@ export async function finalizePipelineToolRun(params: {
 				},
 			};
 		} catch (err) {
-			if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
-			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
+			try {
+				if (!params.previousStateConsumed) await restorePreviousPipelineResumeState(params);
+			} finally {
+				if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
+			}
 			throw err;
 		}
 	}

--- a/src/pipeline_resume_state.ts
+++ b/src/pipeline_resume_state.ts
@@ -97,6 +97,9 @@ export async function finalizePipelineToolRun(params: {
 	pipeline: PipelineResumeState["pipeline"];
 	output: PipelineRunOutput;
 	previousStateKey?: string;
+	previousState?: PipelineResumeState;
+	restorePreviousStateOnAbort?: boolean;
+	onPreviousStateRestored?: () => void;
 	signal?: AbortSignal;
 }): Promise<PipelineToolRunResolution> {
 	params.signal?.throwIfAborted();
@@ -118,15 +121,12 @@ export async function finalizePipelineToolRun(params: {
 			);
 			let approvalId: string | null;
 			approvalId = await createApprovalIndex({ env: params.env, stateKey: nextStateKey });
-			params.signal?.throwIfAborted();
-			if (params.previousStateKey) {
-				await cleanupApprovalIndexByStateKey({
-					env: params.env,
-					stateKey: params.previousStateKey,
-				});
-				await deleteStateJson({ env: params.env, key: params.previousStateKey });
-			}
-			params.signal?.throwIfAborted();
+			await replacePipelineResumeState({
+				env: params.env,
+				previousStateKey: params.previousStateKey,
+				replacementStateKey: nextStateKey,
+				signal: params.signal,
+			});
 			const resumeToken = encodeToken({
 				protocolVersion: 1,
 				v: 1,
@@ -144,6 +144,7 @@ export async function finalizePipelineToolRun(params: {
 				requiresInput: null,
 			};
 		} catch (err) {
+			await restorePreviousPipelineResumeState(params);
 			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
 			throw err;
 		}
@@ -171,14 +172,12 @@ export async function finalizePipelineToolRun(params: {
 				},
 				params.signal,
 			);
-			if (params.previousStateKey) {
-				await cleanupApprovalIndexByStateKey({
-					env: params.env,
-					stateKey: params.previousStateKey,
-				});
-				await deleteStateJson({ env: params.env, key: params.previousStateKey });
-			}
-			params.signal?.throwIfAborted();
+			await replacePipelineResumeState({
+				env: params.env,
+				previousStateKey: params.previousStateKey,
+				replacementStateKey: nextStateKey,
+				signal: params.signal,
+			});
 			const resumeToken = encodeToken({
 				protocolVersion: 1,
 				v: 1,
@@ -199,6 +198,7 @@ export async function finalizePipelineToolRun(params: {
 				},
 			};
 		} catch (err) {
+			await restorePreviousPipelineResumeState(params);
 			if (nextStateKey) await discardPipelineResumeState(params.env, nextStateKey);
 			throw err;
 		}
@@ -233,6 +233,45 @@ export async function savePipelineResumeState(
 		if (signal?.aborted) await discardPipelineResumeState(env, stateKey);
 		throw err;
 	}
+}
+
+async function replacePipelineResumeState({
+	env,
+	previousStateKey,
+	replacementStateKey,
+	signal,
+}: {
+	env: Record<string, string | undefined>;
+	previousStateKey?: string;
+	replacementStateKey: string;
+	signal?: AbortSignal;
+}) {
+	if (previousStateKey && previousStateKey !== replacementStateKey) {
+		await deleteStateJson({ env, key: previousStateKey });
+	}
+	signal?.throwIfAborted();
+}
+
+async function restorePreviousPipelineResumeState({
+	env,
+	previousStateKey,
+	previousState,
+	restorePreviousStateOnAbort,
+	onPreviousStateRestored,
+	signal,
+}: {
+	env: Record<string, string | undefined>;
+	previousStateKey?: string;
+	previousState?: PipelineResumeState;
+	restorePreviousStateOnAbort?: boolean;
+	onPreviousStateRestored?: () => void;
+	signal?: AbortSignal;
+}) {
+	if (!signal?.aborted || !restorePreviousStateOnAbort || !previousStateKey || !previousState) {
+		return;
+	}
+	await writeStateJson({ env, key: previousStateKey, value: previousState });
+	onPreviousStateRestored?.();
 }
 
 async function discardPipelineResumeState(

--- a/src/read_line.ts
+++ b/src/read_line.ts
@@ -1,5 +1,9 @@
-export function readLineFromStream(stream: NodeJS.ReadableStream, opts?: { timeoutMs?: number }) {
+export function readLineFromStream(
+	stream: NodeJS.ReadableStream,
+	opts?: { timeoutMs?: number; signal?: AbortSignal },
+) {
 	const timeoutMs = Number(opts?.timeoutMs ?? 0);
+	const signal = opts?.signal;
 
 	return new Promise<string>((resolve, reject) => {
 		let settled = false;
@@ -11,6 +15,7 @@ export function readLineFromStream(stream: NodeJS.ReadableStream, opts?: { timeo
 			stream.off("end", onEnd);
 			stream.off("close", onClose);
 			stream.off("error", onError);
+			signal?.removeEventListener("abort", onAbort);
 			if (timer) clearTimeout(timer);
 		};
 
@@ -39,6 +44,15 @@ export function readLineFromStream(stream: NodeJS.ReadableStream, opts?: { timeo
 		const onEnd = () => finish(buf);
 		const onClose = () => finish(buf);
 		const onError = (err: Error) => fail(err);
+		const onAbort = () => {
+			const reason = signal?.reason;
+			fail(reason instanceof Error ? reason : new Error("Input read aborted"));
+		};
+
+		if (signal?.aborted) {
+			onAbort();
+			return;
+		}
 
 		if (timeoutMs > 0) {
 			timer = setTimeout(() => {
@@ -50,5 +64,6 @@ export function readLineFromStream(stream: NodeJS.ReadableStream, opts?: { timeo
 		stream.on("end", onEnd);
 		stream.on("close", onClose);
 		stream.on("error", onError);
+		signal?.addEventListener("abort", onAbort, { once: true });
 	});
 }

--- a/src/read_line.ts
+++ b/src/read_line.ts
@@ -15,6 +15,7 @@ export function readLineFromStream(
 			stream.off("end", onEnd);
 			stream.off("close", onClose);
 			stream.off("error", onError);
+			stream.pause();
 			signal?.removeEventListener("abort", onAbort);
 			if (timer) clearTimeout(timer);
 		};

--- a/src/read_line.ts
+++ b/src/read_line.ts
@@ -1,4 +1,9 @@
 const unreadInput = new WeakMap<NodeJS.ReadableStream, string>();
+type ObservableReadableStream = NodeJS.ReadableStream & {
+	readableEnded?: boolean;
+	destroyed?: boolean;
+	closed?: boolean;
+};
 
 export function readLineFromStream(
 	stream: NodeJS.ReadableStream,
@@ -6,6 +11,7 @@ export function readLineFromStream(
 ) {
 	const timeoutMs = Number(opts?.timeoutMs ?? 0);
 	const signal = opts?.signal;
+	const observableStream = stream as ObservableReadableStream;
 
 	return new Promise<string>((resolve, reject) => {
 		let settled = false;
@@ -81,6 +87,10 @@ export function readLineFromStream(
 		stream.on("close", onClose);
 		stream.on("error", onError);
 		signal?.addEventListener("abort", onAbort, { once: true });
-		if (!consumeLine()) stream.resume();
+		if (!consumeLine()) {
+			if (observableStream.readableEnded || observableStream.destroyed || observableStream.closed)
+				onEnd();
+			else stream.resume();
+		}
 	});
 }

--- a/src/read_line.ts
+++ b/src/read_line.ts
@@ -56,12 +56,20 @@ export function readLineFromStream(
 			buf += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
 			consumeLine();
 		};
+		const drainBuffered = () => {
+			let chunk: Buffer | string | null;
+			while (!settled && (chunk = stream.read()) !== null) onData(chunk);
+		};
 
 		const onEnd = () => {
+			drainBuffered();
+			if (settled) return;
 			unreadInput.delete(stream);
 			finish(buf);
 		};
 		const onClose = () => {
+			drainBuffered();
+			if (settled) return;
 			unreadInput.delete(stream);
 			finish(buf);
 		};
@@ -87,7 +95,8 @@ export function readLineFromStream(
 		stream.on("close", onClose);
 		stream.on("error", onError);
 		signal?.addEventListener("abort", onAbort, { once: true });
-		if (!consumeLine()) {
+		drainBuffered();
+		if (!settled && !consumeLine()) {
 			if (observableStream.readableEnded || observableStream.destroyed || observableStream.closed)
 				onEnd();
 			else stream.resume();

--- a/src/read_line.ts
+++ b/src/read_line.ts
@@ -10,12 +10,12 @@ export function readLineFromStream(
 		let buf = "";
 		let timer: NodeJS.Timeout | null = null;
 
-		const cleanup = () => {
+		const cleanup = ({ pauseStream = false } = {}) => {
 			stream.off("data", onData);
 			stream.off("end", onEnd);
 			stream.off("close", onClose);
 			stream.off("error", onError);
-			stream.pause();
+			if (pauseStream) stream.pause();
 			signal?.removeEventListener("abort", onAbort);
 			if (timer) clearTimeout(timer);
 		};
@@ -27,10 +27,10 @@ export function readLineFromStream(
 			resolve(value);
 		};
 
-		const fail = (err: Error) => {
+		const fail = (err: Error, { pauseStream = false } = {}) => {
 			if (settled) return;
 			settled = true;
-			cleanup();
+			cleanup({ pauseStream });
 			reject(err);
 		};
 
@@ -47,7 +47,9 @@ export function readLineFromStream(
 		const onError = (err: Error) => fail(err);
 		const onAbort = () => {
 			const reason = signal?.reason;
-			fail(reason instanceof Error ? reason : new Error("Input read aborted"));
+			fail(reason instanceof Error ? reason : new Error("Input read aborted"), {
+				pauseStream: true,
+			});
 		};
 
 		if (signal?.aborted) {

--- a/src/read_line.ts
+++ b/src/read_line.ts
@@ -1,3 +1,5 @@
+const unreadInput = new WeakMap<NodeJS.ReadableStream, string>();
+
 export function readLineFromStream(
 	stream: NodeJS.ReadableStream,
 	opts?: { timeoutMs?: number; signal?: AbortSignal },
@@ -7,15 +9,16 @@ export function readLineFromStream(
 
 	return new Promise<string>((resolve, reject) => {
 		let settled = false;
-		let buf = "";
+		let buf = unreadInput.get(stream) ?? "";
+		unreadInput.delete(stream);
 		let timer: NodeJS.Timeout | null = null;
 
-		const cleanup = ({ pauseStream = false } = {}) => {
+		const cleanup = () => {
 			stream.off("data", onData);
 			stream.off("end", onEnd);
 			stream.off("close", onClose);
 			stream.off("error", onError);
-			if (pauseStream) stream.pause();
+			stream.pause();
 			signal?.removeEventListener("abort", onAbort);
 			if (timer) clearTimeout(timer);
 		};
@@ -27,29 +30,39 @@ export function readLineFromStream(
 			resolve(value);
 		};
 
-		const fail = (err: Error, { pauseStream = false } = {}) => {
+		const fail = (err: Error) => {
 			if (settled) return;
 			settled = true;
-			cleanup({ pauseStream });
+			unreadInput.delete(stream);
+			cleanup();
 			reject(err);
+		};
+
+		const consumeLine = () => {
+			const idx = buf.indexOf("\n");
+			if (idx === -1) return false;
+			unreadInput.set(stream, buf.slice(idx + 1));
+			finish(buf.slice(0, idx));
+			return true;
 		};
 
 		const onData = (chunk: Buffer | string) => {
 			buf += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
-			const idx = buf.indexOf("\n");
-			if (idx !== -1) {
-				finish(buf.slice(0, idx));
-			}
+			consumeLine();
 		};
 
-		const onEnd = () => finish(buf);
-		const onClose = () => finish(buf);
+		const onEnd = () => {
+			unreadInput.delete(stream);
+			finish(buf);
+		};
+		const onClose = () => {
+			unreadInput.delete(stream);
+			finish(buf);
+		};
 		const onError = (err: Error) => fail(err);
 		const onAbort = () => {
 			const reason = signal?.reason;
-			fail(reason instanceof Error ? reason : new Error("Input read aborted"), {
-				pauseStream: true,
-			});
+			fail(reason instanceof Error ? reason : new Error("Input read aborted"));
 		};
 
 		if (signal?.aborted) {
@@ -68,5 +81,6 @@ export function readLineFromStream(
 		stream.on("close", onClose);
 		stream.on("error", onError);
 		signal?.addEventListener("abort", onAbort, { once: true });
+		if (!consumeLine()) stream.resume();
 	});
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -132,7 +132,7 @@ export async function runPipeline({
 			commandActive = false;
 			inactiveReason = "requestInput cannot suspend from lazy output before downstream stages";
 			assertRequestInputResumeConsumed(stageResume);
-			stream = trackCommandOutput(
+			const trackedOutput = trackCommandOutput(
 				output,
 				() => {
 					commandOutputStarted = true;
@@ -141,6 +141,9 @@ export async function runPipeline({
 				(err) => assertNoUnconsumedResumeAfterError(stageResume, err),
 				finishStage,
 			);
+			stream = haltAfterStageOnAbort
+				? throwIfAbortedAfterDrain(trackedOutput, signal)
+				: trackedOutput;
 		} else {
 			stream = output
 				? trackCommandOutput(
@@ -242,6 +245,16 @@ function formatStageArgs(args: Record<string, unknown>) {
 function streamFromItems(items: unknown[]) {
 	return (async function* () {
 		for (const item of items) yield item;
+	})();
+}
+
+function throwIfAbortedAfterDrain(
+	input: AsyncIterable<unknown> | Iterable<unknown>,
+	signal?: AbortSignal,
+) {
+	return (async function* () {
+		for await (const item of input) yield item;
+		signal?.throwIfAborted();
 	})();
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -167,7 +167,6 @@ export async function runPipeline({
 		}
 	}
 
-	const abortedBeforeFinalDrain = signal?.aborted === true;
 	const items = [];
 	try {
 		for await (const item of stream) items.push(item);
@@ -179,7 +178,7 @@ export async function runPipeline({
 			throw err;
 		}
 	}
-	if (haltAfterStageOnAbort && !abortedBeforeFinalDrain) signal?.throwIfAborted();
+	if (haltAfterStageOnAbort) signal?.throwIfAborted();
 	assertRequestInputResumeConsumed(requestInputResume);
 
 	return { items, rendered, halted, haltedAt };

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -247,17 +247,63 @@ function streamFromItems(items: unknown[]) {
 	})();
 }
 
-function throwIfAbortedAfterDrain(
-	input: AsyncIterable<unknown> | Iterable<unknown>,
-	signal?: AbortSignal,
-) {
+function throwIfAbortedAfterDrain(input: AsyncIterable<unknown>, signal?: AbortSignal) {
 	return (async function* () {
-		for await (const item of input) {
+		const iterator = input[Symbol.asyncIterator]();
+		let completed = false;
+		try {
+			while (true) {
+				const next = await nextWithAbort(iterator, signal);
+				if (next.done) {
+					completed = true;
+					break;
+				}
+				signal?.throwIfAborted();
+				yield next.value;
+			}
 			signal?.throwIfAborted();
-			yield item;
+		} finally {
+			if (!completed) await closeAfterAbortedRead(iterator, signal);
 		}
-		signal?.throwIfAborted();
 	})();
+}
+
+async function closeAfterAbortedRead(iterator: AsyncIterator<unknown>, signal?: AbortSignal) {
+	if (typeof iterator.return !== "function") return;
+	try {
+		const close = iterator.return();
+		if (signal?.aborted) {
+			void Promise.resolve(close).catch(() => {});
+			return;
+		}
+		await close;
+	} catch (err) {
+		if (!signal?.aborted) throw err;
+	}
+}
+
+async function nextWithAbort(iterator: AsyncIterator<unknown>, signal?: AbortSignal) {
+	if (!signal) return iterator.next();
+	signal.throwIfAborted();
+
+	let onAbort!: () => void;
+	const aborted = new Promise<never>((_resolve, reject) => {
+		onAbort = () => {
+			try {
+				signal.throwIfAborted();
+			} catch (err) {
+				reject(err);
+			}
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	if (signal.aborted) onAbort();
+
+	try {
+		return await Promise.race([iterator.next(), aborted]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
 }
 
 function trackCommandOutput(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -20,6 +20,7 @@ export async function runPipeline({
 	cwd = undefined,
 	llmAdapters = undefined,
 	signal = undefined,
+	haltAfterStageOnAbort = false,
 	dryRun = false,
 	requestInputResume = undefined,
 	requestInputEnabled = true,
@@ -35,6 +36,7 @@ export async function runPipeline({
 	cwd?: string | undefined;
 	llmAdapters?: Record<string, any> | undefined;
 	signal?: AbortSignal | undefined;
+	haltAfterStageOnAbort?: boolean;
 	dryRun?: boolean;
 	requestInputResume?: CommandInputResume | undefined;
 	requestInputEnabled?: boolean;
@@ -120,11 +122,12 @@ export async function runPipeline({
 			rendered = true;
 		}
 
+		let stageHalted = Boolean(result?.halt || (haltAfterStageOnAbort && signal?.aborted));
 		const output = result?.output;
 		if (Array.isArray(output)) {
 			stream = output;
 			await finishStage();
-		} else if (output && !result?.halt && idx < pipeline.length - 1) {
+		} else if (output && !stageHalted && idx < pipeline.length - 1) {
 			commandActive = false;
 			inactiveReason = "requestInput cannot suspend from lazy output before downstream stages";
 			assertRequestInputResumeConsumed(stageResume);
@@ -152,7 +155,8 @@ export async function runPipeline({
 			if (!output) await finishStage();
 		}
 
-		if (result?.halt) {
+		stageHalted ||= Boolean(haltAfterStageOnAbort && signal?.aborted);
+		if (stageHalted) {
 			halted = true;
 			haltedAt = { index: idx, stage };
 			break;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -252,7 +252,10 @@ function throwIfAbortedAfterDrain(
 	signal?: AbortSignal,
 ) {
 	return (async function* () {
-		for await (const item of input) yield item;
+		for await (const item of input) {
+			signal?.throwIfAborted();
+			yield item;
+		}
 		signal?.throwIfAborted();
 	})();
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -39,7 +39,6 @@ export async function runPipeline({
 	requestInputResume?: CommandInputResume | undefined;
 	requestInputEnabled?: boolean;
 }) {
-	signal?.throwIfAborted();
 	if (dryRun) {
 		return dryRunPipeline({ pipeline, registry, stderr });
 	}
@@ -63,7 +62,6 @@ export async function runPipeline({
 	};
 
 	for (let idx = 0; idx < pipeline.length; idx++) {
-		signal?.throwIfAborted();
 		const stage = pipeline[idx];
 		const command = registry.get(stage.name);
 		if (!command) {
@@ -111,7 +109,6 @@ export async function runPipeline({
 		let result;
 		try {
 			result = await command.run({ input: inputTracker.iterable, args: stage.args, ctx: stageCtx });
-			signal?.throwIfAborted();
 		} catch (err) {
 			await finishStage({ assertResume: false, suppressCloseErrors: true });
 			if (haltForInputRequest(err)) break;
@@ -164,19 +161,11 @@ export async function runPipeline({
 
 	const items = [];
 	try {
-		for await (const item of stream) {
-			signal?.throwIfAborted();
-			items.push(item);
-		}
-		signal?.throwIfAborted();
+		for await (const item of stream) items.push(item);
 	} catch (err) {
 		if (haltForInputRequest(err)) {
 			items.length = 0;
-			for await (const item of stream) {
-				signal?.throwIfAborted();
-				items.push(item);
-			}
-			signal?.throwIfAborted();
+			for await (const item of stream) items.push(item);
 		} else {
 			throw err;
 		}
@@ -187,7 +176,6 @@ export async function runPipeline({
 
 	function haltForInputRequest(err: unknown) {
 		if (!(err instanceof InputRequestSuspension)) return false;
-		signal?.throwIfAborted();
 		const stageIndex = err.stageIndex;
 		halted = true;
 		haltedAt = {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -39,6 +39,7 @@ export async function runPipeline({
 	requestInputResume?: CommandInputResume | undefined;
 	requestInputEnabled?: boolean;
 }) {
+	signal?.throwIfAborted();
 	if (dryRun) {
 		return dryRunPipeline({ pipeline, registry, stderr });
 	}
@@ -62,6 +63,7 @@ export async function runPipeline({
 	};
 
 	for (let idx = 0; idx < pipeline.length; idx++) {
+		signal?.throwIfAborted();
 		const stage = pipeline[idx];
 		const command = registry.get(stage.name);
 		if (!command) {
@@ -109,6 +111,7 @@ export async function runPipeline({
 		let result;
 		try {
 			result = await command.run({ input: inputTracker.iterable, args: stage.args, ctx: stageCtx });
+			signal?.throwIfAborted();
 		} catch (err) {
 			await finishStage({ assertResume: false, suppressCloseErrors: true });
 			if (haltForInputRequest(err)) break;
@@ -161,11 +164,19 @@ export async function runPipeline({
 
 	const items = [];
 	try {
-		for await (const item of stream) items.push(item);
+		for await (const item of stream) {
+			signal?.throwIfAborted();
+			items.push(item);
+		}
+		signal?.throwIfAborted();
 	} catch (err) {
 		if (haltForInputRequest(err)) {
 			items.length = 0;
-			for await (const item of stream) items.push(item);
+			for await (const item of stream) {
+				signal?.throwIfAborted();
+				items.push(item);
+			}
+			signal?.throwIfAborted();
 		} else {
 			throw err;
 		}
@@ -176,6 +187,7 @@ export async function runPipeline({
 
 	function haltForInputRequest(err: unknown) {
 		if (!(err instanceof InputRequestSuspension)) return false;
+		signal?.throwIfAborted();
 		const stageIndex = err.stageIndex;
 		halted = true;
 		haltedAt = {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -64,6 +64,7 @@ export async function runPipeline({
 	};
 
 	for (let idx = 0; idx < pipeline.length; idx++) {
+		if (haltAfterStageOnAbort) signal?.throwIfAborted();
 		const stage = pipeline[idx];
 		const command = registry.get(stage.name);
 		if (!command) {
@@ -163,6 +164,7 @@ export async function runPipeline({
 		}
 	}
 
+	const abortedBeforeFinalDrain = signal?.aborted === true;
 	const items = [];
 	try {
 		for await (const item of stream) items.push(item);
@@ -174,6 +176,7 @@ export async function runPipeline({
 			throw err;
 		}
 	}
+	if (haltAfterStageOnAbort && !abortedBeforeFinalDrain) signal?.throwIfAborted();
 	assertRequestInputResumeConsumed(requestInputResume);
 
 	return { items, rendered, halted, haltedAt };

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -280,10 +280,8 @@ function throwIfAbortedAfterDrain(input: AsyncIterable<unknown>, signal?: AbortS
 					completed = true;
 					break;
 				}
-				// Once cancellation begins, keep draining values which are already
-				// immediately available so generator cleanup runs, but never expose
-				// them as tool output. A stalled read is interrupted by nextWithAbort.
-				if (!signal?.aborted) yield next.value;
+				signal?.throwIfAborted();
+				yield next.value;
 			}
 			signal?.throwIfAborted();
 		} finally {
@@ -312,9 +310,9 @@ async function closeAfterAbortedRead(
 		const close = iterator.return();
 		if (signal?.aborted && !abort) {
 			// Legacy iterators cannot interrupt an in-flight next(). Keep the
-			// existing prompt cancellation behavior, while still giving a normally
-			// settling generator one event-loop turn to run its finally cleanup.
-			await settleBeforeNextTurn(close);
+			// existing prompt cancellation behavior, while resource-owning sources
+			// opt into the abort hook above so their cleanup is awaited.
+			void Promise.resolve(close).catch(() => {});
 			return;
 		}
 		await close;
@@ -325,21 +323,16 @@ async function closeAfterAbortedRead(
 
 async function nextWithAbort(iterator: AsyncIterator<unknown>, signal?: AbortSignal) {
 	if (!signal) return iterator.next();
+	signal.throwIfAborted();
 
 	let onAbort!: () => void;
-	let abortTimer: ReturnType<typeof setTimeout> | undefined;
 	const aborted = new Promise<never>((_resolve, reject) => {
 		onAbort = () => {
-			// Give a synchronous or microtask-ready iterator a chance to finish its
-			// cleanup path. A genuinely stalled read is still interrupted on the
-			// next event-loop turn.
-			abortTimer = setTimeout(() => {
-				try {
-					signal.throwIfAborted();
-				} catch (err) {
-					reject(err);
-				}
-			}, 0);
+			try {
+				signal.throwIfAborted();
+			} catch (err) {
+				reject(err);
+			}
 		};
 		signal.addEventListener("abort", onAbort, { once: true });
 	});
@@ -348,22 +341,7 @@ async function nextWithAbort(iterator: AsyncIterator<unknown>, signal?: AbortSig
 	try {
 		return await Promise.race([iterator.next(), aborted]);
 	} finally {
-		if (abortTimer) clearTimeout(abortTimer);
 		signal.removeEventListener("abort", onAbort);
-	}
-}
-
-async function settleBeforeNextTurn(promise: Promise<unknown>) {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		await Promise.race([
-			Promise.resolve(promise).catch(() => {}),
-			new Promise<void>((resolve) => {
-				timer = setTimeout(resolve, 0);
-			}),
-		]);
-	} finally {
-		if (timer) clearTimeout(timer);
 	}
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -116,6 +116,8 @@ export async function runPipeline({
 						getInactiveReason: () => inactiveReason,
 						isOutputStarted: () => pipelineOutputStarted || commandOutputStarted,
 						resume: stageResume,
+						onResumedInput:
+							command.meta?.resumeSafeAfterInput === true ? undefined : markExecutionStarted,
 					})
 				: createUnsupportedRequestInput(),
 		};
@@ -275,16 +277,36 @@ function throwIfAbortedAfterDrain(input: AsyncIterable<unknown>, signal?: AbortS
 			}
 			signal?.throwIfAborted();
 		} finally {
-			if (!completed) await closeAfterAbortedRead(iterator, signal);
+			if (!completed) await closeAfterAbortedRead(input, iterator, signal);
 		}
 	})();
 }
 
-async function closeAfterAbortedRead(iterator: AsyncIterator<unknown>, signal?: AbortSignal) {
-	if (typeof iterator.return !== "function") return;
+type CancellableLazyOutput = {
+	abort?: (reason?: unknown) => void | Promise<void>;
+	awaitReturnOnAbort?: boolean;
+};
+
+async function closeAfterAbortedRead(
+	input: AsyncIterable<unknown>,
+	iterator: AsyncIterator<unknown>,
+	signal?: AbortSignal,
+) {
+	const cancellable = iterator as AsyncIterator<unknown> & CancellableLazyOutput;
+	const inputCancellable = input as AsyncIterable<unknown> & CancellableLazyOutput;
+	const abort = cancellable.abort ?? inputCancellable.abort;
+	const awaitReturnOnAbort =
+		cancellable.awaitReturnOnAbort === true || inputCancellable.awaitReturnOnAbort === true;
 	try {
+		// A source that owns a pending timer, socket, or process can expose this
+		// small cancellation hook. It must release the pending next() operation.
+		if (signal?.aborted && abort) await abort(signal.reason);
+		if (typeof iterator.return !== "function") return;
 		const close = iterator.return();
-		if (signal?.aborted) {
+		if (signal?.aborted && !abort && !awaitReturnOnAbort) {
+			// Legacy iterators cannot interrupt an in-flight next(). Keep the
+			// existing prompt cancellation behavior, while resource-owning sources
+			// opt into the abort hook above so their cleanup is awaited.
 			void Promise.resolve(close).catch(() => {});
 			return;
 		}
@@ -328,7 +350,7 @@ function trackCommandOutput(
 		suppressCloseErrors?: boolean;
 	}) => Promise<void>,
 ) {
-	return (async function* () {
+	const tracked = (async function* () {
 		let completed = false;
 		try {
 			for await (const item of output) {
@@ -345,6 +367,15 @@ function trackCommandOutput(
 			await finishStage({ assertResume: completed });
 		}
 	})();
+	const source = output as AsyncIterable<unknown> & CancellableLazyOutput & AsyncIterator<unknown>;
+	const cancellation = {
+		...(source.abort ? { abort: (reason?: unknown) => source.abort?.call(output, reason) } : null),
+		...(typeof source.return === "function" ? { awaitReturnOnAbort: true } : null),
+	};
+	if (Object.keys(cancellation).length > 0) {
+		Object.assign(tracked, cancellation);
+	}
+	return tracked;
 }
 
 function assertNoUnconsumedResumeAfterError(resume: CommandInputResume | undefined, err: unknown) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -347,13 +347,27 @@ function trackCommandOutput(
 		suppressCloseErrors?: boolean;
 	}) => Promise<void>,
 ) {
+	const source = output as AsyncIterable<unknown> & CancellableLazyOutput & AsyncIterator<unknown>;
+	const sourceIterator =
+		typeof source[Symbol.asyncIterator] === "function" ? source[Symbol.asyncIterator]() : undefined;
 	const tracked = (async function* () {
 		let completed = false;
 		try {
-			for await (const item of output) {
-				assertResumeConsumed();
-				markOutput();
-				yield item;
+			if (sourceIterator) {
+				const iteratorInput: AsyncIterable<unknown> = {
+					[Symbol.asyncIterator]: () => sourceIterator,
+				};
+				for await (const item of iteratorInput) {
+					assertResumeConsumed();
+					markOutput();
+					yield item;
+				}
+			} else {
+				for (const item of output as Iterable<unknown>) {
+					assertResumeConsumed();
+					markOutput();
+					yield item;
+				}
 			}
 			completed = true;
 		} catch (err) {
@@ -364,9 +378,10 @@ function trackCommandOutput(
 			await finishStage({ assertResume: completed });
 		}
 	})();
-	const source = output as AsyncIterable<unknown> & CancellableLazyOutput & AsyncIterator<unknown>;
+	const cancellationOwner = (sourceIterator ?? source) as CancellableLazyOutput;
+	const abort = cancellationOwner.abort;
 	const cancellation = {
-		...(source.abort ? { abort: (reason?: unknown) => source.abort?.call(output, reason) } : null),
+		...(abort ? { abort: (reason?: unknown) => abort.call(cancellationOwner, reason) } : null),
 	};
 	if (Object.keys(cancellation).length > 0) {
 		Object.assign(tracked, cancellation);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -20,6 +20,7 @@ export async function runPipeline({
 	cwd = undefined,
 	llmAdapters = undefined,
 	signal = undefined,
+	forceTerminationSignal = undefined,
 	haltAfterStageOnAbort = false,
 	dryRun = false,
 	requestInputResume = undefined,
@@ -37,6 +38,7 @@ export async function runPipeline({
 	cwd?: string | undefined;
 	llmAdapters?: Record<string, any> | undefined;
 	signal?: AbortSignal | undefined;
+	forceTerminationSignal?: AbortSignal | undefined;
 	haltAfterStageOnAbort?: boolean;
 	dryRun?: boolean;
 	requestInputResume?: CommandInputResume | undefined;
@@ -73,6 +75,7 @@ export async function runPipeline({
 		cwd,
 		llmAdapters,
 		signal,
+		forceTerminationSignal,
 	};
 
 	for (let idx = 0; idx < pipeline.length; idx++) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -134,12 +134,13 @@ export async function runPipeline({
 			rendered = true;
 		}
 
-		let stageHalted = Boolean(result?.halt || (haltAfterStageOnAbort && signal?.aborted));
+		const terminalOutput = Boolean(result?.halt);
+		let stageHalted = Boolean(terminalOutput || (haltAfterStageOnAbort && signal?.aborted));
 		const output = result?.output;
 		if (Array.isArray(output)) {
 			stream = output;
 			await finishStage();
-		} else if (output && idx < pipeline.length - 1) {
+		} else if (output && idx < pipeline.length - 1 && !terminalOutput) {
 			commandActive = false;
 			inactiveReason = "requestInput cannot suspend from lazy output before downstream stages";
 			assertRequestInputResumeConsumed(stageResume);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -159,18 +159,26 @@ export async function runPipeline({
 				? throwIfAbortedAfterDrain(trackedOutput, signal)
 				: trackedOutput;
 		} else {
-			stream = output
-				? trackCommandOutput(
-						output,
-						() => {
-							commandOutputStarted = true;
-						},
-						() => assertRequestInputResumeConsumed(stageResume),
-						(err) => assertNoUnconsumedResumeAfterError(stageResume, err),
-						finishStage,
-					)
-				: [];
-			if (!output) await finishStage();
+			if (output) {
+				const trackedOutput = trackCommandOutput(
+					output,
+					() => {
+						commandOutputStarted = true;
+					},
+					() => assertRequestInputResumeConsumed(stageResume),
+					(err) => assertNoUnconsumedResumeAfterError(stageResume, err),
+					finishStage,
+				);
+				// Terminal output is drained after the stage loop as well. It needs the
+				// same abort-aware read as a handoff, otherwise a stalled final iterator
+				// can prevent the tool cancellation from settling forever.
+				stream = haltAfterStageOnAbort
+					? throwIfAbortedAfterDrain(trackedOutput, signal)
+					: trackedOutput;
+			} else {
+				stream = [];
+				await finishStage();
+			}
 		}
 
 		stageHalted ||= Boolean(haltAfterStageOnAbort && signal?.aborted);
@@ -272,8 +280,10 @@ function throwIfAbortedAfterDrain(input: AsyncIterable<unknown>, signal?: AbortS
 					completed = true;
 					break;
 				}
-				signal?.throwIfAborted();
-				yield next.value;
+				// Once cancellation begins, keep draining values which are already
+				// immediately available so generator cleanup runs, but never expose
+				// them as tool output. A stalled read is interrupted by nextWithAbort.
+				if (!signal?.aborted) yield next.value;
 			}
 			signal?.throwIfAborted();
 		} finally {
@@ -302,9 +312,9 @@ async function closeAfterAbortedRead(
 		const close = iterator.return();
 		if (signal?.aborted && !abort) {
 			// Legacy iterators cannot interrupt an in-flight next(). Keep the
-			// existing prompt cancellation behavior, while resource-owning sources
-			// opt into the abort hook above so their cleanup is awaited.
-			void Promise.resolve(close).catch(() => {});
+			// existing prompt cancellation behavior, while still giving a normally
+			// settling generator one event-loop turn to run its finally cleanup.
+			await settleBeforeNextTurn(close);
 			return;
 		}
 		await close;
@@ -315,16 +325,21 @@ async function closeAfterAbortedRead(
 
 async function nextWithAbort(iterator: AsyncIterator<unknown>, signal?: AbortSignal) {
 	if (!signal) return iterator.next();
-	signal.throwIfAborted();
 
 	let onAbort!: () => void;
+	let abortTimer: ReturnType<typeof setTimeout> | undefined;
 	const aborted = new Promise<never>((_resolve, reject) => {
 		onAbort = () => {
-			try {
-				signal.throwIfAborted();
-			} catch (err) {
-				reject(err);
-			}
+			// Give a synchronous or microtask-ready iterator a chance to finish its
+			// cleanup path. A genuinely stalled read is still interrupted on the
+			// next event-loop turn.
+			abortTimer = setTimeout(() => {
+				try {
+					signal.throwIfAborted();
+				} catch (err) {
+					reject(err);
+				}
+			}, 0);
 		};
 		signal.addEventListener("abort", onAbort, { once: true });
 	});
@@ -333,7 +348,22 @@ async function nextWithAbort(iterator: AsyncIterator<unknown>, signal?: AbortSig
 	try {
 		return await Promise.race([iterator.next(), aborted]);
 	} finally {
+		if (abortTimer) clearTimeout(abortTimer);
 		signal.removeEventListener("abort", onAbort);
+	}
+}
+
+async function settleBeforeNextTurn(promise: Promise<unknown>) {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			Promise.resolve(promise).catch(() => {}),
+			new Promise<void>((resolve) => {
+				timer = setTimeout(resolve, 0);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
 	}
 }
 
@@ -348,14 +378,14 @@ function trackCommandOutput(
 	}) => Promise<void>,
 ) {
 	const source = output as AsyncIterable<unknown> & CancellableLazyOutput & AsyncIterator<unknown>;
-	const sourceIterator =
-		typeof source[Symbol.asyncIterator] === "function" ? source[Symbol.asyncIterator]() : undefined;
+	let sourceIterator: AsyncIterator<unknown> | undefined;
 	const tracked = (async function* () {
 		let completed = false;
 		try {
-			if (sourceIterator) {
+			if (typeof source[Symbol.asyncIterator] === "function") {
+				sourceIterator = source[Symbol.asyncIterator]();
 				const iteratorInput: AsyncIterable<unknown> = {
-					[Symbol.asyncIterator]: () => sourceIterator,
+					[Symbol.asyncIterator]: () => sourceIterator!,
 				};
 				for await (const item of iteratorInput) {
 					assertResumeConsumed();
@@ -378,14 +408,19 @@ function trackCommandOutput(
 			await finishStage({ assertResume: completed });
 		}
 	})();
-	const cancellationOwner = (sourceIterator ?? source) as CancellableLazyOutput;
-	const abort = cancellationOwner.abort;
-	const cancellation = {
-		...(abort ? { abort: (reason?: unknown) => abort.call(cancellationOwner, reason) } : null),
-	};
-	if (Object.keys(cancellation).length > 0) {
-		Object.assign(tracked, cancellation);
-	}
+	// Iterator-owned abort hooks are only discoverable after iterator acquisition.
+	// A getter lets the abort-aware wrapper find that hook once a read is pending,
+	// without performing acquisition outside the generator's guarded cleanup path.
+	Object.defineProperty(tracked, "abort", {
+		configurable: true,
+		get() {
+			const cancellationOwner = (sourceIterator ?? source) as CancellableLazyOutput;
+			const abort = cancellationOwner.abort;
+			return typeof abort === "function"
+				? (reason?: unknown) => abort.call(cancellationOwner, reason)
+				: undefined;
+		},
+	});
 	return tracked;
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -284,7 +284,6 @@ function throwIfAbortedAfterDrain(input: AsyncIterable<unknown>, signal?: AbortS
 
 type CancellableLazyOutput = {
 	abort?: (reason?: unknown) => void | Promise<void>;
-	awaitReturnOnAbort?: boolean;
 };
 
 async function closeAfterAbortedRead(
@@ -295,15 +294,13 @@ async function closeAfterAbortedRead(
 	const cancellable = iterator as AsyncIterator<unknown> & CancellableLazyOutput;
 	const inputCancellable = input as AsyncIterable<unknown> & CancellableLazyOutput;
 	const abort = cancellable.abort ?? inputCancellable.abort;
-	const awaitReturnOnAbort =
-		cancellable.awaitReturnOnAbort === true || inputCancellable.awaitReturnOnAbort === true;
 	try {
 		// A source that owns a pending timer, socket, or process can expose this
 		// small cancellation hook. It must release the pending next() operation.
 		if (signal?.aborted && abort) await abort(signal.reason);
 		if (typeof iterator.return !== "function") return;
 		const close = iterator.return();
-		if (signal?.aborted && !abort && !awaitReturnOnAbort) {
+		if (signal?.aborted && !abort) {
 			// Legacy iterators cannot interrupt an in-flight next(). Keep the
 			// existing prompt cancellation behavior, while resource-owning sources
 			// opt into the abort hook above so their cleanup is awaited.
@@ -370,7 +367,6 @@ function trackCommandOutput(
 	const source = output as AsyncIterable<unknown> & CancellableLazyOutput & AsyncIterator<unknown>;
 	const cancellation = {
 		...(source.abort ? { abort: (reason?: unknown) => source.abort?.call(output, reason) } : null),
-		...(typeof source.return === "function" ? { awaitReturnOnAbort: true } : null),
 	};
 	if (Object.keys(cancellation).length > 0) {
 		Object.assign(tracked, cancellation);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -50,6 +50,7 @@ export async function runPipeline({
 	let halted = false;
 	let haltedAt = null;
 	let pipelineOutputStarted = false;
+	let executionStarted = false;
 
 	const baseCtx = {
 		stdin,
@@ -69,6 +70,9 @@ export async function runPipeline({
 		const command = registry.get(stage.name);
 		if (!command) {
 			throw new Error(`Unknown command: ${stage.name}`);
+		}
+		if (command.meta?.resumeSafeBeforeInput !== true) {
+			executionStarted = true;
 		}
 
 		const inputTracker = createInputTracker(stream);
@@ -181,7 +185,7 @@ export async function runPipeline({
 	if (haltAfterStageOnAbort) signal?.throwIfAborted();
 	assertRequestInputResumeConsumed(requestInputResume);
 
-	return { items, rendered, halted, haltedAt };
+	return { items, rendered, halted, haltedAt, executionStarted };
 
 	function haltForInputRequest(err: unknown) {
 		if (!(err instanceof InputRequestSuspension)) return false;
@@ -223,7 +227,7 @@ function dryRunPipeline({
 	lines.push("");
 	stderr.write(lines.join("\n"));
 	// Return rendered:true so the CLI does not print an empty JSON array to stdout.
-	return { items: [], rendered: true, halted: false, haltedAt: null };
+	return { items: [], rendered: true, halted: false, haltedAt: null, executionStarted: false };
 }
 
 function formatStageArgs(args: Record<string, unknown>) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -139,7 +139,7 @@ export async function runPipeline({
 		if (Array.isArray(output)) {
 			stream = output;
 			await finishStage();
-		} else if (output && !stageHalted && idx < pipeline.length - 1) {
+		} else if (output && idx < pipeline.length - 1) {
 			commandActive = false;
 			inactiveReason = "requestInput cannot suspend from lazy output before downstream stages";
 			assertRequestInputResumeConsumed(stageResume);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -24,6 +24,7 @@ export async function runPipeline({
 	dryRun = false,
 	requestInputResume = undefined,
 	requestInputEnabled = true,
+	onExecutionStart = undefined,
 }: {
 	pipeline: any[];
 	registry: any;
@@ -40,6 +41,7 @@ export async function runPipeline({
 	dryRun?: boolean;
 	requestInputResume?: CommandInputResume | undefined;
 	requestInputEnabled?: boolean;
+	onExecutionStart?: (() => void) | undefined;
 }) {
 	if (dryRun) {
 		return dryRunPipeline({ pipeline, registry, stderr });
@@ -51,6 +53,11 @@ export async function runPipeline({
 	let haltedAt = null;
 	let pipelineOutputStarted = false;
 	let executionStarted = false;
+	const markExecutionStarted = () => {
+		if (executionStarted) return;
+		executionStarted = true;
+		onExecutionStart?.();
+	};
 
 	const baseCtx = {
 		stdin,
@@ -72,7 +79,7 @@ export async function runPipeline({
 			throw new Error(`Unknown command: ${stage.name}`);
 		}
 		if (command.meta?.resumeSafeBeforeInput !== true) {
-			executionStarted = true;
+			markExecutionStarted();
 		}
 
 		const inputTracker = createInputTracker(stream);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -41,7 +41,7 @@ export async function runPipeline({
 	dryRun?: boolean;
 	requestInputResume?: CommandInputResume | undefined;
 	requestInputEnabled?: boolean;
-	onExecutionStart?: (() => void) | undefined;
+	onExecutionStart?: (() => void | Promise<void>) | undefined;
 }) {
 	if (dryRun) {
 		return dryRunPipeline({ pipeline, registry, stderr });
@@ -53,10 +53,14 @@ export async function runPipeline({
 	let haltedAt = null;
 	let pipelineOutputStarted = false;
 	let executionStarted = false;
-	const markExecutionStarted = () => {
-		if (executionStarted) return;
-		executionStarted = true;
-		onExecutionStart?.();
+	let executionStart: Promise<void> | undefined;
+	const markExecutionStarted = async () => {
+		if (executionStart) return executionStart;
+		executionStart = (async () => {
+			await onExecutionStart?.();
+			executionStarted = true;
+		})();
+		return executionStart;
 	};
 
 	const baseCtx = {
@@ -79,7 +83,7 @@ export async function runPipeline({
 			throw new Error(`Unknown command: ${stage.name}`);
 		}
 		if (command.meta?.resumeSafeBeforeInput !== true) {
-			markExecutionStarted();
+			await markExecutionStarted();
 		}
 
 		const inputTracker = createInputTracker(stream);
@@ -392,7 +396,10 @@ function trackCommandOutput(
 	Object.defineProperty(tracked, "abort", {
 		configurable: true,
 		get() {
-			const cancellationOwner = (sourceIterator ?? source) as CancellableLazyOutput;
+			const cancellationOwner =
+				sourceIterator && typeof (sourceIterator as CancellableLazyOutput).abort === "function"
+					? (sourceIterator as CancellableLazyOutput)
+					: source;
 			const abort = cancellationOwner.abort;
 			return typeof abort === "function"
 				? (reason?: unknown) => abort.call(cancellationOwner, reason)

--- a/src/sdk/Lobster.ts
+++ b/src/sdk/Lobster.ts
@@ -3,7 +3,7 @@ import { runPipelineInternal } from "./runtime.js";
 import { encodeToken, decodeToken } from "./token.js";
 import { compileCached } from "../validation.js";
 import { validateCommandInputState, type CommandInputState } from "../input_request.js";
-import { deleteStateJson, readStateJson, writeStateJson } from "../state/store.js";
+import { deleteStateJson, readStateJsonWithLock, writeStateJson } from "../state/store.js";
 
 type SdkResumePayload = {
 	protocolVersion: 1;
@@ -449,7 +449,11 @@ async function loadSdkCommandInputResumeState(
 	options: any,
 	stateKey: string,
 ): Promise<SdkCommandInputResumeState> {
-	const stored = await readStateJson({ env: sdkStateEnv(options), key: stateKey });
+	const stored = await readStateJsonWithLock({
+		env: sdkStateEnv(options),
+		key: stateKey,
+		signal: options?.signal,
+	});
 	if (!stored || typeof stored !== "object") throw new Error("SDK resume state not found");
 	const data = stored as Partial<SdkCommandInputResumeState>;
 	if (

--- a/src/sdk/primitives/diff.ts
+++ b/src/sdk/primitives/diff.ts
@@ -55,6 +55,7 @@ export function diffLast(key, options: any = {}) {
 				env: stateEnv(ctx),
 				key,
 				value,
+				signal: ctx?.signal,
 			});
 
 			// Build result
@@ -91,6 +92,6 @@ export function diffLast(key, options: any = {}) {
  * @param {Object} [ctx]
  * @returns {Promise<{before: any, after: any, changed: boolean}>}
  */
-export async function diffAndStoreValue(key, value, ctx = {}) {
-	return diffAndStore({ env: stateEnv(ctx), key, value });
+export async function diffAndStoreValue(key, value, ctx: any = {}) {
+	return diffAndStore({ env: stateEnv(ctx), key, value, signal: ctx?.signal });
 }

--- a/src/sdk/primitives/diff.ts
+++ b/src/sdk/primitives/diff.ts
@@ -14,56 +14,12 @@
  *   });
  */
 
-import { promises as fsp } from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { ensureDirectory, isJsonSyntaxError, writeFileAtomic } from "../../state/store.js";
+import { diffAndStore } from "../../state/store.js";
 
-/**
- * Get the state directory
- * @param {Object} ctx
- * @returns {string}
- */
-function getStateDir(ctx) {
-	return (
-		ctx?.stateDir ||
-		(ctx?.env?.LOBSTER_STATE_DIR && String(ctx.env.LOBSTER_STATE_DIR).trim()) ||
-		path.join(os.homedir(), ".lobster", "state")
-	);
-}
-
-/**
- * Convert a key to a safe file path
- * @param {string} stateDir
- * @param {string} key
- * @returns {string}
- */
-function keyToPath(stateDir, key) {
-	const safe = String(key)
-		.toLowerCase()
-		.replace(/[^a-z0-9._-]+/g, "_")
-		.replace(/_+/g, "_")
-		.replace(/^_+|_+$/g, "");
-	if (!safe) throw new Error("state key is empty/invalid");
-	return path.join(stateDir, `${safe}.json`);
-}
-
-/**
- * Stable JSON stringify for comparison
- * @param {any} value
- * @returns {string}
- */
-function stableStringify(value) {
-	return JSON.stringify(value, (_k, v) => {
-		if (v && typeof v === "object" && !Array.isArray(v)) {
-			return Object.fromEntries(
-				Object.keys(v)
-					.sort()
-					.map((k) => [k, v[k]]),
-			);
-		}
-		return v;
-	});
+function stateEnv(ctx) {
+	return ctx?.stateDir
+		? { ...(ctx?.env ?? process.env), LOBSTER_STATE_DIR: ctx.stateDir }
+		: (ctx?.env ?? process.env);
 }
 
 /**
@@ -95,26 +51,11 @@ export function diffLast(key, options: any = {}) {
 
 			const value = items.length === 1 ? items[0] : items;
 
-			const stateDir = getStateDir(ctx);
-			const filePath = keyToPath(stateDir, key);
-
-			// Read previous value
-			let before = null;
-			try {
-				const text = await fsp.readFile(filePath, "utf8");
-				before = JSON.parse(text);
-			} catch (err) {
-				if (err?.code !== "ENOENT" && !isJsonSyntaxError(err)) {
-					throw err;
-				}
-			}
-
-			// Compare
-			const changed = stableStringify(before) !== stableStringify(value);
-
-			// Store new value
-			await ensureDirectory(stateDir);
-			await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n");
+			const { before, after, changed } = await diffAndStore({
+				env: stateEnv(ctx),
+				key,
+				value,
+			});
 
 			// Build result
 			const result = {
@@ -122,7 +63,7 @@ export function diffLast(key, options: any = {}) {
 				key,
 				changed,
 				before,
-				after: value,
+				after,
 			};
 
 			// If changesOnly and no change, output suppressed marker
@@ -151,26 +92,5 @@ export function diffLast(key, options: any = {}) {
  * @returns {Promise<{before: any, after: any, changed: boolean}>}
  */
 export async function diffAndStoreValue(key, value, ctx = {}) {
-	const stateDir = getStateDir(ctx);
-	const filePath = keyToPath(stateDir, key);
-
-	// Read previous value
-	let before = null;
-	try {
-		const text = await fsp.readFile(filePath, "utf8");
-		before = JSON.parse(text);
-	} catch (err) {
-		if (err?.code !== "ENOENT" && !isJsonSyntaxError(err)) {
-			throw err;
-		}
-	}
-
-	// Compare
-	const changed = stableStringify(before) !== stableStringify(value);
-
-	// Store new value
-	await ensureDirectory(stateDir);
-	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n");
-
-	return { before, after: value, changed };
+	return diffAndStore({ env: stateEnv(ctx), key, value });
 }

--- a/src/sdk/primitives/state.ts
+++ b/src/sdk/primitives/state.ts
@@ -15,77 +15,12 @@
  *   .pipe(stateSet('my-key'));
  */
 
-import { randomBytes } from "node:crypto";
-import { promises as fsp } from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { readStateJson, writeStateJson } from "../../state/store.js";
 
-/**
- * Write a file atomically (stage to a sibling temp file, fsync, then rename).
- * `rename(2)` is atomic on a single filesystem, so a concurrent reader or a
- * crash never observes a truncated/partial file. Plain `fsp.writeFile`
- * truncates the target up front, leaving a corruption window on SIGKILL/OOM/
- * power loss. New state files are private by default; existing file modes are
- * preserved across replacement. Kept local to keep the SDK self-contained.
- * @param {string} filePath
- * @param {string} data
- */
-async function writeFileAtomic(filePath, data) {
-	const dir = path.dirname(filePath);
-	const tmpPath = path.join(
-		dir,
-		`.${path.basename(filePath)}.${randomBytes(6).toString("hex")}.tmp`,
-	);
-	let mode = 0o600;
-	let handle;
-	let cleanup = true;
-	try {
-		try {
-			mode = (await fsp.stat(filePath)).mode & 0o777;
-		} catch (err) {
-			if (err?.code !== "ENOENT") throw err;
-		}
-		handle = await fsp.open(tmpPath, "wx", mode);
-		await handle.writeFile(data, "utf8");
-		await handle.sync();
-		await handle.close();
-		handle = undefined;
-		await fsp.chmod(tmpPath, mode);
-		await fsp.rename(tmpPath, filePath);
-		cleanup = false;
-	} finally {
-		if (handle) await handle.close().catch(() => {});
-		if (cleanup) await fsp.rm(tmpPath, { force: true }).catch(() => {});
-	}
-}
-
-/**
- * Get the state directory
- * @param {Object} ctx
- * @returns {string}
- */
-function getStateDir(ctx) {
-	return (
-		ctx?.stateDir ||
-		(ctx?.env?.LOBSTER_STATE_DIR && String(ctx.env.LOBSTER_STATE_DIR).trim()) ||
-		path.join(os.homedir(), ".lobster", "state")
-	);
-}
-
-/**
- * Convert a key to a safe file path
- * @param {string} stateDir
- * @param {string} key
- * @returns {string}
- */
-function keyToPath(stateDir, key) {
-	const safe = String(key)
-		.toLowerCase()
-		.replace(/[^a-z0-9._-]+/g, "_")
-		.replace(/_+/g, "_")
-		.replace(/^_+|_+$/g, "");
-	if (!safe) throw new Error("state key is empty/invalid");
-	return path.join(stateDir, `${safe}.json`);
+function stateEnv(ctx) {
+	return ctx?.stateDir
+		? { ...(ctx?.env ?? process.env), LOBSTER_STATE_DIR: ctx.stateDir }
+		: (ctx?.env ?? process.env);
 }
 
 /**
@@ -107,19 +42,7 @@ export function stateGet(key) {
 				// no-op
 			}
 
-			const stateDir = getStateDir(ctx);
-			const filePath = keyToPath(stateDir, key);
-
-			let value = null;
-			try {
-				const text = await fsp.readFile(filePath, "utf8");
-				value = JSON.parse(text);
-			} catch (err) {
-				if (err?.code !== "ENOENT") {
-					throw err;
-				}
-				// File doesn't exist, return null
-			}
+			const value = await readStateJson({ env: stateEnv(ctx), key });
 
 			return {
 				output: (async function* () {
@@ -152,11 +75,7 @@ export function stateSet(key) {
 
 			const value = items.length === 1 ? items[0] : items;
 
-			const stateDir = getStateDir(ctx);
-			const filePath = keyToPath(stateDir, key);
-
-			await fsp.mkdir(stateDir, { recursive: true });
-			await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n");
+			await writeStateJson({ env: stateEnv(ctx), key, value });
 
 			// Pass through the value
 			return {
@@ -190,16 +109,7 @@ export const state = {
  * @returns {Promise<any>}
  */
 export async function readState(key, ctx = {}) {
-	const stateDir = getStateDir(ctx);
-	const filePath = keyToPath(stateDir, key);
-
-	try {
-		const text = await fsp.readFile(filePath, "utf8");
-		return JSON.parse(text);
-	} catch (err) {
-		if (err?.code === "ENOENT") return null;
-		throw err;
-	}
+	return readStateJson({ env: stateEnv(ctx), key });
 }
 
 /**
@@ -210,9 +120,5 @@ export async function readState(key, ctx = {}) {
  * @returns {Promise<void>}
  */
 export async function writeState(key, value, ctx = {}) {
-	const stateDir = getStateDir(ctx);
-	const filePath = keyToPath(stateDir, key);
-
-	await fsp.mkdir(stateDir, { recursive: true });
-	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n");
+	await writeStateJson({ env: stateEnv(ctx), key, value });
 }

--- a/src/sdk/primitives/state.ts
+++ b/src/sdk/primitives/state.ts
@@ -15,7 +15,7 @@
  *   .pipe(stateSet('my-key'));
  */
 
-import { readStateJson, writeStateJson } from "../../state/store.js";
+import { readStateJsonWithLock, writeStateJson } from "../../state/store.js";
 
 function stateEnv(ctx) {
 	return ctx?.stateDir
@@ -42,7 +42,7 @@ export function stateGet(key) {
 				// no-op
 			}
 
-			const value = await readStateJson({ env: stateEnv(ctx), key });
+			const value = await readStateJsonWithLock({ env: stateEnv(ctx), key, signal: ctx?.signal });
 
 			return {
 				output: (async function* () {
@@ -108,8 +108,8 @@ export const state = {
  * @param {Object} [ctx]
  * @returns {Promise<any>}
  */
-export async function readState(key, ctx = {}) {
-	return readStateJson({ env: stateEnv(ctx), key });
+export async function readState(key, ctx: any = {}) {
+	return readStateJsonWithLock({ env: stateEnv(ctx), key, signal: ctx?.signal });
 }
 
 /**

--- a/src/sdk/primitives/state.ts
+++ b/src/sdk/primitives/state.ts
@@ -75,7 +75,7 @@ export function stateSet(key) {
 
 			const value = items.length === 1 ? items[0] : items;
 
-			await writeStateJson({ env: stateEnv(ctx), key, value });
+			await writeStateJson({ env: stateEnv(ctx), key, value, signal: ctx?.signal });
 
 			// Pass through the value
 			return {
@@ -119,6 +119,6 @@ export async function readState(key, ctx = {}) {
  * @param {Object} [ctx]
  * @returns {Promise<void>}
  */
-export async function writeState(key, value, ctx = {}) {
-	await writeStateJson({ env: stateEnv(ctx), key, value });
+export async function writeState(key, value, ctx: any = {}) {
+	await writeStateJson({ env: stateEnv(ctx), key, value, signal: ctx?.signal });
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -36,6 +36,7 @@ export function stableStringify(value) {
 type AtomicWriteOptions = {
 	renameFile?: typeof fsp.rename;
 	syncParentDir?: (filePath: string) => Promise<void>;
+	signal?: AbortSignal;
 };
 
 type AtomicExclusiveWriteOptions = {
@@ -148,6 +149,7 @@ export async function writeFileAtomic(filePath, data, options: AtomicWriteOption
 		await handle.sync();
 		await handle.close();
 		handle = undefined;
+		options.signal?.throwIfAborted();
 		await renameFile(tmpPath, filePath);
 		await syncDir(filePath);
 		cleanup = false;
@@ -215,12 +217,12 @@ export async function readStateJson({ env, key }) {
 	}
 }
 
-export async function writeStateJson({ env, key, value }) {
+export async function writeStateJson({ env, key, value, signal = undefined }) {
 	const stateDir = defaultStateDir(env);
 	const filePath = keyToPath(stateDir, key);
 
 	await ensureDirectory(stateDir);
-	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n");
+	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n", { signal });
 }
 
 export async function deleteStateJson({ env, key }) {
@@ -390,6 +392,6 @@ export async function diffAndStore({ env, key, value, signal = undefined }) {
 	});
 	const changed = stableStringify(before) !== stableStringify(value);
 	signal?.throwIfAborted();
-	await writeStateJson({ env, key, value });
+	await writeStateJson({ env, key, value, signal });
 	return { before, after: value, changed };
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -383,12 +383,13 @@ export async function cleanupApprovalIndexByStateKey({
 	}
 }
 
-export async function diffAndStore({ env, key, value }) {
+export async function diffAndStore({ env, key, value, signal = undefined }) {
 	const before = await readStateJson({ env, key }).catch((err) => {
 		if (isJsonSyntaxError(err)) return null;
 		throw err;
 	});
 	const changed = stableStringify(before) !== stableStringify(value);
+	signal?.throwIfAborted();
 	await writeStateJson({ env, key, value });
 	return { before, after: value, changed };
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -60,9 +60,28 @@ type AtomicExclusiveWriteOptions = {
 	syncParentDir?: (filePath: string) => Promise<void>;
 };
 
+type PublishedAtomicWriteError = NodeJS.ErrnoException & {
+	atomicWritePublished?: true;
+};
+
+function markAtomicWritePublished(err: unknown) {
+	if (err && (typeof err === "object" || typeof err === "function")) {
+		Object.defineProperty(err, "atomicWritePublished", {
+			value: true,
+			configurable: true,
+		});
+	}
+	return err;
+}
+
+function atomicWriteWasPublished(err: unknown): err is PublishedAtomicWriteError {
+	return Boolean((err as PublishedAtomicWriteError | undefined)?.atomicWritePublished);
+}
+
 const STATE_LOCK_RETRY_MS = 10;
 const STATE_LOCK_ORPHAN_MS = 30_000;
 const STATE_LOCK_HEARTBEAT_MS = 250;
+const TERMINAL_RESUME_CLEANUP_TIMEOUT_MS = STATE_LOCK_RETRY_MS * 10;
 
 function isDirectorySyncUnsupportedError(err: any): boolean {
 	return [
@@ -420,11 +439,15 @@ export async function writeFileAtomic(filePath, data, options: AtomicWriteOption
 		handle = undefined;
 		options.signal?.throwIfAborted();
 		await renameFile(tmpPath, filePath);
-		// The rename is the irreversible publication point. Callers that need to
-		// compensate an aborted write must decide from the returned commit status;
-		// throwing here would hide that the replacement is already visible.
-		await syncDir(filePath);
 		cleanup = false;
+		// The rename is the irreversible publication point. Keep propagating a
+		// directory-sync failure, but mark it so a state transition can reconcile
+		// the visible replacement before deciding whether dispatch is safe.
+		try {
+			await syncDir(filePath);
+		} catch (err) {
+			throw markAtomicWritePublished(err);
+		}
 		return { signalAbortedAfterCommit: options.signal?.aborted === true };
 	} finally {
 		if (handle) await handle.close().catch(() => {});
@@ -563,21 +586,31 @@ export async function consumeResumeState({
 				return { consumed: false as const };
 			}
 			const claimId = randomBytes(16).toString("hex");
-			const result = await writeStateJsonUnlocked({
-				env,
-				key,
-				value: {
-					type: CONSUMED_RESUME_STATE_TYPE,
-					consumedAt: new Date().toISOString(),
+			try {
+				const result = await writeStateJsonUnlocked({
+					env,
+					key,
+					value: {
+						type: CONSUMED_RESUME_STATE_TYPE,
+						consumedAt: new Date().toISOString(),
+						claimId,
+					},
+					signal,
+				});
+				return {
+					consumed: true as const,
 					claimId,
-				},
-				signal,
-			});
-			return {
-				consumed: true as const,
-				claimId,
-				signalAbortedAfterCommit: result?.signalAbortedAfterCommit === true,
-			};
+					signalAbortedAfterCommit: result?.signalAbortedAfterCommit === true,
+				};
+			} catch (err) {
+				if (atomicWriteWasPublished(err)) {
+					const latest = await readStateJson({ env, key });
+					if (isConsumedResumeState(latest) && latest.claimId === claimId) {
+						await writeStateJsonUnlocked({ env, key, value: expectedState });
+					}
+				}
+				throw err;
+			}
 		},
 	});
 }
@@ -641,18 +674,25 @@ export async function deleteResumeStateWithRollback({
 
 			const claimId = randomBytes(16).toString("hex");
 			let claimPublished = false;
+			let claimMayBePublished = false;
 			let deleted = false;
 			try {
-				const result = await writeStateJsonUnlocked({
-					env,
-					key,
-					value: {
-						type: CONSUMED_RESUME_STATE_TYPE,
-						consumedAt: new Date().toISOString(),
-						claimId,
-					},
-					signal,
-				});
+				let result;
+				try {
+					result = await writeStateJsonUnlocked({
+						env,
+						key,
+						value: {
+							type: CONSUMED_RESUME_STATE_TYPE,
+							consumedAt: new Date().toISOString(),
+							claimId,
+						},
+						signal,
+					});
+				} catch (err) {
+					claimMayBePublished = atomicWriteWasPublished(err);
+					throw err;
+				}
 				claimPublished = true;
 				if (result?.signalAbortedAfterCommit) signal?.throwIfAborted();
 				signal?.throwIfAborted();
@@ -661,7 +701,7 @@ export async function deleteResumeStateWithRollback({
 				signal?.throwIfAborted();
 				return true;
 			} catch (err) {
-				if (signal?.aborted && claimPublished) {
+				if ((signal?.aborted && claimPublished) || claimMayBePublished) {
 					const latest = await readStateJson({ env, key });
 					if (
 						(deleted && latest === null) ||
@@ -723,6 +763,27 @@ export async function deleteStateJson({
 		signal,
 		task: () => deleteStateJsonUnlocked({ env, key }),
 	});
+}
+
+/**
+ * After an effect has started, its consumed marker already prevents replay.
+ * Give terminal cleanup a small, bounded opportunity to remove that marker,
+ * but never let a live state writer turn cancellation into an unbounded wait.
+ */
+export async function deleteStateJsonWithBoundedResumeCleanup({
+	env,
+	key,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+}) {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TERMINAL_RESUME_CLEANUP_TIMEOUT_MS);
+	try {
+		await deleteStateJson({ env, key, signal: controller.signal });
+	} finally {
+		clearTimeout(timeout);
+	}
 }
 
 /**

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -281,8 +281,29 @@ async function withStateKeyLock<T>({
 	task: () => Promise<T>;
 }): Promise<T> {
 	const stateDir = defaultStateDir(env);
-	await ensureDirectory(stateDir);
-	const lockPath = `${keyToPath(stateDir, key)}.lock`;
+	return withFileLock({
+		filePath: keyToPath(stateDir, key),
+		signal,
+		task,
+	});
+}
+
+/**
+ * Serialize a transition for an arbitrary durable file. Readers that need a
+ * publish-or-rollback decision use the same lock as writers, rather than
+ * observing an atomic rename that cancellation may still need to undo.
+ */
+export async function withFileLock<T>({
+	filePath,
+	signal,
+	task,
+}: {
+	filePath: string;
+	signal?: AbortSignal;
+	task: () => Promise<T>;
+}): Promise<T> {
+	await ensureDirectory(path.dirname(filePath));
+	const lockPath = `${filePath}.lock`;
 	let acquired = false;
 	let owner: string | undefined;
 	let ownerWritten = false;
@@ -612,6 +633,44 @@ export async function deleteStateJson({
 		key,
 		signal,
 		task: () => deleteStateJsonUnlocked({ env, key }),
+	});
+}
+
+/**
+ * Retire a resume capability only while it is still a live, unclaimed state.
+ * A consumed marker belongs to a resume that has already started its atomic
+ * predecessor-to-successor handoff, so cancellation must not delete it and
+ * report success while that successor remains executable.
+ */
+export async function deleteUnconsumedResumeState({
+	env,
+	key,
+	signal = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	signal?: AbortSignal;
+}): Promise<"deleted" | "missing" | "claimed"> {
+	return withStateKeyLock({
+		env,
+		key,
+		signal,
+		task: async () => {
+			let currentState: unknown;
+			try {
+				currentState = await readStateJson({ env, key });
+			} catch (err) {
+				// A corrupt state is not resumable, so explicit cancellation may still
+				// remove it. This keeps the legacy workflow-alias recovery behavior.
+				if (!isJsonSyntaxError(err)) throw err;
+				await deleteStateJsonUnlocked({ env, key });
+				return "deleted";
+			}
+			if (currentState === null) return "missing";
+			if (isConsumedResumeState(currentState)) return "claimed";
+			await deleteStateJsonUnlocked({ env, key });
+			return "deleted";
+		},
 	});
 }
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -209,9 +209,7 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 		if (owner && isProcessAlive(owner.pid)) {
 			const processStartIdentity = await readProcessStartIdentity(owner.pid);
 			if (owner.processStartIdentity && processStartIdentity) {
-				stale =
-					owner.processStartIdentity !== processStartIdentity ||
-					(await hasExpiredStateLockLease(ownerPath));
+				stale = owner.processStartIdentity !== processStartIdentity;
 			} else {
 				// A live PID without a matching process-instance identity may have
 				// been reused. Require a conservative expired lease and a second
@@ -666,6 +664,14 @@ export async function diffAndStore({
 		key,
 		signal,
 		task: async () => {
+			const filePath = keyToPath(defaultStateDir(env), key);
+			let beforeExists = true;
+			try {
+				await fsp.access(filePath);
+			} catch (err: any) {
+				if (err?.code !== "ENOENT") throw err;
+				beforeExists = false;
+			}
 			const before = await readStateJson({ env, key }).catch((err) => {
 				if (isJsonSyntaxError(err)) return null;
 				throw err;
@@ -677,7 +683,7 @@ export async function diffAndStore({
 				signal?.throwIfAborted();
 			} catch (err) {
 				if (signal?.aborted) {
-					if (before === null) {
+					if (!beforeExists) {
 						await deleteStateJsonUnlocked({ env, key });
 					} else {
 						await writeStateJsonUnlocked({ env, key, value: before });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -384,7 +384,19 @@ export async function withFileLock<T>({
 		if (acquired) {
 			const ownerPath = path.join(lockPath, "owner");
 			if (!ownerWritten || !owner || (await stillOwnsStateLock(ownerPath, owner))) {
-				await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+				// Detach an owned lock before best-effort cleanup. If a filesystem error
+				// prevents removing the detached directory, the canonical lock path is
+				// already free for a subsequent operation; leaving it in place would
+				// instead look like a live lock owned by this still-running process.
+				const cleanupPath = `${lockPath}.release-${process.pid}-${randomBytes(6).toString("hex")}`;
+				try {
+					await fsp.rename(lockPath, cleanupPath);
+					await fsp.rm(cleanupPath, { recursive: true, force: true }).catch(() => {});
+				} catch (err: any) {
+					if (err?.code !== "ENOENT") {
+						await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+					}
+				}
 			}
 		}
 	}
@@ -500,13 +512,24 @@ export async function writeFileAtomicExclusive(
 	}
 }
 
-async function readStateJson({ env, key }) {
+export async function readStateJson({
+	env,
+	key,
+	signal = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	signal?: AbortSignal;
+}) {
+	signal?.throwIfAborted();
 	const stateDir = defaultStateDir(env);
 	const filePath = keyToPath(stateDir, key);
 
 	try {
 		const text = await fsp.readFile(filePath, "utf8");
-		return JSON.parse(text);
+		const value = JSON.parse(text);
+		signal?.throwIfAborted();
+		return value;
 	} catch (err) {
 		if (err?.code === "ENOENT") return null;
 		throw err;
@@ -527,7 +550,17 @@ export async function readStateJsonWithLock({
 	key: string;
 	signal?: AbortSignal;
 }) {
-	return withStateKeyLock({ env, key, signal, task: () => readStateJson({ env, key }) });
+	try {
+		return await withStateKeyLock({ env, key, signal, task: () => readStateJson({ env, key }) });
+	} catch (err: any) {
+		// A readable state directory can deliberately be mounted read-only. In that
+		// case no writer can begin a paired publish-or-rollback transition, so use
+		// the non-mutating JSON read instead of requiring creation of a lock path.
+		if (["EACCES", "EPERM", "EROFS"].includes(err?.code)) {
+			return readStateJson({ env, key, signal });
+		}
+		throw err;
+	}
 }
 
 async function writeStateJsonUnlocked({

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -44,6 +44,9 @@ type AtomicExclusiveWriteOptions = {
 	syncParentDir?: (filePath: string) => Promise<void>;
 };
 
+const STATE_LOCK_RETRY_MS = 10;
+const STATE_LOCK_ORPHAN_MS = 1_000;
+
 function isDirectorySyncUnsupportedError(err: any): boolean {
 	return [
 		"EACCES",
@@ -100,6 +103,108 @@ export async function ensureDirectory(dir: string) {
 
 export function isJsonSyntaxError(err) {
 	return err instanceof SyntaxError;
+}
+
+async function waitForStateLock(signal?: AbortSignal) {
+	await new Promise<void>((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			try {
+				signal?.throwIfAborted();
+			} catch (err) {
+				reject(err);
+			}
+		};
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, STATE_LOCK_RETRY_MS);
+		if (signal?.aborted) {
+			onAbort();
+			return;
+		}
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+function isProcessAlive(pid: number) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err: any) {
+		return err?.code !== "ESRCH";
+	}
+}
+
+async function reclaimOrphanedStateLock(lockPath: string) {
+	let stale = false;
+	try {
+		const ownerPath = path.join(lockPath, "owner");
+		const owner = Number((await fsp.readFile(ownerPath, "utf8")).trim());
+		stale = Number.isInteger(owner) && owner > 0 && !isProcessAlive(owner);
+	} catch (err: any) {
+		if (err?.code === "ENOENT") {
+			try {
+				const stat = await fsp.stat(lockPath);
+				stale = Date.now() - stat.mtimeMs >= STATE_LOCK_ORPHAN_MS;
+			} catch (statErr: any) {
+				if (statErr?.code === "ENOENT") return true;
+				throw statErr;
+			}
+		} else {
+			throw err;
+		}
+	}
+	if (!stale) return false;
+
+	const orphanPath = `${lockPath}.${randomBytes(6).toString("hex")}.orphan`;
+	try {
+		await fsp.rename(lockPath, orphanPath);
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return true;
+		throw err;
+	}
+	await fsp.rm(orphanPath, { recursive: true, force: true });
+	return true;
+}
+
+async function withStateKeyLock<T>({
+	env,
+	key,
+	signal,
+	task,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	signal?: AbortSignal;
+	task: () => Promise<T>;
+}): Promise<T> {
+	const stateDir = defaultStateDir(env);
+	await ensureDirectory(stateDir);
+	const lockPath = `${keyToPath(stateDir, key)}.lock`;
+	let acquired = false;
+	try {
+		while (!acquired) {
+			signal?.throwIfAborted();
+			try {
+				await fsp.mkdir(lockPath, { mode: 0o700 });
+				acquired = true;
+				await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}\n`, {
+					encoding: "utf8",
+					mode: 0o600,
+				});
+			} catch (err: any) {
+				if (acquired) throw err;
+				if (err?.code !== "EEXIST") throw err;
+				if (!(await reclaimOrphanedStateLock(lockPath))) {
+					await waitForStateLock(signal);
+				}
+			}
+		}
+		return await task();
+	} finally {
+		if (acquired) await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+	}
 }
 
 function isLinkUnsupportedError(err: any): boolean {
@@ -414,24 +519,31 @@ export async function diffAndStore({
 	signal?: AbortSignal;
 	atomicWriteOptions?: Omit<AtomicWriteOptions, "signal">;
 }) {
-	const before = await readStateJson({ env, key }).catch((err) => {
-		if (isJsonSyntaxError(err)) return null;
-		throw err;
-	});
-	const changed = stableStringify(before) !== stableStringify(value);
-	try {
-		signal?.throwIfAborted();
-		await writeStateJson({ env, key, value, signal, atomicWriteOptions });
-		signal?.throwIfAborted();
-	} catch (err) {
-		if (signal?.aborted) {
-			if (before === null) {
-				await deleteStateJson({ env, key });
-			} else {
-				await writeStateJson({ env, key, value: before });
+	return withStateKeyLock({
+		env,
+		key,
+		signal,
+		task: async () => {
+			const before = await readStateJson({ env, key }).catch((err) => {
+				if (isJsonSyntaxError(err)) return null;
+				throw err;
+			});
+			const changed = stableStringify(before) !== stableStringify(value);
+			try {
+				signal?.throwIfAborted();
+				await writeStateJson({ env, key, value, signal, atomicWriteOptions });
+				signal?.throwIfAborted();
+			} catch (err) {
+				if (signal?.aborted) {
+					if (before === null) {
+						await deleteStateJson({ env, key });
+					} else {
+						await writeStateJson({ env, key, value: before });
+					}
+				}
+				throw err;
 			}
-		}
-		throw err;
-	}
-	return { before, after: value, changed };
+			return { before, after: value, changed };
+		},
+	});
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -613,6 +613,70 @@ export async function restoreConsumedResumeState({
 }
 
 /**
+ * Retire an unconsumed capability at a safe terminal boundary. The snapshot is
+ * first replaced by a caller-owned marker under the state lock, so a
+ * cancellation can restore only the state this caller claimed. A stale resume
+ * that merely observed an earlier snapshot can never recreate a state another
+ * resume has already settled.
+ */
+export async function deleteResumeStateWithRollback({
+	env,
+	key,
+	expectedState,
+	signal = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	expectedState: unknown;
+	signal?: AbortSignal;
+}): Promise<boolean> {
+	return withStateKeyLock({
+		env,
+		key,
+		signal,
+		task: async () => {
+			signal?.throwIfAborted();
+			const currentState = await readStateJson({ env, key });
+			if (stableStringify(currentState) !== stableStringify(expectedState)) return false;
+
+			const claimId = randomBytes(16).toString("hex");
+			let claimPublished = false;
+			let deleted = false;
+			try {
+				const result = await writeStateJsonUnlocked({
+					env,
+					key,
+					value: {
+						type: CONSUMED_RESUME_STATE_TYPE,
+						consumedAt: new Date().toISOString(),
+						claimId,
+					},
+					signal,
+				});
+				claimPublished = true;
+				if (result?.signalAbortedAfterCommit) signal?.throwIfAborted();
+				signal?.throwIfAborted();
+				await deleteStateJsonUnlocked({ env, key });
+				deleted = true;
+				signal?.throwIfAborted();
+				return true;
+			} catch (err) {
+				if (signal?.aborted && claimPublished) {
+					const latest = await readStateJson({ env, key });
+					if (
+						(deleted && latest === null) ||
+						(isConsumedResumeState(latest) && latest.claimId === claimId)
+					) {
+						await writeStateJsonUnlocked({ env, key, value: expectedState });
+					}
+				}
+				throw err;
+			}
+		},
+	});
+}
+
+/**
  * Check physical state presence without parsing it. Cancellation uses this to
  * retain the authoritative workflow spelling even if the state file is corrupt.
  */

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -3,6 +3,21 @@ import path from "node:path";
 import { promises as fsp } from "node:fs";
 import { randomBytes } from "node:crypto";
 
+const CONSUMED_RESUME_STATE_TYPE = "lobster.consumed-resume-state.v1";
+
+export type ConsumedResumeState = {
+	type: typeof CONSUMED_RESUME_STATE_TYPE;
+	consumedAt: string;
+};
+
+export function isConsumedResumeState(value: unknown): value is ConsumedResumeState {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		(value as { type?: unknown }).type === CONSUMED_RESUME_STATE_TYPE
+	);
+}
+
 export function defaultStateDir(env) {
 	return (
 		(env?.LOBSTER_STATE_DIR && String(env.LOBSTER_STATE_DIR).trim()) ||
@@ -467,6 +482,49 @@ export async function writeStateJson({
 		signal,
 		task: () => writeStateJsonUnlocked({ env, key, value, signal, atomicWriteOptions }),
 	});
+}
+
+/**
+ * Retire a resume capability before its first unsafe execution boundary. The
+ * replacement is deliberately persistent: a failed later unlink must not make
+ * the original token replayable.
+ */
+export async function consumeResumeState({
+	env,
+	key,
+	signal = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	signal?: AbortSignal;
+}) {
+	await writeStateJson({
+		env,
+		key,
+		value: { type: CONSUMED_RESUME_STATE_TYPE, consumedAt: new Date().toISOString() },
+		signal,
+	});
+}
+
+/**
+ * Check physical state presence without parsing it. Cancellation uses this to
+ * retain the authoritative workflow spelling even if the state file is corrupt.
+ */
+export async function stateJsonExists({
+	env,
+	key,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+}) {
+	const filePath = keyToPath(defaultStateDir(env), key);
+	try {
+		await fsp.access(filePath);
+		return true;
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return false;
+		throw err;
+	}
 }
 
 async function deleteStateJsonUnlocked({ env, key }) {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -209,7 +209,9 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 		if (owner && isProcessAlive(owner.pid)) {
 			const processStartIdentity = await readProcessStartIdentity(owner.pid);
 			if (owner.processStartIdentity && processStartIdentity) {
-				stale = owner.processStartIdentity !== processStartIdentity;
+				stale =
+					owner.processStartIdentity !== processStartIdentity ||
+					(await hasExpiredStateLockLease(ownerPath));
 			} else {
 				// A live PID without a matching process-instance identity may have
 				// been reused. Require a conservative expired lease and a second
@@ -241,6 +243,18 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 	return true;
 }
 
+async function stillOwnsStateLock(ownerPath: string, owner: string) {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			return (await fsp.readFile(ownerPath, "utf8")) === owner;
+		} catch (err: any) {
+			if (err?.code === "ENOENT" || attempt === 1) return false;
+			await new Promise<void>((resolve) => setTimeout(resolve, STATE_LOCK_RETRY_MS));
+		}
+	}
+	return false;
+}
+
 async function withStateKeyLock<T>({
 	env,
 	key,
@@ -257,6 +271,7 @@ async function withStateKeyLock<T>({
 	const lockPath = `${keyToPath(stateDir, key)}.lock`;
 	let acquired = false;
 	let owner: string | undefined;
+	let ownerWritten = false;
 	let heartbeat: ReturnType<typeof setInterval> | undefined;
 	try {
 		while (!acquired) {
@@ -270,6 +285,7 @@ async function withStateKeyLock<T>({
 					encoding: "utf8",
 					mode: 0o600,
 				});
+				ownerWritten = true;
 				const ownerPath = path.join(lockPath, "owner");
 				heartbeat = setInterval(() => {
 					void fsp.utimes(ownerPath, new Date(), new Date()).catch(() => {});
@@ -288,8 +304,7 @@ async function withStateKeyLock<T>({
 		if (heartbeat) clearInterval(heartbeat);
 		if (acquired) {
 			const ownerPath = path.join(lockPath, "owner");
-			const currentOwner = await fsp.readFile(ownerPath, "utf8").catch(() => undefined);
-			if (!owner || currentOwner === owner) {
+			if (!ownerWritten || !owner || (await stillOwnsStateLock(ownerPath, owner))) {
 				await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
 			}
 		}
@@ -470,13 +485,16 @@ async function deleteStateJsonUnlocked({ env, key }) {
 export async function deleteStateJson({
 	env,
 	key,
+	signal = undefined,
 }: {
 	env: Record<string, string | undefined>;
 	key: string;
+	signal?: AbortSignal;
 }) {
 	return withStateKeyLock({
 		env,
 		key,
+		signal,
 		task: () => deleteStateJsonUnlocked({ env, key }),
 	});
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -513,6 +513,23 @@ export async function readStateJson({ env, key }) {
 	}
 }
 
+/**
+ * Read a state record only after any in-progress publish-or-rollback transition
+ * for the same key has settled. Callers that compose state with another durable
+ * resource use this to avoid observing a value that cancellation may undo.
+ */
+export async function readStateJsonWithLock({
+	env,
+	key,
+	signal = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	signal?: AbortSignal;
+}) {
+	return withStateKeyLock({ env, key, signal, task: () => readStateJson({ env, key }) });
+}
+
 async function writeStateJsonUnlocked({
 	env,
 	key,
@@ -979,12 +996,14 @@ export async function diffAndStore({
 	value,
 	signal = undefined,
 	atomicWriteOptions = undefined,
+	afterStore = undefined,
 }: {
 	env: Record<string, string | undefined>;
 	key: string;
 	value: unknown;
 	signal?: AbortSignal;
 	atomicWriteOptions?: Omit<AtomicWriteOptions, "signal">;
+	afterStore?: (snapshot: { before: unknown; after: unknown; changed: boolean }) => Promise<void>;
 }) {
 	return withStateKeyLock({
 		env,
@@ -1004,12 +1023,19 @@ export async function diffAndStore({
 				throw err;
 			});
 			const changed = stableStringify(before) !== stableStringify(value);
+			const snapshot = { before, after: value, changed };
+			let stored = false;
 			try {
 				signal?.throwIfAborted();
 				await writeStateJsonUnlocked({ env, key, value, signal, atomicWriteOptions });
+				stored = true;
 				signal?.throwIfAborted();
+				await afterStore?.(snapshot);
 			} catch (err) {
-				if (signal?.aborted) {
+				// A caller can publish another resource while this state lock is held.
+				// If that coordinated publication fails, restore the state snapshot before
+				// releasing the lock so readers never reuse a cancelled result.
+				if (stored && (signal?.aborted || afterStore)) {
 					if (!beforeExists) {
 						await deleteStateJsonUnlocked({ env, key });
 					} else {
@@ -1018,7 +1044,7 @@ export async function diffAndStore({
 				}
 				throw err;
 			}
-			return { before, after: value, changed };
+			return snapshot;
 		},
 	});
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -151,6 +151,7 @@ export async function writeFileAtomic(filePath, data, options: AtomicWriteOption
 		handle = undefined;
 		options.signal?.throwIfAborted();
 		await renameFile(tmpPath, filePath);
+		options.signal?.throwIfAborted();
 		await syncDir(filePath);
 		cleanup = false;
 	} finally {
@@ -217,12 +218,27 @@ export async function readStateJson({ env, key }) {
 	}
 }
 
-export async function writeStateJson({ env, key, value, signal = undefined }) {
+export async function writeStateJson({
+	env,
+	key,
+	value,
+	signal = undefined,
+	atomicWriteOptions = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	value: unknown;
+	signal?: AbortSignal;
+	atomicWriteOptions?: Omit<AtomicWriteOptions, "signal">;
+}) {
 	const stateDir = defaultStateDir(env);
 	const filePath = keyToPath(stateDir, key);
 
 	await ensureDirectory(stateDir);
-	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n", { signal });
+	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n", {
+		...atomicWriteOptions,
+		signal,
+	});
 }
 
 export async function deleteStateJson({ env, key }) {
@@ -385,13 +401,37 @@ export async function cleanupApprovalIndexByStateKey({
 	}
 }
 
-export async function diffAndStore({ env, key, value, signal = undefined }) {
+export async function diffAndStore({
+	env,
+	key,
+	value,
+	signal = undefined,
+	atomicWriteOptions = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	value: unknown;
+	signal?: AbortSignal;
+	atomicWriteOptions?: Omit<AtomicWriteOptions, "signal">;
+}) {
 	const before = await readStateJson({ env, key }).catch((err) => {
 		if (isJsonSyntaxError(err)) return null;
 		throw err;
 	});
 	const changed = stableStringify(before) !== stableStringify(value);
-	signal?.throwIfAborted();
-	await writeStateJson({ env, key, value, signal });
+	try {
+		signal?.throwIfAborted();
+		await writeStateJson({ env, key, value, signal, atomicWriteOptions });
+		signal?.throwIfAborted();
+	} catch (err) {
+		if (signal?.aborted) {
+			if (before === null) {
+				await deleteStateJson({ env, key });
+			} else {
+				await writeStateJson({ env, key, value: before });
+			}
+		}
+		throw err;
+	}
 	return { before, after: value, changed };
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -46,6 +46,7 @@ type AtomicExclusiveWriteOptions = {
 
 const STATE_LOCK_RETRY_MS = 10;
 const STATE_LOCK_ORPHAN_MS = 1_000;
+const STATE_LOCK_HEARTBEAT_MS = 250;
 
 function isDirectorySyncUnsupportedError(err: any): boolean {
 	return [
@@ -136,27 +137,72 @@ function isProcessAlive(pid: number) {
 	}
 }
 
+type StateLockOwner = {
+	pid: number;
+	processStartIdentity: string | null;
+	nonce: string;
+};
+
+function parseStateLockOwner(ownerText: string): StateLockOwner | null {
+	const parts = ownerText.trim().split(":");
+	if (parts.length !== 3) return null;
+	const pid = Number(parts[0]);
+	const processStartIdentity = parts[1] || null;
+	const nonce = parts[2];
+	if (!Number.isInteger(pid) || pid <= 0 || !nonce) return null;
+	return { pid, processStartIdentity, nonce };
+}
+
+async function readProcessStartIdentity(pid: number): Promise<string | null> {
+	if (process.platform !== "linux") return null;
+	try {
+		const stat = await fsp.readFile(`/proc/${pid}/stat`, "utf8");
+		const closeParen = stat.lastIndexOf(")");
+		if (closeParen < 0) return null;
+		// The remainder starts at procfs field 3; starttime is field 22.
+		const fields = stat
+			.slice(closeParen + 1)
+			.trim()
+			.split(/\s+/);
+		return fields[19] || null;
+	} catch {
+		return null;
+	}
+}
+
+async function isStateLockOld(lockPath: string) {
+	try {
+		const stat = await fsp.stat(lockPath);
+		return Date.now() - stat.mtimeMs >= STATE_LOCK_ORPHAN_MS;
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return true;
+		throw err;
+	}
+}
+
 async function reclaimOrphanedStateLock(lockPath: string) {
 	let stale = false;
 	try {
 		const ownerPath = path.join(lockPath, "owner");
 		const ownerText = (await fsp.readFile(ownerPath, "utf8")).trim();
-		const owner = Number(ownerText.split(":", 1)[0]);
-		if (Number.isInteger(owner) && owner > 0) {
-			stale = !isProcessAlive(owner);
+		const owner = parseStateLockOwner(ownerText);
+		if (owner && isProcessAlive(owner.pid)) {
+			const processStartIdentity = await readProcessStartIdentity(owner.pid);
+			if (owner.processStartIdentity && processStartIdentity) {
+				stale = owner.processStartIdentity !== processStartIdentity;
+			} else {
+				// A live PID without a matching process-instance identity may have
+				// been reused. Active writers renew this lease while holding the lock.
+				stale = await isStateLockOld(ownerPath);
+			}
+		} else if (owner) {
+			stale = true;
 		} else {
-			const stat = await fsp.stat(lockPath);
-			stale = Date.now() - stat.mtimeMs >= STATE_LOCK_ORPHAN_MS;
+			stale = await isStateLockOld(lockPath);
 		}
 	} catch (err: any) {
 		if (err?.code === "ENOENT") {
-			try {
-				const stat = await fsp.stat(lockPath);
-				stale = Date.now() - stat.mtimeMs >= STATE_LOCK_ORPHAN_MS;
-			} catch (statErr: any) {
-				if (statErr?.code === "ENOENT") return true;
-				throw statErr;
-			}
+			stale = await isStateLockOld(lockPath);
 		} else {
 			throw err;
 		}
@@ -190,17 +236,24 @@ async function withStateKeyLock<T>({
 	const lockPath = `${keyToPath(stateDir, key)}.lock`;
 	let acquired = false;
 	let owner: string | undefined;
+	let heartbeat: ReturnType<typeof setInterval> | undefined;
 	try {
 		while (!acquired) {
 			signal?.throwIfAborted();
 			try {
 				await fsp.mkdir(lockPath, { mode: 0o700 });
 				acquired = true;
-				owner = `${process.pid}:${randomBytes(6).toString("hex")}\n`;
+				const processStartIdentity = await readProcessStartIdentity(process.pid);
+				owner = `${process.pid}:${processStartIdentity ?? ""}:${randomBytes(6).toString("hex")}\n`;
 				await fsp.writeFile(path.join(lockPath, "owner"), owner, {
 					encoding: "utf8",
 					mode: 0o600,
 				});
+				const ownerPath = path.join(lockPath, "owner");
+				heartbeat = setInterval(() => {
+					void fsp.utimes(ownerPath, new Date(), new Date()).catch(() => {});
+				}, STATE_LOCK_HEARTBEAT_MS);
+				heartbeat.unref?.();
 			} catch (err: any) {
 				if (acquired) throw err;
 				if (err?.code !== "EEXIST") throw err;
@@ -211,6 +264,7 @@ async function withStateKeyLock<T>({
 		}
 		return await task();
 	} finally {
+		if (heartbeat) clearInterval(heartbeat);
 		if (acquired) {
 			const ownerPath = path.join(lockPath, "owner");
 			const currentOwner = await fsp.readFile(ownerPath, "utf8").catch(() => undefined);

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -45,7 +45,7 @@ type AtomicExclusiveWriteOptions = {
 };
 
 const STATE_LOCK_RETRY_MS = 10;
-const STATE_LOCK_ORPHAN_MS = 1_000;
+const STATE_LOCK_ORPHAN_MS = 30_000;
 const STATE_LOCK_HEARTBEAT_MS = 250;
 
 function isDirectorySyncUnsupportedError(err: any): boolean {
@@ -180,6 +180,26 @@ async function isStateLockOld(lockPath: string) {
 	}
 }
 
+async function hasExpiredStateLockLease(lockPath: string) {
+	let first;
+	try {
+		first = await fsp.stat(lockPath);
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return true;
+		throw err;
+	}
+	if (Date.now() - first.mtimeMs < STATE_LOCK_ORPHAN_MS) return false;
+
+	await new Promise<void>((resolve) => setTimeout(resolve, STATE_LOCK_HEARTBEAT_MS));
+	try {
+		const second = await fsp.stat(lockPath);
+		return second.mtimeMs === first.mtimeMs && Date.now() - second.mtimeMs >= STATE_LOCK_ORPHAN_MS;
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return true;
+		throw err;
+	}
+}
+
 async function reclaimOrphanedStateLock(lockPath: string) {
 	let stale = false;
 	try {
@@ -192,8 +212,9 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 				stale = owner.processStartIdentity !== processStartIdentity;
 			} else {
 				// A live PID without a matching process-instance identity may have
-				// been reused. Active writers renew this lease while holding the lock.
-				stale = await isStateLockOld(ownerPath);
+				// been reused. Require a conservative expired lease and a second
+				// unchanged observation before reclaiming it.
+				stale = await hasExpiredStateLockLease(ownerPath);
 			}
 		} else if (owner) {
 			stale = true;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -8,6 +8,7 @@ const CONSUMED_RESUME_STATE_TYPE = "lobster.consumed-resume-state.v1";
 export type ConsumedResumeState = {
 	type: typeof CONSUMED_RESUME_STATE_TYPE;
 	consumedAt: string;
+	claimId: string;
 };
 
 export function isConsumedResumeState(value: unknown): value is ConsumedResumeState {
@@ -373,9 +374,12 @@ export async function writeFileAtomic(filePath, data, options: AtomicWriteOption
 		handle = undefined;
 		options.signal?.throwIfAborted();
 		await renameFile(tmpPath, filePath);
-		options.signal?.throwIfAborted();
+		// The rename is the irreversible publication point. Callers that need to
+		// compensate an aborted write must decide from the returned commit status;
+		// throwing here would hide that the replacement is already visible.
 		await syncDir(filePath);
 		cleanup = false;
+		return { signalAbortedAfterCommit: options.signal?.aborted === true };
 	} finally {
 		if (handle) await handle.close().catch(() => {});
 		if (cleanup) await fsp.rm(tmpPath, { force: true }).catch(() => {});
@@ -457,7 +461,7 @@ async function writeStateJsonUnlocked({
 	const filePath = keyToPath(stateDir, key);
 
 	await ensureDirectory(stateDir);
-	await writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n", {
+	return writeFileAtomic(filePath, JSON.stringify(value, null, 2) + "\n", {
 		...atomicWriteOptions,
 		signal,
 	});
@@ -492,17 +496,73 @@ export async function writeStateJson({
 export async function consumeResumeState({
 	env,
 	key,
+	expectedState,
 	signal = undefined,
 }: {
 	env: Record<string, string | undefined>;
 	key: string;
+	expectedState: unknown;
 	signal?: AbortSignal;
 }) {
-	await writeStateJson({
+	return withStateKeyLock({
 		env,
 		key,
-		value: { type: CONSUMED_RESUME_STATE_TYPE, consumedAt: new Date().toISOString() },
 		signal,
+		task: async () => {
+			const currentState = await readStateJson({ env, key });
+			// A resume snapshot is loaded before command/workflow setup. Re-check it
+			// while holding the state lock so two callers cannot both turn the same
+			// approval into an executable invocation.
+			if (stableStringify(currentState) !== stableStringify(expectedState)) {
+				return { consumed: false as const };
+			}
+			const claimId = randomBytes(16).toString("hex");
+			const result = await writeStateJsonUnlocked({
+				env,
+				key,
+				value: {
+					type: CONSUMED_RESUME_STATE_TYPE,
+					consumedAt: new Date().toISOString(),
+					claimId,
+				},
+				signal,
+			});
+			return {
+				consumed: true as const,
+				claimId,
+				signalAbortedAfterCommit: result?.signalAbortedAfterCommit === true,
+			};
+		},
+	});
+}
+
+/**
+ * Undo a just-published consumed marker only when it is still owned by the
+ * caller's pre-dispatch claim. This never overwrites a replacement state or a
+ * concurrent claimant's marker.
+ */
+export async function restoreConsumedResumeState({
+	env,
+	key,
+	expectedState,
+	claimId,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	expectedState: unknown;
+	claimId: string;
+}) {
+	return withStateKeyLock({
+		env,
+		key,
+		task: async () => {
+			const currentState = await readStateJson({ env, key });
+			if (!isConsumedResumeState(currentState) || currentState.claimId !== claimId) {
+				return false;
+			}
+			await writeStateJsonUnlocked({ env, key, value: expectedState });
+			return true;
+		},
 	});
 }
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -500,7 +500,7 @@ export async function writeFileAtomicExclusive(
 	}
 }
 
-export async function readStateJson({ env, key }) {
+async function readStateJson({ env, key }) {
 	const stateDir = defaultStateDir(env);
 	const filePath = keyToPath(stateDir, key);
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -140,8 +140,14 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 	let stale = false;
 	try {
 		const ownerPath = path.join(lockPath, "owner");
-		const owner = Number((await fsp.readFile(ownerPath, "utf8")).trim());
-		stale = Number.isInteger(owner) && owner > 0 && !isProcessAlive(owner);
+		const ownerText = (await fsp.readFile(ownerPath, "utf8")).trim();
+		const owner = Number(ownerText.split(":", 1)[0]);
+		if (Number.isInteger(owner) && owner > 0) {
+			stale = !isProcessAlive(owner);
+		} else {
+			const stat = await fsp.stat(lockPath);
+			stale = Date.now() - stat.mtimeMs >= STATE_LOCK_ORPHAN_MS;
+		}
 	} catch (err: any) {
 		if (err?.code === "ENOENT") {
 			try {
@@ -183,13 +189,15 @@ async function withStateKeyLock<T>({
 	await ensureDirectory(stateDir);
 	const lockPath = `${keyToPath(stateDir, key)}.lock`;
 	let acquired = false;
+	let owner: string | undefined;
 	try {
 		while (!acquired) {
 			signal?.throwIfAborted();
 			try {
 				await fsp.mkdir(lockPath, { mode: 0o700 });
 				acquired = true;
-				await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}\n`, {
+				owner = `${process.pid}:${randomBytes(6).toString("hex")}\n`;
+				await fsp.writeFile(path.join(lockPath, "owner"), owner, {
 					encoding: "utf8",
 					mode: 0o600,
 				});
@@ -203,7 +211,13 @@ async function withStateKeyLock<T>({
 		}
 		return await task();
 	} finally {
-		if (acquired) await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+		if (acquired) {
+			const ownerPath = path.join(lockPath, "owner");
+			const currentOwner = await fsp.readFile(ownerPath, "utf8").catch(() => undefined);
+			if (!owner || currentOwner === owner) {
+				await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+			}
+		}
 	}
 }
 
@@ -323,7 +337,7 @@ export async function readStateJson({ env, key }) {
 	}
 }
 
-export async function writeStateJson({
+async function writeStateJsonUnlocked({
 	env,
 	key,
 	value,
@@ -346,7 +360,28 @@ export async function writeStateJson({
 	});
 }
 
-export async function deleteStateJson({ env, key }) {
+export async function writeStateJson({
+	env,
+	key,
+	value,
+	signal = undefined,
+	atomicWriteOptions = undefined,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+	value: unknown;
+	signal?: AbortSignal;
+	atomicWriteOptions?: Omit<AtomicWriteOptions, "signal">;
+}) {
+	return withStateKeyLock({
+		env,
+		key,
+		signal,
+		task: () => writeStateJsonUnlocked({ env, key, value, signal, atomicWriteOptions }),
+	});
+}
+
+async function deleteStateJsonUnlocked({ env, key }) {
 	const stateDir = defaultStateDir(env);
 	const filePath = keyToPath(stateDir, key);
 	try {
@@ -355,6 +390,20 @@ export async function deleteStateJson({ env, key }) {
 		if (err?.code === "ENOENT") return;
 		throw err;
 	}
+}
+
+export async function deleteStateJson({
+	env,
+	key,
+}: {
+	env: Record<string, string | undefined>;
+	key: string;
+}) {
+	return withStateKeyLock({
+		env,
+		key,
+		task: () => deleteStateJsonUnlocked({ env, key }),
+	});
 }
 
 function sanitizeApprovalId(approvalId: string): string {
@@ -531,14 +580,14 @@ export async function diffAndStore({
 			const changed = stableStringify(before) !== stableStringify(value);
 			try {
 				signal?.throwIfAborted();
-				await writeStateJson({ env, key, value, signal, atomicWriteOptions });
+				await writeStateJsonUnlocked({ env, key, value, signal, atomicWriteOptions });
 				signal?.throwIfAborted();
 			} catch (err) {
 				if (signal?.aborted) {
 					if (before === null) {
-						await deleteStateJson({ env, key });
+						await deleteStateJsonUnlocked({ env, key });
 					} else {
-						await writeStateJson({ env, key, value: before });
+						await writeStateJsonUnlocked({ env, key, value: before });
 					}
 				}
 				throw err;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -217,6 +217,15 @@ async function hasExpiredStateLockLease(lockPath: string) {
 }
 
 async function reclaimOrphanedStateLock(lockPath: string) {
+	let observedLock: { dev: number; ino: number };
+	try {
+		const stat = await fsp.lstat(lockPath);
+		observedLock = { dev: stat.dev, ino: stat.ino };
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return true;
+		throw err;
+	}
+
 	let stale = false;
 	try {
 		const ownerPath = path.join(lockPath, "owner");
@@ -246,14 +255,30 @@ async function reclaimOrphanedStateLock(lockPath: string) {
 	}
 	if (!stale) return false;
 
-	const orphanPath = `${lockPath}.${randomBytes(6).toString("hex")}.orphan`;
+	// Claim reclamation inside the observed directory before removing it. Renaming
+	// `lockPath` directly is unsafe: another reclaimer can replace that pathname
+	// with a live lock after the stale observation, and a later recursive cleanup
+	// would then delete the new owner's lock while it is in use.
+	const reclaimPath = path.join(lockPath, ".reclaiming");
 	try {
-		await fsp.rename(lockPath, orphanPath);
+		await fsp.mkdir(reclaimPath, { mode: 0o700 });
 	} catch (err: any) {
 		if (err?.code === "ENOENT") return true;
+		if (err?.code === "EEXIST") return false;
 		throw err;
 	}
-	await fsp.rm(orphanPath, { recursive: true, force: true });
+
+	try {
+		const currentLock = await fsp.lstat(lockPath);
+		if (currentLock.dev !== observedLock.dev || currentLock.ino !== observedLock.ino) {
+			return false;
+		}
+		await fsp.rm(lockPath, { recursive: true, force: true });
+	} finally {
+		// If the path changed before the reclamation marker was claimed, leave the
+		// replacement lock intact and only remove our harmless marker.
+		await fsp.rmdir(reclaimPath).catch(() => {});
+	}
 	return true;
 }
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -74,7 +74,7 @@ function markAtomicWritePublished(err: unknown) {
 	return err;
 }
 
-function atomicWriteWasPublished(err: unknown): err is PublishedAtomicWriteError {
+export function atomicWriteWasPublished(err: unknown): err is PublishedAtomicWriteError {
 	return Boolean((err as PublishedAtomicWriteError | undefined)?.atomicWritePublished);
 }
 
@@ -1068,7 +1068,8 @@ export async function diffAndStore({
 				// A caller can publish another resource while this state lock is held.
 				// If that coordinated publication fails, restore the state snapshot before
 				// releasing the lock so readers never reuse a cancelled result.
-				if (stored && (signal?.aborted || afterStore)) {
+				const stateWasPublished = stored || atomicWriteWasPublished(err);
+				if (stateWasPublished && (signal?.aborted || afterStore || atomicWriteWasPublished(err))) {
 					if (!beforeExists) {
 						await deleteStateJsonUnlocked({ env, key });
 					} else {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -2900,6 +2900,7 @@ async function runPipelineStep({
 		mode: ctx.mode,
 		cwd,
 		signal: ctx.signal,
+		haltAfterStageOnAbort: true,
 		llmAdapters: ctx.llmAdapters,
 		input: resume ? resume.pipelineInput.items : inputValueToPipelineItems(inputValue),
 		requestInputEnabled,
@@ -2912,6 +2913,7 @@ async function runPipelineStep({
 			: undefined,
 	});
 	stdout.end();
+	ctx.signal?.throwIfAborted();
 
 	if (result.halted) {
 		const haltedName = result.haltedAt?.stage?.name ?? "unknown";

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -170,6 +170,7 @@ type RunContext = {
 	dryRun?: boolean;
 	_activeWorkflows?: Set<string>;
 	_onExecutionStart?: () => void;
+	_onResumeStateResolved?: (stateKey: string) => void;
 };
 
 export type WorkflowResumePayload = {
@@ -703,6 +704,7 @@ export async function runWorkflowFile({
 		resume?.stateKey && typeof resume.stateKey === "string"
 			? await resolveWorkflowResumeStateKey(ctx.env, resume.stateKey)
 			: null;
+	if (consumedResumeStateKey) ctx._onResumeStateResolved?.(consumedResumeStateKey);
 	const resumeState = resume?.stateKey
 		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey)
 		: (resume ?? null);
@@ -1823,7 +1825,7 @@ async function saveWorkflowResumeState(
 	return stateKey;
 }
 
-function alternateWorkflowResumeStateKey(stateKey: string): string | null {
+export function alternateWorkflowResumeStateKey(stateKey: string): string | null {
 	if (stateKey.includes("workflow-resume_")) {
 		return stateKey.replace("workflow-resume_", "workflow_resume_");
 	}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -856,6 +856,7 @@ export async function runWorkflowFile({
 			resumeState?.inputStepId ?? findLastCompletedStepId(steps, results);
 
 		for (let idx = startIndex; idx < steps.length; idx++) {
+			ctx.signal?.throwIfAborted();
 			const step = steps[idx];
 
 			if (!evaluateCondition(step.when ?? step.condition, results)) {
@@ -948,6 +949,7 @@ export async function runWorkflowFile({
 				const iterationResults: unknown[] = [];
 
 				for (let itemIdx = 0; itemIdx < itemsRef.length; itemIdx++) {
+					ctx.signal?.throwIfAborted();
 					if (step.pause_ms && itemIdx > 0 && itemIdx % batchSize === 0) {
 						await abortableSleep(step.pause_ms, ctx.signal);
 					}
@@ -966,6 +968,7 @@ export async function runWorkflowFile({
 					};
 
 					for (const subStep of step.steps) {
+						ctx.signal?.throwIfAborted();
 						if (!evaluateCondition(subStep.when ?? subStep.condition, scopedResults)) {
 							scopedResults[subStep.id] = { id: subStep.id, skipped: true };
 							continue;
@@ -1060,6 +1063,7 @@ export async function runWorkflowFile({
 				result: WorkflowStepResult;
 				parallelBranchResults: Record<string, WorkflowStepResult> | null;
 			}> => {
+				ctx.signal?.throwIfAborted();
 				// Combine external cancellation and optional per-step timeout into one signal.
 				let stepSignal: AbortSignal | undefined = ctx.signal;
 				let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -2776,7 +2780,9 @@ async function runShellCommand({
 	signal?: AbortSignal;
 	killSignal?: NodeJS.Signals;
 }) {
+	signal?.throwIfAborted();
 	const { spawn } = await import("node:child_process");
+	signal?.throwIfAborted();
 
 	return await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
 		const shell = resolveInlineShellCommand({ command, env });

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -169,6 +169,7 @@ type RunContext = {
 	llmAdapters?: Record<string, any>;
 	dryRun?: boolean;
 	_activeWorkflows?: Set<string>;
+	_onExecutionStart?: () => void;
 };
 
 export type WorkflowResumePayload = {
@@ -857,6 +858,7 @@ export async function runWorkflowFile({
 
 		for (let idx = startIndex; idx < steps.length; idx++) {
 			ctx.signal?.throwIfAborted();
+			ctx._onExecutionStart?.();
 			const step = steps[idx];
 
 			if (!evaluateCondition(step.when ?? step.condition, results)) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1379,7 +1379,7 @@ export async function runWorkflowFile({
 				if (err instanceof RequestInputResumeError) {
 					throw err;
 				}
-				if (ctx.signal?.aborted && (err?.name === "AbortError" || err?.code === "ABORT_ERR")) {
+				if (ctx.signal?.aborted) {
 					throw err;
 				}
 				if (

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -10,6 +10,7 @@ import { parsePipeline } from "../parser.js";
 import { runPipeline } from "../runtime.js";
 import { encodeToken, decodeToken } from "../token.js";
 import {
+	cleanupApprovalIndexByStateKey,
 	createApprovalIndex,
 	deleteStateJson,
 	readStateJson,
@@ -886,38 +887,49 @@ export async function runWorkflowFile({
 						subject,
 						maxEnvelopeBytes: resolveToolEnvelopeMaxBytes(ctx.env),
 					});
-					const stateKey = await saveWorkflowResumeState(ctx.env, {
-						filePath: resolvedFilePath,
-						resumeAtIndex: idx + 1,
-						steps: results,
-						args: resolvedArgs,
-						inputStepId: step.id,
-						inputSchema: step.input.responseSchema,
-						// Preserve the full resolved subject for resume semantics; the tool
-						// envelope may contain a truncated preview to stay within size limits.
-						inputSubject: subject,
-						createdAt: new Date().toISOString(),
-					});
+					let stateKey: string | undefined;
+					try {
+						stateKey = await saveWorkflowResumeState(
+							ctx.env,
+							{
+								filePath: resolvedFilePath,
+								resumeAtIndex: idx + 1,
+								steps: results,
+								args: resolvedArgs,
+								inputStepId: step.id,
+								inputSchema: step.input.responseSchema,
+								// Preserve the full resolved subject for resume semantics; the tool
+								// envelope may contain a truncated preview to stay within size limits.
+								inputSubject: subject,
+								createdAt: new Date().toISOString(),
+							},
+							ctx.signal,
+						);
 
-					if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
-						await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+						if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
+							await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+						}
+						ctx.signal?.throwIfAborted();
+
+						const resumeToken = encodeToken({
+							protocolVersion: 1,
+							v: 1,
+							kind: "workflow-file",
+							stateKey,
+						} satisfies WorkflowResumePayload);
+
+						return {
+							status: "needs_input",
+							output: [],
+							requiresInput: {
+								...inputRequest,
+								resumeToken,
+							},
+						};
+					} catch (err) {
+						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
+						throw err;
 					}
-
-					const resumeToken = encodeToken({
-						protocolVersion: 1,
-						v: 1,
-						kind: "workflow-file",
-						stateKey,
-					} satisfies WorkflowResumePayload);
-
-					return {
-						status: "needs_input",
-						output: [],
-						requiresInput: {
-							...inputRequest,
-							resumeToken,
-						},
-					};
 				}
 
 				ctx.stdout.write(`${step.input.prompt}\n`);
@@ -1352,38 +1364,49 @@ export async function runWorkflowFile({
 						subject: err.request.subject,
 						maxEnvelopeBytes: resolveToolEnvelopeMaxBytes(ctx.env),
 					});
-					const stateKey = await saveWorkflowResumeState(ctx.env, {
-						filePath: resolvedFilePath,
-						resumeAtIndex: idx,
-						steps: results,
-						args: resolvedArgs,
-						inputStepId: err.stepId,
-						inputKind: "pipeline_command",
-						inputSchema: err.request.responseSchema,
-						inputSubject: err.request.subject,
-						pipelineInput: err.pipelineInput,
-						createdAt: new Date().toISOString(),
-					});
+					let stateKey: string | undefined;
+					try {
+						stateKey = await saveWorkflowResumeState(
+							ctx.env,
+							{
+								filePath: resolvedFilePath,
+								resumeAtIndex: idx,
+								steps: results,
+								args: resolvedArgs,
+								inputStepId: err.stepId,
+								inputKind: "pipeline_command",
+								inputSchema: err.request.responseSchema,
+								inputSubject: err.request.subject,
+								pipelineInput: err.pipelineInput,
+								createdAt: new Date().toISOString(),
+							},
+							ctx.signal,
+						);
 
-					if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
-						await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+						if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
+							await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+						}
+						ctx.signal?.throwIfAborted();
+
+						const resumeToken = encodeToken({
+							protocolVersion: 1,
+							v: 1,
+							kind: "workflow-file",
+							stateKey,
+						} satisfies WorkflowResumePayload);
+
+						return {
+							status: "needs_input",
+							output: [],
+							requiresInput: {
+								...inputRequest,
+								resumeToken,
+							},
+						};
+					} catch (stateError) {
+						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
+						throw stateError;
 					}
-
-					const resumeToken = encodeToken({
-						protocolVersion: 1,
-						v: 1,
-						kind: "workflow-file",
-						stateKey,
-					} satisfies WorkflowResumePayload);
-
-					return {
-						status: "needs_input",
-						output: [],
-						requiresInput: {
-							...inputRequest,
-							resumeToken,
-						},
-					};
 				}
 				if (err instanceof RequestInputResumeError) {
 					throw err;
@@ -1443,44 +1466,49 @@ export async function runWorkflowFile({
 				}
 
 				if (ctx.mode === "tool" || !isInteractive(ctx.stdin)) {
-					const stateKey = await saveWorkflowResumeState(ctx.env, {
-						filePath: resolvedFilePath,
-						resumeAtIndex: idx + 1,
-						steps: results,
-						args: resolvedArgs,
-						approvalStepId: step.id,
-						approvalIdentity,
-						createdAt: new Date().toISOString(),
-					});
-
-					let approvalId: string | null;
+					let stateKey: string | undefined;
 					try {
-						approvalId = await createApprovalIndex({ env: ctx.env, stateKey });
+						stateKey = await saveWorkflowResumeState(
+							ctx.env,
+							{
+								filePath: resolvedFilePath,
+								resumeAtIndex: idx + 1,
+								steps: results,
+								args: resolvedArgs,
+								approvalStepId: step.id,
+								approvalIdentity,
+								createdAt: new Date().toISOString(),
+							},
+							ctx.signal,
+						);
+
+						const approvalId = await createApprovalIndex({ env: ctx.env, stateKey });
+						ctx.signal?.throwIfAborted();
+						if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
+							await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+						}
+						ctx.signal?.throwIfAborted();
+
+						const resumeToken = encodeToken({
+							protocolVersion: 1,
+							v: 1,
+							kind: "workflow-file",
+							stateKey,
+						} satisfies WorkflowResumePayload);
+
+						return {
+							status: "needs_approval",
+							output: [],
+							requiresApproval: {
+								...approval,
+								resumeToken,
+								...(approvalId ? { approvalId } : null),
+							},
+						};
 					} catch (err) {
-						await deleteStateJson({ env: ctx.env, key: stateKey }).catch(() => {});
+						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
-
-					if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
-						await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-					}
-
-					const resumeToken = encodeToken({
-						protocolVersion: 1,
-						v: 1,
-						kind: "workflow-file",
-						stateKey,
-					} satisfies WorkflowResumePayload);
-
-					return {
-						status: "needs_approval",
-						output: [],
-						requiresApproval: {
-							...approval,
-							resumeToken,
-							...(approvalId ? { approvalId } : null),
-						},
-					};
 				}
 
 				ctx.stdout.write(`${approval.prompt} [y/N] `);
@@ -1820,10 +1848,26 @@ export function decodeWorkflowResumePayload(payload: unknown): WorkflowResumePay
 async function saveWorkflowResumeState(
 	env: Record<string, string | undefined>,
 	state: WorkflowResumeState,
+	signal?: AbortSignal,
 ) {
 	const stateKey = `workflow_resume_${randomUUID()}`;
-	await writeStateJson({ env, key: stateKey, value: state });
-	return stateKey;
+	try {
+		signal?.throwIfAborted();
+		await writeStateJson({ env, key: stateKey, value: state, signal });
+		signal?.throwIfAborted();
+		return stateKey;
+	} catch (err) {
+		if (signal?.aborted) await discardWorkflowResumeState(env, stateKey);
+		throw err;
+	}
+}
+
+async function discardWorkflowResumeState(
+	env: Record<string, string | undefined>,
+	stateKey: string,
+) {
+	await cleanupApprovalIndexByStateKey({ env, stateKey }).catch(() => {});
+	await deleteStateJson({ env, key: stateKey }).catch(() => {});
 }
 
 export function alternateWorkflowResumeStateKey(stateKey: string): string | null {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -13,6 +13,7 @@ import {
 	cleanupApprovalIndexByStateKey,
 	consumeResumeState,
 	createApprovalIndex,
+	deleteResumeStateWithRollback,
 	deleteStateJson,
 	deleteUnconsumedResumeState,
 	isConsumedResumeState,
@@ -719,7 +720,6 @@ export async function runWorkflowFile({
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
 	let resumeStateConsumed = false;
-	let resumeStateClaimRejected = false;
 	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
 	let executionStart: Promise<void> | undefined;
 	const markExecutionStarted = async (signal?: AbortSignal) => {
@@ -735,7 +735,6 @@ export async function runWorkflowFile({
 					signal,
 				});
 				if (!consumption.consumed) {
-					resumeStateClaimRejected = true;
 					throw new Error("Workflow resume state not found");
 				}
 				if (consumption.signalAbortedAfterCommit) {
@@ -745,7 +744,6 @@ export async function runWorkflowFile({
 						expectedState: resumeState,
 						claimId: consumption.claimId,
 					});
-					resumeStateClaimRejected = true;
 					signal?.throwIfAborted();
 				}
 				signal?.throwIfAborted();
@@ -979,7 +977,6 @@ export async function runWorkflowFile({
 							signal: ctx.signal,
 						});
 						if (!replaced) {
-							resumeStateClaimRejected = true;
 							throw new Error("Workflow resume state not found");
 						}
 
@@ -999,13 +996,6 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (err) {
-						if (!resumeStateConsumed) {
-							await restoreWorkflowResumeState({
-								env: ctx.env,
-								stateKey: consumedResumeStateKey,
-								state: resumeState,
-							});
-						}
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
@@ -1503,7 +1493,6 @@ export async function runWorkflowFile({
 							signal: ctx.signal,
 						});
 						if (!replaced) {
-							resumeStateClaimRejected = true;
 							throw new Error("Workflow resume state not found");
 						}
 
@@ -1523,13 +1512,6 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (stateError) {
-						if (!resumeStateConsumed) {
-							await restoreWorkflowResumeState({
-								env: ctx.env,
-								stateKey: consumedResumeStateKey,
-								state: resumeState,
-							});
-						}
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw stateError;
 					}
@@ -1623,7 +1605,6 @@ export async function runWorkflowFile({
 							signal: ctx.signal,
 						});
 						if (!replaced) {
-							resumeStateClaimRejected = true;
 							throw new Error("Workflow resume state not found");
 						}
 
@@ -1644,13 +1625,6 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (err) {
-						if (!resumeStateConsumed) {
-							await restoreWorkflowResumeState({
-								env: ctx.env,
-								stateKey: consumedResumeStateKey,
-								state: resumeState,
-							});
-						}
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
@@ -1677,7 +1651,7 @@ export async function runWorkflowFile({
 
 		const output = lastStepId ? toOutputItems(results[lastStepId]) : [];
 		if (consumedResumeStateKey) {
-			try {
+			if (resumeStateConsumed) {
 				ctx.signal?.throwIfAborted();
 				await deleteStateJson({
 					env: ctx.env,
@@ -1685,20 +1659,18 @@ export async function runWorkflowFile({
 					signal: ctx.signal,
 				});
 				ctx.signal?.throwIfAborted();
-				await cleanupSupersededWorkflowResumeStates(
-					ctx.env,
-					resumeState?.supersededResumeStateKeys,
-				);
-			} catch (err) {
-				if (!resumeStateConsumed) {
-					await restoreWorkflowResumeState({
-						env: ctx.env,
-						stateKey: consumedResumeStateKey,
-						state: resumeState,
-					});
+			} else {
+				const deleted = await deleteResumeStateWithRollback({
+					env: ctx.env,
+					key: consumedResumeStateKey,
+					expectedState: resumeState,
+					signal: ctx.signal,
+				});
+				if (!deleted) {
+					throw new Error("Workflow resume state not found");
 				}
-				throw err;
 			}
+			await cleanupSupersededWorkflowResumeStates(ctx.env, resumeState?.supersededResumeStateKeys);
 		} else {
 			ctx.signal?.throwIfAborted();
 		}
@@ -1708,18 +1680,7 @@ export async function runWorkflowFile({
 		}
 		return runResult;
 	} catch (err) {
-		if (
-			!resumedExecutionStarted &&
-			!resumeStateConsumed &&
-			!resumeStateClaimRejected &&
-			consumedResumeStateKey
-		) {
-			await restoreWorkflowResumeState({
-				env: ctx.env,
-				stateKey: consumedResumeStateKey,
-				state: resumeState,
-			});
-		} else if (resumedExecutionStarted && consumedResumeStateKey) {
+		if (resumedExecutionStarted && consumedResumeStateKey) {
 			try {
 				await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
 				await cleanupApprovalIndexByStateKey({
@@ -2114,20 +2075,6 @@ async function replaceWorkflowResumeState({
 		}
 		throw err;
 	}
-}
-
-async function restoreWorkflowResumeState({
-	env,
-	stateKey,
-	state,
-}: {
-	env: Record<string, string | undefined>;
-	stateKey: string | null;
-	state: WorkflowResumeState | WorkflowResumePayload | null;
-}) {
-	if (!stateKey || !state) return;
-	if ((await readStateJson({ env, key: stateKey })) !== null) return;
-	await writeStateJson({ env, key: stateKey, value: state });
 }
 
 function collectSupersededWorkflowResumeStateKeys(

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -16,6 +16,7 @@ import {
 	deleteStateJson,
 	isConsumedResumeState,
 	readStateJson,
+	restoreConsumedResumeState,
 	writeStateJson,
 } from "../state/store.js";
 import { readLineFromStream } from "../read_line.js";
@@ -716,6 +717,7 @@ export async function runWorkflowFile({
 	let resumedExecutionStarted = false;
 	let resumedExecutionInterrupted = false;
 	let resumeStateConsumed = false;
+	let resumeStateClaimRejected = false;
 	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
 	let executionStart: Promise<void> | undefined;
 	const markExecutionStarted = async (signal?: AbortSignal) => {
@@ -724,7 +726,26 @@ export async function runWorkflowFile({
 		executionStart = (async () => {
 			signal?.throwIfAborted();
 			if (consumedResumeStateKey) {
-				await consumeResumeState({ env: ctx.env, key: consumedResumeStateKey, signal });
+				const consumption = await consumeResumeState({
+					env: ctx.env,
+					key: consumedResumeStateKey,
+					expectedState: resumeState,
+					signal,
+				});
+				if (!consumption.consumed) {
+					resumeStateClaimRejected = true;
+					throw new Error("Workflow resume state not found");
+				}
+				if (consumption.signalAbortedAfterCommit) {
+					const restored = await restoreConsumedResumeState({
+						env: ctx.env,
+						key: consumedResumeStateKey,
+						expectedState: resumeState,
+						claimId: consumption.claimId,
+					});
+					if (!restored) resumeStateClaimRejected = true;
+					signal?.throwIfAborted();
+				}
 				resumeStateConsumed = true;
 				// A retained index may point to the tombstone after an I/O failure, but
 				// it can never re-enable the now-consumed raw token.
@@ -868,15 +889,6 @@ export async function runWorkflowFile({
 					stepId: resumeState.inputStepId,
 					response,
 					pipelineInput: resumeState.pipelineInput!,
-					onConsumed: consumedResumeStateKey
-						? async () => {
-								await deleteStateJson({
-									env: ctx.env,
-									key: consumedResumeStateKey,
-									signal: ctx.signal,
-								});
-							}
-						: undefined,
 				};
 			} else {
 				const inputStep = steps[stepIndexById.get(resumeState.inputStepId) ?? -1];
@@ -1067,9 +1079,9 @@ export async function runWorkflowFile({
 
 						let subResult: WorkflowStepResult;
 						if (subExecution.kind === "shell") {
-							await markExecutionStarted(ctx.signal);
 							const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
+							await markExecutionStarted(ctx.signal);
 							const { stdout } = await runShellCommand({
 								command,
 								stdin: stdinValue,
@@ -1084,7 +1096,6 @@ export async function runWorkflowFile({
 									`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
 								);
 							}
-							await markExecutionStarted(ctx.signal);
 							const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
 							subResult = await runPipelineStep({
@@ -1095,6 +1106,7 @@ export async function runWorkflowFile({
 								env: subEnv,
 								cwd: subCwd,
 								requestInputEnabled: false,
+								onExecutionStart: () => markExecutionStarted(ctx.signal),
 							});
 						} else {
 							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
@@ -1172,7 +1184,6 @@ export async function runWorkflowFile({
 							? AbortSignal.any([stepSignal, parallelTimeoutController.signal])
 							: parallelTimeoutController.signal;
 						const branchSignal = AbortSignal.any([parallelSignal, branchAbortController.signal]);
-						await markExecutionStarted(parallelSignal);
 						const shouldForceKill = Boolean(step.timeout_ms || parallel.timeout_ms);
 						const runBranch = async (
 							branch: ParallelBranch,
@@ -1198,6 +1209,7 @@ export async function runWorkflowFile({
 							if (branchExec.kind === "shell") {
 								const command = resolveTemplate(branchExec.value, resolvedArgs, results);
 								const stdinValue = resolveShellStdin(branch.stdin, resolvedArgs, results);
+								await markExecutionStarted(branchSignal);
 								const { stdout } = await runShellCommand({
 									command,
 									stdin: stdinValue,
@@ -1228,6 +1240,7 @@ export async function runWorkflowFile({
 									env: branchEnv,
 									cwd: branchCwd,
 									requestInputEnabled: false,
+									onExecutionStart: () => markExecutionStarted(branchSignal),
 								});
 								return { branchId: branch.id, result: branchResult };
 							}
@@ -1364,9 +1377,9 @@ export async function runWorkflowFile({
 						const stdout = subResult.output.length ? serializeValueForStdout(json) : "";
 						result = { id: step.id, stdout, json };
 					} else if (execution.kind === "shell") {
-						await markExecutionStarted(stepSignal);
 						const command = resolveTemplate(execution.value, resolvedArgs, results);
 						const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
+						await markExecutionStarted(stepSignal);
 						const { stdout } = await runShellCommand({
 							command,
 							stdin: stdinValue,
@@ -1664,7 +1677,12 @@ export async function runWorkflowFile({
 		}
 		return runResult;
 	} catch (err) {
-		if (!resumedExecutionStarted && !resumeStateConsumed && consumedResumeStateKey) {
+		if (
+			!resumedExecutionStarted &&
+			!resumeStateConsumed &&
+			!resumeStateClaimRejected &&
+			consumedResumeStateKey
+		) {
 			await restoreWorkflowResumeState({
 				env: ctx.env,
 				stateKey: consumedResumeStateKey,

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -862,7 +862,6 @@ export async function runWorkflowFile({
 
 		for (let idx = startIndex; idx < steps.length; idx++) {
 			ctx.signal?.throwIfAborted();
-			ctx._onExecutionStart?.();
 			const step = steps[idx];
 
 			if (!evaluateCondition(step.when ?? step.condition, results)) {
@@ -1008,6 +1007,7 @@ export async function runWorkflowFile({
 
 						let subResult: WorkflowStepResult;
 						if (subExecution.kind === "shell") {
+							ctx._onExecutionStart?.();
 							const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
 							const { stdout } = await runShellCommand({
@@ -1024,6 +1024,7 @@ export async function runWorkflowFile({
 									`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
 								);
 							}
+							ctx._onExecutionStart?.();
 							const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
 							subResult = await runPipelineStep({
@@ -1082,6 +1083,9 @@ export async function runWorkflowFile({
 				parallelBranchResults: Record<string, WorkflowStepResult> | null;
 			}> => {
 				ctx.signal?.throwIfAborted();
+				if (execution.kind !== "none") {
+					ctx._onExecutionStart?.();
+				}
 				// Combine external cancellation and optional per-step timeout into one signal.
 				let stepSignal: AbortSignal | undefined = ctx.signal;
 				let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -1531,6 +1535,7 @@ export async function runWorkflowFile({
 			}
 		}
 
+		ctx.signal?.throwIfAborted();
 		const output = lastStepId ? toOutputItems(results[lastStepId]) : [];
 		if (consumedResumeStateKey) {
 			await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1919,6 +1919,12 @@ async function replaceWorkflowResumeState({
 		await deleteStateJson({ env, key: previousStateKey });
 	}
 	signal?.throwIfAborted();
+	if (previousStateKey && previousStateKey !== replacementStateKey) {
+		// The replacement is committed once its predecessor has been removed.
+		// Do not add another cancellation checkpoint after retiring its old
+		// approval capability: the outer rollback path must be able to restore it.
+		await cleanupApprovalIndexByStateKey({ env, stateKey: previousStateKey }).catch(() => {});
+	}
 }
 
 async function restoreWorkflowResumeState({

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -195,6 +195,7 @@ export type WorkflowResumePayload = {
 	inputSchema?: unknown;
 	inputSubject?: unknown;
 	pipelineInput?: WorkflowPipelineInputResumeState;
+	supersededResumeStateKeys?: string[];
 };
 
 type WorkflowResumeState = {
@@ -209,6 +210,7 @@ type WorkflowResumeState = {
 	inputSchema?: unknown;
 	inputSubject?: unknown;
 	pipelineInput?: WorkflowPipelineInputResumeState;
+	supersededResumeStateKeys?: string[];
 	createdAt: string;
 };
 
@@ -963,17 +965,27 @@ export async function runWorkflowFile({
 								// Preserve the full resolved subject for resume semantics; the tool
 								// envelope may contain a truncated preview to stay within size limits.
 								inputSubject: subject,
+								supersededResumeStateKeys: collectSupersededWorkflowResumeStateKeys(
+									consumedResumeStateKey,
+									resumeState,
+								),
 								createdAt: new Date().toISOString(),
 							},
 							ctx.signal,
 						);
 
-						await replaceWorkflowResumeState({
+						const replaced = await replaceWorkflowResumeState({
 							env: ctx.env,
 							previousStateKey: consumedResumeStateKey,
+							expectedPreviousState: resumeState,
+							previousStateConsumed: resumeStateConsumed,
 							replacementStateKey: stateKey,
 							signal: ctx.signal,
 						});
+						if (!replaced) {
+							resumeStateClaimRejected = true;
+							throw new Error("Workflow resume state not found");
+						}
 
 						const resumeToken = encodeToken({
 							protocolVersion: 1,
@@ -1478,17 +1490,27 @@ export async function runWorkflowFile({
 								inputSchema: err.request.responseSchema,
 								inputSubject: err.request.subject,
 								pipelineInput: err.pipelineInput,
+								supersededResumeStateKeys: collectSupersededWorkflowResumeStateKeys(
+									consumedResumeStateKey,
+									resumeState,
+								),
 								createdAt: new Date().toISOString(),
 							},
 							ctx.signal,
 						);
 
-						await replaceWorkflowResumeState({
+						const replaced = await replaceWorkflowResumeState({
 							env: ctx.env,
 							previousStateKey: consumedResumeStateKey,
+							expectedPreviousState: resumeState,
+							previousStateConsumed: resumeStateConsumed,
 							replacementStateKey: stateKey,
 							signal: ctx.signal,
 						});
+						if (!replaced) {
+							resumeStateClaimRejected = true;
+							throw new Error("Workflow resume state not found");
+						}
 
 						const resumeToken = encodeToken({
 							protocolVersion: 1,
@@ -1586,6 +1608,10 @@ export async function runWorkflowFile({
 								args: resolvedArgs,
 								approvalStepId: step.id,
 								approvalIdentity,
+								supersededResumeStateKeys: collectSupersededWorkflowResumeStateKeys(
+									consumedResumeStateKey,
+									resumeState,
+								),
 								createdAt: new Date().toISOString(),
 							},
 							ctx.signal,
@@ -1593,12 +1619,18 @@ export async function runWorkflowFile({
 
 						const approvalId = await createApprovalIndex({ env: ctx.env, stateKey });
 						ctx.signal?.throwIfAborted();
-						await replaceWorkflowResumeState({
+						const replaced = await replaceWorkflowResumeState({
 							env: ctx.env,
 							previousStateKey: consumedResumeStateKey,
+							expectedPreviousState: resumeState,
+							previousStateConsumed: resumeStateConsumed,
 							replacementStateKey: stateKey,
 							signal: ctx.signal,
 						});
+						if (!replaced) {
+							resumeStateClaimRejected = true;
+							throw new Error("Workflow resume state not found");
+						}
 
 						const resumeToken = encodeToken({
 							protocolVersion: 1,
@@ -1658,6 +1690,10 @@ export async function runWorkflowFile({
 					signal: ctx.signal,
 				});
 				ctx.signal?.throwIfAborted();
+				await cleanupSupersededWorkflowResumeStates(
+					ctx.env,
+					resumeState?.supersededResumeStateKeys,
+				);
 			} catch (err) {
 				if (!resumeStateConsumed) {
 					await restoreWorkflowResumeState({
@@ -2031,23 +2067,54 @@ async function saveWorkflowResumeState(
 async function replaceWorkflowResumeState({
 	env,
 	previousStateKey,
+	expectedPreviousState,
+	previousStateConsumed,
 	replacementStateKey,
 	signal,
 }: {
 	env: Record<string, string | undefined>;
 	previousStateKey: string | null;
+	expectedPreviousState: WorkflowResumeState | WorkflowResumePayload | null;
+	previousStateConsumed: boolean;
 	replacementStateKey: string;
 	signal?: AbortSignal;
 }) {
-	if (previousStateKey && previousStateKey !== replacementStateKey) {
-		await deleteStateJson({ env, key: previousStateKey, signal });
+	if (!previousStateKey || previousStateKey === replacementStateKey) {
+		signal?.throwIfAborted();
+		return true;
 	}
-	signal?.throwIfAborted();
-	if (previousStateKey && previousStateKey !== replacementStateKey) {
-		// The replacement is committed once its predecessor has been removed.
-		// Do not add another cancellation checkpoint after retiring its old
-		// approval capability: the outer rollback path must be able to restore it.
+	if (previousStateConsumed) {
+		signal?.throwIfAborted();
+		return true;
+	}
+	if (!expectedPreviousState) return false;
+
+	let claimId: string | undefined;
+	try {
+		const consumption = await consumeResumeState({
+			env,
+			key: previousStateKey,
+			expectedState: expectedPreviousState,
+			signal,
+		});
+		if (!consumption.consumed) return false;
+		claimId = consumption.claimId;
+		// Keep the consumed marker until terminal cleanup. It is the atomic
+		// predecessor-to-successor handoff and prevents another resume from
+		// creating a competing successor after this call returns.
+		signal?.throwIfAborted();
 		await cleanupApprovalIndexByStateKey({ env, stateKey: previousStateKey }).catch(() => {});
+		return true;
+	} catch (err) {
+		if (claimId && signal?.aborted) {
+			await restoreConsumedResumeState({
+				env,
+				key: previousStateKey,
+				expectedState: expectedPreviousState,
+				claimId,
+			}).catch(() => {});
+		}
+		throw err;
 	}
 }
 
@@ -2063,6 +2130,31 @@ async function restoreWorkflowResumeState({
 	if (!stateKey || !state) return;
 	if ((await readStateJson({ env, key: stateKey })) !== null) return;
 	await writeStateJson({ env, key: stateKey, value: state });
+}
+
+function collectSupersededWorkflowResumeStateKeys(
+	previousStateKey: string | null,
+	previousState: WorkflowResumeState | WorkflowResumePayload | null,
+) {
+	return [
+		...(previousState?.supersededResumeStateKeys ?? []),
+		...(previousStateKey ? [previousStateKey] : []),
+	].filter((stateKey, index, all) => stateKey && all.indexOf(stateKey) === index);
+}
+
+async function cleanupSupersededWorkflowResumeStates(
+	env: Record<string, string | undefined>,
+	stateKeys: string[] | undefined,
+) {
+	for (const stateKey of stateKeys ?? []) {
+		try {
+			if (isConsumedResumeState(await readStateJson({ env, key: stateKey }))) {
+				await deleteStateJson({ env, key: stateKey });
+			}
+		} catch {
+			// The completed successor makes retained ancestor markers safe.
+		}
+	}
 }
 
 async function discardWorkflowResumeState(
@@ -2126,6 +2218,13 @@ async function loadWorkflowResumeState(env: Record<string, string | undefined>, 
 	if (!data.steps || typeof data.steps !== "object")
 		throw new Error("Invalid workflow resume state");
 	if (!data.args || typeof data.args !== "object") throw new Error("Invalid workflow resume state");
+	if (
+		data.supersededResumeStateKeys !== undefined &&
+		(!Array.isArray(data.supersededResumeStateKeys) ||
+			data.supersededResumeStateKeys.some((stateKey) => typeof stateKey !== "string"))
+	) {
+		throw new Error("Invalid workflow resume state");
+	}
 	if (
 		data.inputKind !== undefined &&
 		!["workflow_step", "pipeline_command"].includes(data.inputKind)

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1228,9 +1228,10 @@ export async function runWorkflowFile({
 								})
 							: null;
 
+						const branchPromises = parallel.branches.map((branch) => runBranch(branch));
+						const branchesSettled = Promise.allSettled(branchPromises);
 						try {
 							if (wait === "any") {
-								const branchPromises = parallel.branches.map((branch) => runBranch(branch));
 								const winner = (await (timeoutPromise
 									? Promise.race([...branchPromises, timeoutPromise])
 									: Promise.race(branchPromises))) as {
@@ -1238,12 +1239,10 @@ export async function runWorkflowFile({
 									result: WorkflowStepResult;
 								};
 								parallelBranchResults = { [winner.branchId]: winner.result };
-								branchAbortController.abort();
 							} else {
-								const branchPromises = parallel.branches.map((branch) => runBranch(branch));
 								const settled = (await (timeoutPromise
 									? Promise.race([Promise.allSettled(branchPromises), timeoutPromise])
-									: Promise.allSettled(branchPromises))) as PromiseSettledResult<{
+									: branchesSettled)) as PromiseSettledResult<{
 									branchId: string;
 									result: WorkflowStepResult;
 								}>[];
@@ -1260,6 +1259,8 @@ export async function runWorkflowFile({
 							}
 						} finally {
 							if (parallelTimeoutId !== undefined) clearTimeout(parallelTimeoutId);
+							if (wait === "any" || parallelSignal.aborted) branchAbortController.abort();
+							await branchesSettled;
 						}
 
 						const merged: Record<string, unknown> = {};
@@ -1610,7 +1611,11 @@ export async function runWorkflowFile({
 		if (consumedResumeStateKey) {
 			try {
 				ctx.signal?.throwIfAborted();
-				await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+				await deleteStateJson({
+					env: ctx.env,
+					key: consumedResumeStateKey,
+					signal: ctx.signal,
+				});
 				ctx.signal?.throwIfAborted();
 			} catch (err) {
 				await restoreWorkflowResumeState({
@@ -1976,7 +1981,7 @@ async function replaceWorkflowResumeState({
 	signal?: AbortSignal;
 }) {
 	if (previousStateKey && previousStateKey !== replacementStateKey) {
-		await deleteStateJson({ env, key: previousStateKey });
+		await deleteStateJson({ env, key: previousStateKey, signal });
 	}
 	signal?.throwIfAborted();
 	if (previousStateKey && previousStateKey !== replacementStateKey) {
@@ -1997,6 +2002,7 @@ async function restoreWorkflowResumeState({
 	state: WorkflowResumeState | WorkflowResumePayload | null;
 }) {
 	if (!stateKey || !state) return;
+	if ((await readStateJson({ env, key: stateKey })) !== null) return;
 	await writeStateJson({ env, key: stateKey, value: state });
 }
 

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -851,7 +851,11 @@ export async function runWorkflowFile({
 					pipelineInput: resumeState.pipelineInput!,
 					onConsumed: consumedResumeStateKey
 						? async () => {
-								await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+								await deleteStateJson({
+									env: ctx.env,
+									key: consumedResumeStateKey,
+									signal: ctx.signal,
+								});
 							}
 						: undefined,
 				};
@@ -1358,7 +1362,6 @@ export async function runWorkflowFile({
 								`Workflow step ${step.id} requires a command registry for pipeline execution`,
 							);
 						}
-						markExecutionStarted(stepSignal);
 						const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
 						const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
 						result = await runPipelineStep({
@@ -1376,6 +1379,7 @@ export async function runWorkflowFile({
 											onConsumed: resumedPipelineInput.onConsumed,
 										}
 									: undefined,
+							onExecutionStart: () => markExecutionStarted(stepSignal),
 						});
 					} else {
 						if (execution.kind !== "none") markExecutionStarted(stepSignal);
@@ -1634,7 +1638,13 @@ export async function runWorkflowFile({
 		}
 		return runResult;
 	} catch (err) {
-		if (resumedExecutionInterrupted && resumedExecutionStarted && consumedResumeStateKey) {
+		if (ctx.signal?.aborted && !resumedExecutionStarted && consumedResumeStateKey) {
+			await restoreWorkflowResumeState({
+				env: ctx.env,
+				stateKey: consumedResumeStateKey,
+				state: resumeState,
+			});
+		} else if (resumedExecutionInterrupted && resumedExecutionStarted && consumedResumeStateKey) {
 			await cleanupApprovalIndexByStateKey({
 				env: ctx.env,
 				stateKey: consumedResumeStateKey,
@@ -3022,6 +3032,7 @@ async function runPipelineStep({
 	cwd,
 	resume,
 	requestInputEnabled = true,
+	onExecutionStart,
 }: {
 	stepId: string;
 	pipelineText: string;
@@ -3035,6 +3046,7 @@ async function runPipelineStep({
 		onConsumed?: () => Promise<void>;
 	};
 	requestInputEnabled?: boolean;
+	onExecutionStart?: () => void;
 }) {
 	let pipeline;
 	try {
@@ -3084,6 +3096,7 @@ async function runPipelineStep({
 					onConsumed: resume.onConsumed,
 				}
 			: undefined,
+		onExecutionStart,
 	});
 	stdout.end();
 	ctx.signal?.throwIfAborted();

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -171,7 +171,6 @@ type RunContext = {
 	llmAdapters?: Record<string, any>;
 	dryRun?: boolean;
 	_activeWorkflows?: Set<string>;
-	_onExecutionStart?: () => void;
 	_onResumeStateResolved?: (stateKey: string) => void;
 };
 
@@ -710,6 +709,10 @@ export async function runWorkflowFile({
 	const resumeState = resume?.stateKey
 		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey)
 		: (resume ?? null);
+	let resumedExecutionStarted = false;
+	const markExecutionStarted = () => {
+		if (consumedResumeStateKey) resumedExecutionStarted = true;
+	};
 	if (resumeState?.approvalStepId && resumeState?.inputStepId) {
 		throw new Error("Invalid workflow resume state");
 	}
@@ -1014,7 +1017,7 @@ export async function runWorkflowFile({
 
 						let subResult: WorkflowStepResult;
 						if (subExecution.kind === "shell") {
-							ctx._onExecutionStart?.();
+							markExecutionStarted();
 							const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
 							const { stdout } = await runShellCommand({
@@ -1031,7 +1034,7 @@ export async function runWorkflowFile({
 									`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
 								);
 							}
-							ctx._onExecutionStart?.();
+							markExecutionStarted();
 							const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
 							subResult = await runPipelineStep({
@@ -1091,7 +1094,7 @@ export async function runWorkflowFile({
 			}> => {
 				ctx.signal?.throwIfAborted();
 				if (execution.kind !== "none" && execution.kind !== "workflow") {
-					ctx._onExecutionStart?.();
+					markExecutionStarted();
 				}
 				// Combine external cancellation and optional per-step timeout into one signal.
 				let stepSignal: AbortSignal | undefined = ctx.signal;
@@ -1265,7 +1268,7 @@ export async function runWorkflowFile({
 						childActive.add(canonicalWorkflowPath);
 						const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
 						ctx.signal?.throwIfAborted();
-						ctx._onExecutionStart?.();
+						markExecutionStarted();
 						const subResult = await runWorkflowFile({
 							filePath: resolvedWorkflowPath,
 							args: subArgs,
@@ -1580,6 +1583,15 @@ export async function runWorkflowFile({
 			runResult._meta = { cost: costTracker.getSummary() };
 		}
 		return runResult;
+	} catch (err) {
+		if (ctx.signal?.aborted && resumedExecutionStarted && consumedResumeStateKey) {
+			await cleanupApprovalIndexByStateKey({
+				env: ctx.env,
+				stateKey: consumedResumeStateKey,
+			}).catch(() => {});
+			await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey }).catch(() => {});
+		}
+		throw err;
 	} finally {
 		ctx._activeWorkflows?.delete(canonicalFilePath);
 	}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -27,6 +27,7 @@ import {
 	validateCommandInputState,
 	type CommandInputState,
 } from "../input_request.js";
+import { runAbortableProcess } from "../abortable_process.js";
 
 export type WorkflowFile = {
 	name?: string;
@@ -2785,48 +2786,22 @@ async function runShellCommand({
 	killSignal?: NodeJS.Signals;
 }) {
 	signal?.throwIfAborted();
-	const { spawn } = await import("node:child_process");
 	signal?.throwIfAborted();
-
-	return await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-		const shell = resolveInlineShellCommand({ command, env });
-		const child = spawn(shell.command, shell.argv, {
-			env,
-			cwd,
-			signal,
-			killSignal,
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-
-		let stdout = "";
-		let stderr = "";
-
-		child.stdout.setEncoding("utf8");
-		child.stderr.setEncoding("utf8");
-
-		child.stdout.on("data", (d) => {
-			stdout += d;
-		});
-		child.stderr.on("data", (d) => {
-			stderr += d;
-		});
-
-		if (typeof stdin === "string") {
-			child.stdin.setDefaultEncoding("utf8");
-			child.stdin.write(stdin);
-		}
-		child.stdin.end();
-
-		child.on("error", reject);
-		child.on("close", (code) => {
-			if (code === 0) return resolve({ stdout, stderr });
-			reject(
-				new Error(
-					`workflow command failed (${code}): ${stderr.trim() || stdout.trim() || command}`,
-				),
-			);
-		});
+	const shell = resolveInlineShellCommand({ command, env });
+	const { stdout, stderr, code } = await runAbortableProcess({
+		command: shell.command,
+		argv: shell.argv,
+		env,
+		cwd,
+		stdin,
+		signal,
+		killSignal,
+		notFoundMessage: `workflow command not found: ${shell.command}`,
 	});
+	if (code === 0) return { stdout, stderr };
+	throw new Error(
+		`workflow command failed (${code}): ${stderr.trim() || stdout.trim() || command}`,
+	);
 }
 
 function getStepExecution(step: WorkflowStep) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -748,24 +748,7 @@ export async function runWorkflowFile({
 					resumeStateClaimRejected = true;
 					signal?.throwIfAborted();
 				}
-				// A retained index may point to the tombstone after an I/O failure, but
-				// it can never re-enable the now-consumed raw token.
-				try {
-					await cleanupApprovalIndexByStateKey({
-						env: ctx.env,
-						stateKey: consumedResumeStateKey,
-					}).catch(() => {});
-					signal?.throwIfAborted();
-				} catch (err) {
-					resumeStateClaimRejected = true;
-					await restoreConsumedResumeState({
-						env: ctx.env,
-						key: consumedResumeStateKey,
-						expectedState: resumeState,
-						claimId: consumption.claimId,
-					}).catch(() => {});
-					throw err;
-				}
+				signal?.throwIfAborted();
 				resumeStateConsumed = true;
 				resumedExecutionStarted = true;
 			}
@@ -2097,6 +2080,9 @@ async function replaceWorkflowResumeState({
 	}
 	if (previousStateConsumed) {
 		signal?.throwIfAborted();
+		// The successor is already durable. Retire the predecessor's short ID here,
+		// rather than when the preceding unsafe execution is only being claimed.
+		await cleanupApprovalIndexByStateKey({ env, stateKey: previousStateKey }).catch(() => {});
 		return true;
 	}
 	if (!expectedPreviousState) return false;

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -11,8 +11,10 @@ import { runPipeline } from "../runtime.js";
 import { encodeToken, decodeToken } from "../token.js";
 import {
 	cleanupApprovalIndexByStateKey,
+	consumeResumeState,
 	createApprovalIndex,
 	deleteStateJson,
+	isConsumedResumeState,
 	readStateJson,
 	writeStateJson,
 } from "../state/store.js";
@@ -172,7 +174,7 @@ type RunContext = {
 	dryRun?: boolean;
 	_activeWorkflows?: Set<string>;
 	_onResumeStateResolved?: (stateKey: string) => void;
-	_onExecutionStarted?: () => void;
+	_onExecutionStarted?: () => void | Promise<void>;
 	_onExecutionInterrupted?: () => void;
 };
 
@@ -713,22 +715,39 @@ export async function runWorkflowFile({
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
 	let resumedExecutionInterrupted = false;
+	let resumeStateConsumed = false;
 	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
-	const markExecutionStarted = (signal?: AbortSignal) => {
+	let executionStart: Promise<void> | undefined;
+	const markExecutionStarted = async (signal?: AbortSignal) => {
 		if (!consumedResumeStateKey && !ctx._onExecutionStarted && !ctx._onExecutionInterrupted) return;
-		if (consumedResumeStateKey) resumedExecutionStarted = true;
-		ctx._onExecutionStarted?.();
-		if (!signal) return;
-		const onAbort = () => {
-			if (consumedResumeStateKey) resumedExecutionInterrupted = true;
-			ctx._onExecutionInterrupted?.();
-		};
-		if (signal.aborted) {
-			onAbort();
-			return;
-		}
-		signal.addEventListener("abort", onAbort, { once: true });
-		executionSignalListeners.push({ signal, onAbort });
+		if (executionStart) return executionStart;
+		executionStart = (async () => {
+			signal?.throwIfAborted();
+			if (consumedResumeStateKey) {
+				await consumeResumeState({ env: ctx.env, key: consumedResumeStateKey, signal });
+				resumeStateConsumed = true;
+				// A retained index may point to the tombstone after an I/O failure, but
+				// it can never re-enable the now-consumed raw token.
+				await cleanupApprovalIndexByStateKey({
+					env: ctx.env,
+					stateKey: consumedResumeStateKey,
+				}).catch(() => {});
+				resumedExecutionStarted = true;
+			}
+			await ctx._onExecutionStarted?.();
+			if (!signal) return;
+			const onAbort = () => {
+				if (consumedResumeStateKey) resumedExecutionInterrupted = true;
+				ctx._onExecutionInterrupted?.();
+			};
+			if (signal.aborted) {
+				onAbort();
+				return;
+			}
+			signal.addEventListener("abort", onAbort, { once: true });
+			executionSignalListeners.push({ signal, onAbort });
+		})();
+		return executionStart;
 	};
 	if (resumeState?.approvalStepId && resumeState?.inputStepId) {
 		throw new Error("Invalid workflow resume state");
@@ -960,11 +979,13 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (err) {
-						await restoreWorkflowResumeState({
-							env: ctx.env,
-							stateKey: consumedResumeStateKey,
-							state: resumeState,
-						});
+						if (!resumeStateConsumed) {
+							await restoreWorkflowResumeState({
+								env: ctx.env,
+								stateKey: consumedResumeStateKey,
+								state: resumeState,
+							});
+						}
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
@@ -1046,7 +1067,7 @@ export async function runWorkflowFile({
 
 						let subResult: WorkflowStepResult;
 						if (subExecution.kind === "shell") {
-							markExecutionStarted(ctx.signal);
+							await markExecutionStarted(ctx.signal);
 							const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
 							const { stdout } = await runShellCommand({
@@ -1063,7 +1084,7 @@ export async function runWorkflowFile({
 									`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
 								);
 							}
-							markExecutionStarted(ctx.signal);
+							await markExecutionStarted(ctx.signal);
 							const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
 							subResult = await runPipelineStep({
@@ -1151,7 +1172,7 @@ export async function runWorkflowFile({
 							? AbortSignal.any([stepSignal, parallelTimeoutController.signal])
 							: parallelTimeoutController.signal;
 						const branchSignal = AbortSignal.any([parallelSignal, branchAbortController.signal]);
-						markExecutionStarted(parallelSignal);
+						await markExecutionStarted(parallelSignal);
 						const shouldForceKill = Boolean(step.timeout_ms || parallel.timeout_ms);
 						const runBranch = async (
 							branch: ParallelBranch,
@@ -1311,9 +1332,8 @@ export async function runWorkflowFile({
 								cwd,
 								signal: stepSignal,
 								_activeWorkflows: childActive,
-								_onExecutionStarted: () => {
-									resumedExecutionStarted = true;
-									ctx._onExecutionStarted?.();
+								_onExecutionStarted: async () => {
+									await markExecutionStarted(stepSignal);
 								},
 								_onExecutionInterrupted: () => {
 									resumedExecutionInterrupted = true;
@@ -1344,7 +1364,7 @@ export async function runWorkflowFile({
 						const stdout = subResult.output.length ? serializeValueForStdout(json) : "";
 						result = { id: step.id, stdout, json };
 					} else if (execution.kind === "shell") {
-						markExecutionStarted(stepSignal);
+						await markExecutionStarted(stepSignal);
 						const command = resolveTemplate(execution.value, resolvedArgs, results);
 						const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
 						const { stdout } = await runShellCommand({
@@ -1382,7 +1402,7 @@ export async function runWorkflowFile({
 							onExecutionStart: () => markExecutionStarted(stepSignal),
 						});
 					} else {
-						if (execution.kind !== "none") markExecutionStarted(stepSignal);
+						if (execution.kind !== "none") await markExecutionStarted(stepSignal);
 						const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
 						result = createSyntheticStepResult(step.id, inputValue);
 					}
@@ -1473,11 +1493,13 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (stateError) {
-						await restoreWorkflowResumeState({
-							env: ctx.env,
-							stateKey: consumedResumeStateKey,
-							state: resumeState,
-						});
+						if (!resumeStateConsumed) {
+							await restoreWorkflowResumeState({
+								env: ctx.env,
+								stateKey: consumedResumeStateKey,
+								state: resumeState,
+							});
+						}
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw stateError;
 					}
@@ -1582,11 +1604,13 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (err) {
-						await restoreWorkflowResumeState({
-							env: ctx.env,
-							stateKey: consumedResumeStateKey,
-							state: resumeState,
-						});
+						if (!resumeStateConsumed) {
+							await restoreWorkflowResumeState({
+								env: ctx.env,
+								stateKey: consumedResumeStateKey,
+								state: resumeState,
+							});
+						}
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
@@ -1622,11 +1646,13 @@ export async function runWorkflowFile({
 				});
 				ctx.signal?.throwIfAborted();
 			} catch (err) {
-				await restoreWorkflowResumeState({
-					env: ctx.env,
-					stateKey: consumedResumeStateKey,
-					state: resumeState,
-				});
+				if (!resumeStateConsumed) {
+					await restoreWorkflowResumeState({
+						env: ctx.env,
+						stateKey: consumedResumeStateKey,
+						state: resumeState,
+					});
+				}
 				throw err;
 			}
 		} else {
@@ -1638,18 +1664,23 @@ export async function runWorkflowFile({
 		}
 		return runResult;
 	} catch (err) {
-		if (ctx.signal?.aborted && !resumedExecutionStarted && consumedResumeStateKey) {
+		if (!resumedExecutionStarted && !resumeStateConsumed && consumedResumeStateKey) {
 			await restoreWorkflowResumeState({
 				env: ctx.env,
 				stateKey: consumedResumeStateKey,
 				state: resumeState,
 			});
-		} else if (resumedExecutionInterrupted && resumedExecutionStarted && consumedResumeStateKey) {
-			await cleanupApprovalIndexByStateKey({
-				env: ctx.env,
-				stateKey: consumedResumeStateKey,
-			}).catch(() => {});
-			await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey }).catch(() => {});
+		} else if (resumedExecutionStarted && consumedResumeStateKey) {
+			try {
+				await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+				await cleanupApprovalIndexByStateKey({
+					env: ctx.env,
+					stateKey: consumedResumeStateKey,
+				});
+			} catch {
+				// Leave the tombstone in place if cleanup fails: it is the durable
+				// record that prevents the consumed token from replaying an effect.
+			}
 		}
 		throw err;
 	} finally {
@@ -2055,10 +2086,16 @@ async function resolveWorkflowResumeStateKey(
 
 async function loadWorkflowResumeState(env: Record<string, string | undefined>, stateKey: string) {
 	let stored = await readStateJson({ env, key: stateKey });
+	if (isConsumedResumeState(stored)) {
+		throw new Error("Workflow resume state not found");
+	}
 	if ((!stored || typeof stored !== "object") && typeof stateKey === "string") {
 		const altKey = alternateWorkflowResumeStateKey(stateKey);
 		if (altKey) {
 			stored = await readStateJson({ env, key: altKey });
+			if (isConsumedResumeState(stored)) {
+				throw new Error("Workflow resume state not found");
+			}
 		}
 	}
 	if (!stored || typeof stored !== "object") {
@@ -3046,7 +3083,7 @@ async function runPipelineStep({
 		onConsumed?: () => Promise<void>;
 	};
 	requestInputEnabled?: boolean;
-	onExecutionStart?: () => void;
+	onExecutionStart?: () => void | Promise<void>;
 }) {
 	let pipeline;
 	try {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -936,6 +936,7 @@ export async function runWorkflowFile({
 				ctx.stdout.write("Enter JSON response: ");
 				const raw = await readLineFromStream(ctx.stdin, {
 					timeoutMs: parseApprovalTimeoutMs(ctx.env),
+					signal: ctx.signal,
 				});
 				const parsed = parseResponseJson(String(raw ?? "").trim());
 				validateInputResponse({
@@ -1514,6 +1515,7 @@ export async function runWorkflowFile({
 				ctx.stdout.write(`${approval.prompt} [y/N] `);
 				const answer = await readLineFromStream(ctx.stdin, {
 					timeoutMs: parseApprovalTimeoutMs(ctx.env),
+					signal: ctx.signal,
 				});
 				if (!/^y(es)?$/i.test(String(answer).trim())) {
 					throw new Error("Not approved");

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -721,6 +721,7 @@ export async function runWorkflowFile({
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
 	let resumeStateConsumed = false;
+	let executionBoundaryStarted = false;
 	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
 	let executionStart: Promise<void> | undefined;
 	const markExecutionStarted = async (signal?: AbortSignal) => {
@@ -752,6 +753,7 @@ export async function runWorkflowFile({
 				resumedExecutionStarted = true;
 			}
 			await ctx._onExecutionStarted?.();
+			executionBoundaryStarted = true;
 			if (!signal) return;
 			const onAbort = () => {
 				ctx._onExecutionInterrupted?.();
@@ -763,7 +765,15 @@ export async function runWorkflowFile({
 			signal.addEventListener("abort", onAbort, { once: true });
 			executionSignalListeners.push({ signal, onAbort });
 		})();
-		return executionStart;
+		try {
+			await executionStart;
+		} catch (err) {
+			// A per-attempt timeout can abort while this invocation is only waiting
+			// to claim its resume state. Keep the successful boundary memoized, but
+			// let the workflow retry make a fresh claim after that pre-dispatch wait.
+			if (!resumeStateConsumed && !executionBoundaryStarted) executionStart = undefined;
+			throw err;
+		}
 	};
 	if (resumeState?.approvalStepId && resumeState?.inputStepId) {
 		throw new Error("Invalid workflow resume state");

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -171,6 +171,7 @@ type RunContext = {
 	mode: "human" | "tool" | "sdk";
 	cwd?: string;
 	signal?: AbortSignal;
+	forceTerminationSignal?: AbortSignal;
 	registry?: {
 		get: (name: string) => any;
 	};
@@ -181,6 +182,25 @@ type RunContext = {
 	_onExecutionStarted?: () => void | Promise<void>;
 	_onExecutionInterrupted?: () => void;
 };
+
+const PARALLEL_BRANCH_ABORT_SETTLE_TIMEOUT_MS = 500;
+
+async function waitForCancelledParallelBranches(branchesSettled: Promise<unknown>) {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			branchesSettled,
+			new Promise<never>((_resolve, reject) => {
+				timeoutId = setTimeout(
+					() => reject(new Error("Parallel branches did not settle after cancellation")),
+					PARALLEL_BRANCH_ABORT_SETTLE_TIMEOUT_MS,
+				);
+			}),
+		]);
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId);
+	}
+}
 
 export type WorkflowResumePayload = {
 	protocolVersion: 1;
@@ -1097,6 +1117,7 @@ export async function runWorkflowFile({
 								env: subEnv,
 								cwd: subCwd,
 								signal: ctx.signal,
+								forceTerminationSignal: ctx.forceTerminationSignal,
 							});
 							subResult = { id: subStep.id, stdout, json: parseJson(stdout) };
 						} else if (subExecution.kind === "pipeline") {
@@ -1229,6 +1250,7 @@ export async function runWorkflowFile({
 									env: branchEnv,
 									cwd: branchCwd,
 									signal: branchSignal,
+									forceTerminationSignal: ctx.forceTerminationSignal,
 									killSignal: timeoutKillSignal,
 								});
 								return {
@@ -1310,8 +1332,10 @@ export async function runWorkflowFile({
 							}
 						} finally {
 							if (parallelTimeoutId !== undefined) clearTimeout(parallelTimeoutId);
-							if (wait === "any" || parallelSignal.aborted) branchAbortController.abort();
-							await branchesSettled;
+							const branchesCancelled = wait === "any" || parallelSignal.aborted;
+							if (branchesCancelled) branchAbortController.abort();
+							if (branchesCancelled) await waitForCancelledParallelBranches(branchesSettled);
+							else await branchesSettled;
 						}
 
 						const merged: Record<string, unknown> = {};
@@ -1398,6 +1422,7 @@ export async function runWorkflowFile({
 							env,
 							cwd,
 							signal: stepSignal,
+							forceTerminationSignal: ctx.forceTerminationSignal,
 							killSignal: () =>
 								stepTimeoutController?.signal.aborted ? ("SIGKILL" as NodeJS.Signals) : undefined,
 						});
@@ -3103,6 +3128,7 @@ async function runShellCommand({
 	env,
 	cwd,
 	signal,
+	forceTerminationSignal,
 	killSignal,
 }: {
 	command: string;
@@ -3110,6 +3136,7 @@ async function runShellCommand({
 	env: Record<string, string | undefined>;
 	cwd?: string;
 	signal?: AbortSignal;
+	forceTerminationSignal?: AbortSignal;
 	killSignal?: NodeJS.Signals | (() => NodeJS.Signals | undefined);
 }) {
 	signal?.throwIfAborted();
@@ -3122,6 +3149,7 @@ async function runShellCommand({
 		cwd,
 		stdin,
 		signal,
+		forceTerminationSignal,
 		killSignal,
 		notFoundMessage: `workflow command not found: ${shell.command}`,
 	});
@@ -3214,6 +3242,7 @@ async function runPipelineStep({
 		mode: ctx.mode,
 		cwd,
 		signal: ctx.signal,
+		forceTerminationSignal: ctx.forceTerminationSignal,
 		haltAfterStageOnAbort: true,
 		llmAdapters: ctx.llmAdapters,
 		input: resume ? resume.pipelineInput.items : inputValueToPipelineItems(inputValue),

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1090,7 +1090,7 @@ export async function runWorkflowFile({
 				parallelBranchResults: Record<string, WorkflowStepResult> | null;
 			}> => {
 				ctx.signal?.throwIfAborted();
-				if (execution.kind !== "none") {
+				if (execution.kind !== "none" && execution.kind !== "workflow") {
 					ctx._onExecutionStart?.();
 				}
 				// Combine external cancellation and optional per-step timeout into one signal.
@@ -1264,6 +1264,8 @@ export async function runWorkflowFile({
 						const childActive = new Set(activeWorkflows);
 						childActive.add(canonicalWorkflowPath);
 						const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
+						ctx.signal?.throwIfAborted();
+						ctx._onExecutionStart?.();
 						const subResult = await runWorkflowFile({
 							filePath: resolvedWorkflowPath,
 							args: subArgs,

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -14,6 +14,7 @@ import {
 	consumeResumeState,
 	createApprovalIndex,
 	deleteStateJson,
+	deleteUnconsumedResumeState,
 	isConsumedResumeState,
 	readStateJson,
 	restoreConsumedResumeState,
@@ -789,11 +790,12 @@ export async function runWorkflowFile({
 		}
 		if (cancel === true || approved === false) {
 			if (consumedResumeStateKey) {
-				await deleteStateJson({
+				const deletion = await deleteUnconsumedResumeState({
 					env: ctx.env,
 					key: consumedResumeStateKey,
 					signal: ctx.signal,
 				});
+				if (deletion !== "deleted") throw new Error("Workflow resume state not found");
 			}
 			return { status: "cancelled", output: [] };
 		}
@@ -801,11 +803,12 @@ export async function runWorkflowFile({
 
 	if (resumeState?.inputStepId && cancel === true) {
 		if (consumedResumeStateKey) {
-			await deleteStateJson({
+			const deletion = await deleteUnconsumedResumeState({
 				env: ctx.env,
 				key: consumedResumeStateKey,
 				signal: ctx.signal,
 			});
+			if (deletion !== "deleted") throw new Error("Workflow resume state not found");
 		}
 		return { status: "cancelled", output: [] };
 	}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -172,7 +172,8 @@ type RunContext = {
 	dryRun?: boolean;
 	_activeWorkflows?: Set<string>;
 	_onResumeStateResolved?: (stateKey: string) => void;
-	_onExecutionCancelled?: () => void;
+	_onExecutionStarted?: () => void;
+	_onExecutionInterrupted?: () => void;
 };
 
 export type WorkflowResumePayload = {
@@ -711,15 +712,16 @@ export async function runWorkflowFile({
 		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey)
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
-	let resumedExecutionCancelled = false;
+	let resumedExecutionInterrupted = false;
 	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
 	const markExecutionStarted = (signal?: AbortSignal) => {
-		if (!consumedResumeStateKey && !ctx._onExecutionCancelled) return;
+		if (!consumedResumeStateKey && !ctx._onExecutionStarted && !ctx._onExecutionInterrupted) return;
 		if (consumedResumeStateKey) resumedExecutionStarted = true;
+		ctx._onExecutionStarted?.();
 		if (!signal) return;
 		const onAbort = () => {
-			if (consumedResumeStateKey) resumedExecutionCancelled = true;
-			ctx._onExecutionCancelled?.();
+			if (consumedResumeStateKey) resumedExecutionInterrupted = true;
+			ctx._onExecutionInterrupted?.();
 		};
 		if (signal.aborted) {
 			onAbort();
@@ -1287,7 +1289,6 @@ export async function runWorkflowFile({
 						childActive.add(canonicalWorkflowPath);
 						const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
 						stepSignal?.throwIfAborted();
-						markExecutionStarted(stepSignal);
 						const subResult = await runWorkflowFile({
 							filePath: resolvedWorkflowPath,
 							args: subArgs,
@@ -1297,9 +1298,13 @@ export async function runWorkflowFile({
 								cwd,
 								signal: stepSignal,
 								_activeWorkflows: childActive,
-								_onExecutionCancelled: () => {
-									resumedExecutionCancelled = true;
-									ctx._onExecutionCancelled?.();
+								_onExecutionStarted: () => {
+									resumedExecutionStarted = true;
+									ctx._onExecutionStarted?.();
+								},
+								_onExecutionInterrupted: () => {
+									resumedExecutionInterrupted = true;
+									ctx._onExecutionInterrupted?.();
 								},
 							},
 						});
@@ -1390,9 +1395,8 @@ export async function runWorkflowFile({
 										return false;
 									}
 									const message = error?.message ?? String(error);
-									return (
-										!/halted (for approval inside|before completion at) pipeline/.test(message) &&
-										!resumedExecutionCancelled
+									return !/halted (for approval inside|before completion at) pipeline/.test(
+										message,
 									);
 								},
 								onRetry: (attempt, error, delayMs) => {
@@ -1402,9 +1406,6 @@ export async function runWorkflowFile({
 								},
 							})
 						: await executeStepAttempt();
-				if (resumedExecutionCancelled) {
-					throw new Error(`Workflow step '${step.id}' cancelled after execution started`);
-				}
 				result = attemptResult.result;
 				parallelBranchResults = attemptResult.parallelBranchResults;
 			} catch (err: any) {
@@ -1471,7 +1472,7 @@ export async function runWorkflowFile({
 				if (err instanceof RequestInputResumeError) {
 					throw err;
 				}
-				if (ctx.signal?.aborted || resumedExecutionCancelled) {
+				if (ctx.signal?.aborted) {
 					throw err;
 				}
 				if (
@@ -1620,7 +1621,7 @@ export async function runWorkflowFile({
 		}
 		return runResult;
 	} catch (err) {
-		if (resumedExecutionCancelled && resumedExecutionStarted && consumedResumeStateKey) {
+		if (resumedExecutionInterrupted && resumedExecutionStarted && consumedResumeStateKey) {
 			await cleanupApprovalIndexByStateKey({
 				env: ctx.env,
 				stateKey: consumedResumeStateKey,

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -747,7 +747,11 @@ export async function runWorkflowFile({
 		}
 		if (cancel === true || approved === false) {
 			if (consumedResumeStateKey) {
-				await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+				await deleteStateJson({
+					env: ctx.env,
+					key: consumedResumeStateKey,
+					signal: ctx.signal,
+				});
 			}
 			return { status: "cancelled", output: [] };
 		}
@@ -755,7 +759,11 @@ export async function runWorkflowFile({
 
 	if (resumeState?.inputStepId && cancel === true) {
 		if (consumedResumeStateKey) {
-			await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+			await deleteStateJson({
+				env: ctx.env,
+				key: consumedResumeStateKey,
+				signal: ctx.signal,
+			});
 		}
 		return { status: "cancelled", output: [] };
 	}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -718,7 +718,6 @@ export async function runWorkflowFile({
 		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey)
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
-	let resumedExecutionInterrupted = false;
 	let resumeStateConsumed = false;
 	let resumeStateClaimRejected = false;
 	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
@@ -740,28 +739,39 @@ export async function runWorkflowFile({
 					throw new Error("Workflow resume state not found");
 				}
 				if (consumption.signalAbortedAfterCommit) {
-					const restored = await restoreConsumedResumeState({
+					await restoreConsumedResumeState({
 						env: ctx.env,
 						key: consumedResumeStateKey,
 						expectedState: resumeState,
 						claimId: consumption.claimId,
 					});
-					if (!restored) resumeStateClaimRejected = true;
+					resumeStateClaimRejected = true;
 					signal?.throwIfAborted();
 				}
-				resumeStateConsumed = true;
 				// A retained index may point to the tombstone after an I/O failure, but
 				// it can never re-enable the now-consumed raw token.
-				await cleanupApprovalIndexByStateKey({
-					env: ctx.env,
-					stateKey: consumedResumeStateKey,
-				}).catch(() => {});
+				try {
+					await cleanupApprovalIndexByStateKey({
+						env: ctx.env,
+						stateKey: consumedResumeStateKey,
+					}).catch(() => {});
+					signal?.throwIfAborted();
+				} catch (err) {
+					resumeStateClaimRejected = true;
+					await restoreConsumedResumeState({
+						env: ctx.env,
+						key: consumedResumeStateKey,
+						expectedState: resumeState,
+						claimId: consumption.claimId,
+					}).catch(() => {});
+					throw err;
+				}
+				resumeStateConsumed = true;
 				resumedExecutionStarted = true;
 			}
 			await ctx._onExecutionStarted?.();
 			if (!signal) return;
 			const onAbort = () => {
-				if (consumedResumeStateKey) resumedExecutionInterrupted = true;
 				ctx._onExecutionInterrupted?.();
 			};
 			if (signal.aborted) {
@@ -1364,7 +1374,6 @@ export async function runWorkflowFile({
 									await markExecutionStarted(stepSignal);
 								},
 								_onExecutionInterrupted: () => {
-									resumedExecutionInterrupted = true;
 									ctx._onExecutionInterrupted?.();
 								},
 							},

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -172,6 +172,7 @@ type RunContext = {
 	dryRun?: boolean;
 	_activeWorkflows?: Set<string>;
 	_onResumeStateResolved?: (stateKey: string) => void;
+	_onExecutionCancelled?: () => void;
 };
 
 export type WorkflowResumePayload = {
@@ -710,8 +711,22 @@ export async function runWorkflowFile({
 		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey)
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
-	const markExecutionStarted = () => {
+	let resumedExecutionCancelled = false;
+	const executionSignalListeners: Array<{ signal: AbortSignal; onAbort: () => void }> = [];
+	const markExecutionStarted = (signal?: AbortSignal) => {
+		if (!consumedResumeStateKey && !ctx._onExecutionCancelled) return;
 		if (consumedResumeStateKey) resumedExecutionStarted = true;
+		if (!signal) return;
+		const onAbort = () => {
+			if (consumedResumeStateKey) resumedExecutionCancelled = true;
+			ctx._onExecutionCancelled?.();
+		};
+		if (signal.aborted) {
+			onAbort();
+			return;
+		}
+		signal.addEventListener("abort", onAbort, { once: true });
+		executionSignalListeners.push({ signal, onAbort });
 	};
 	if (resumeState?.approvalStepId && resumeState?.inputStepId) {
 		throw new Error("Invalid workflow resume state");
@@ -1017,7 +1032,7 @@ export async function runWorkflowFile({
 
 						let subResult: WorkflowStepResult;
 						if (subExecution.kind === "shell") {
-							markExecutionStarted();
+							markExecutionStarted(ctx.signal);
 							const command = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const stdinValue = resolveShellStdin(subStep.stdin, resolvedArgs, scopedResults);
 							const { stdout } = await runShellCommand({
@@ -1034,7 +1049,7 @@ export async function runWorkflowFile({
 									`Workflow step ${step.id} for_each sub-step ${subStep.id} requires a command registry for pipeline execution`,
 								);
 							}
-							markExecutionStarted();
+							markExecutionStarted(ctx.signal);
 							const pipelineText = resolveTemplate(subExecution.value, resolvedArgs, scopedResults);
 							const inputValue = resolveInputValue(subStep.stdin, resolvedArgs, scopedResults);
 							subResult = await runPipelineStep({
@@ -1093,9 +1108,6 @@ export async function runWorkflowFile({
 				parallelBranchResults: Record<string, WorkflowStepResult> | null;
 			}> => {
 				ctx.signal?.throwIfAborted();
-				if (execution.kind !== "none" && execution.kind !== "workflow") {
-					markExecutionStarted();
-				}
 				// Combine external cancellation and optional per-step timeout into one signal.
 				let stepSignal: AbortSignal | undefined = ctx.signal;
 				let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -1120,9 +1132,12 @@ export async function runWorkflowFile({
 						const parallel = execution.value;
 						const wait = parallel.wait ?? "all";
 						const branchAbortController = new AbortController();
-						const branchSignal = stepSignal
-							? AbortSignal.any([stepSignal, branchAbortController.signal])
-							: branchAbortController.signal;
+						const parallelTimeoutController = new AbortController();
+						const parallelSignal = stepSignal
+							? AbortSignal.any([stepSignal, parallelTimeoutController.signal])
+							: parallelTimeoutController.signal;
+						const branchSignal = AbortSignal.any([parallelSignal, branchAbortController.signal]);
+						markExecutionStarted(parallelSignal);
 						const shouldForceKill = Boolean(step.timeout_ms || parallel.timeout_ms);
 						const runBranch = async (
 							branch: ParallelBranch,
@@ -1189,7 +1204,11 @@ export async function runWorkflowFile({
 						const timeoutPromise = parallel.timeout_ms
 							? new Promise<never>((_resolve, reject) => {
 									parallelTimeoutId = setTimeout(() => {
-										branchAbortController.abort();
+										parallelTimeoutController.abort(
+											new Error(
+												`Parallel step ${step.id} timed out after ${parallel.timeout_ms}ms`,
+											),
+										);
 										reject(
 											new Error(
 												`Parallel step ${step.id} timed out after ${parallel.timeout_ms}ms`,
@@ -1267,12 +1286,22 @@ export async function runWorkflowFile({
 						const childActive = new Set(activeWorkflows);
 						childActive.add(canonicalWorkflowPath);
 						const subArgs = resolveWorkflowStepArgs(step.workflow_args, resolvedArgs, results);
-						ctx.signal?.throwIfAborted();
-						markExecutionStarted();
+						stepSignal?.throwIfAborted();
+						markExecutionStarted(stepSignal);
 						const subResult = await runWorkflowFile({
 							filePath: resolvedWorkflowPath,
 							args: subArgs,
-							ctx: { ...ctx, env, cwd, _activeWorkflows: childActive },
+							ctx: {
+								...ctx,
+								env,
+								cwd,
+								signal: stepSignal,
+								_activeWorkflows: childActive,
+								_onExecutionCancelled: () => {
+									resumedExecutionCancelled = true;
+									ctx._onExecutionCancelled?.();
+								},
+							},
 						});
 						if (subResult.status === "needs_approval" || subResult.status === "needs_input") {
 							const resumeToken =
@@ -1297,6 +1326,7 @@ export async function runWorkflowFile({
 						const stdout = subResult.output.length ? serializeValueForStdout(json) : "";
 						result = { id: step.id, stdout, json };
 					} else if (execution.kind === "shell") {
+						markExecutionStarted(stepSignal);
 						const command = resolveTemplate(execution.value, resolvedArgs, results);
 						const stdinValue = resolveShellStdin(step.stdin, resolvedArgs, results);
 						const { stdout } = await runShellCommand({
@@ -1314,6 +1344,7 @@ export async function runWorkflowFile({
 								`Workflow step ${step.id} requires a command registry for pipeline execution`,
 							);
 						}
+						markExecutionStarted(stepSignal);
 						const pipelineText = resolveTemplate(execution.value, resolvedArgs, results);
 						const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
 						result = await runPipelineStep({
@@ -1333,6 +1364,7 @@ export async function runWorkflowFile({
 									: undefined,
 						});
 					} else {
+						if (execution.kind !== "none") markExecutionStarted(stepSignal);
 						const inputValue = resolveInputValue(step.stdin, resolvedArgs, results);
 						result = createSyntheticStepResult(step.id, inputValue);
 					}
@@ -1358,8 +1390,9 @@ export async function runWorkflowFile({
 										return false;
 									}
 									const message = error?.message ?? String(error);
-									return !/halted (for approval inside|before completion at) pipeline/.test(
-										message,
+									return (
+										!/halted (for approval inside|before completion at) pipeline/.test(message) &&
+										!resumedExecutionCancelled
 									);
 								},
 								onRetry: (attempt, error, delayMs) => {
@@ -1369,6 +1402,9 @@ export async function runWorkflowFile({
 								},
 							})
 						: await executeStepAttempt();
+				if (resumedExecutionCancelled) {
+					throw new Error(`Workflow step '${step.id}' cancelled after execution started`);
+				}
 				result = attemptResult.result;
 				parallelBranchResults = attemptResult.parallelBranchResults;
 			} catch (err: any) {
@@ -1435,7 +1471,7 @@ export async function runWorkflowFile({
 				if (err instanceof RequestInputResumeError) {
 					throw err;
 				}
-				if (ctx.signal?.aborted) {
+				if (ctx.signal?.aborted || resumedExecutionCancelled) {
 					throw err;
 				}
 				if (
@@ -1584,7 +1620,7 @@ export async function runWorkflowFile({
 		}
 		return runResult;
 	} catch (err) {
-		if (ctx.signal?.aborted && resumedExecutionStarted && consumedResumeStateKey) {
+		if (resumedExecutionCancelled && resumedExecutionStarted && consumedResumeStateKey) {
 			await cleanupApprovalIndexByStateKey({
 				env: ctx.env,
 				stateKey: consumedResumeStateKey,
@@ -1593,6 +1629,9 @@ export async function runWorkflowFile({
 		}
 		throw err;
 	} finally {
+		for (const { signal, onAbort } of executionSignalListeners) {
+			signal.removeEventListener("abort", onAbort);
+		}
 		ctx._activeWorkflows?.delete(canonicalFilePath);
 	}
 }

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -18,7 +18,7 @@ import {
 	deleteStateJson,
 	deleteUnconsumedResumeState,
 	isConsumedResumeState,
-	readStateJson,
+	readStateJsonWithLock,
 	restoreConsumedResumeState,
 	writeStateJson,
 } from "../state/store.js";
@@ -713,11 +713,11 @@ export async function runWorkflowFile({
 }): Promise<WorkflowRunResult> {
 	const consumedResumeStateKey =
 		resume?.stateKey && typeof resume.stateKey === "string"
-			? await resolveWorkflowResumeStateKey(ctx.env, resume.stateKey)
+			? await resolveWorkflowResumeStateKey(ctx.env, resume.stateKey, ctx.signal)
 			: null;
 	if (consumedResumeStateKey) ctx._onResumeStateResolved?.(consumedResumeStateKey);
 	const resumeState = resume?.stateKey
-		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey)
+		? await loadWorkflowResumeState(ctx.env, consumedResumeStateKey ?? resume.stateKey, ctx.signal)
 		: (resume ?? null);
 	let resumedExecutionStarted = false;
 	let resumeStateConsumed = false;
@@ -2113,7 +2113,7 @@ async function cleanupSupersededWorkflowResumeStates(
 ) {
 	for (const stateKey of stateKeys ?? []) {
 		try {
-			if (isConsumedResumeState(await readStateJson({ env, key: stateKey }))) {
+			if (isConsumedResumeState(await readStateJsonWithLock({ env, key: stateKey }))) {
 				await deleteStateJson({ env, key: stateKey });
 			}
 		} catch {
@@ -2143,8 +2143,9 @@ export function alternateWorkflowResumeStateKey(stateKey: string): string | null
 async function resolveWorkflowResumeStateKey(
 	env: Record<string, string | undefined>,
 	stateKey: string,
+	signal?: AbortSignal,
 ): Promise<string> {
-	const stored = await readStateJson({ env, key: stateKey });
+	const stored = await readStateJsonWithLock({ env, key: stateKey, signal });
 	if (stored && typeof stored === "object") {
 		return stateKey;
 	}
@@ -2152,22 +2153,26 @@ async function resolveWorkflowResumeStateKey(
 	if (!altKey) {
 		return stateKey;
 	}
-	const altStored = await readStateJson({ env, key: altKey });
+	const altStored = await readStateJsonWithLock({ env, key: altKey, signal });
 	if (altStored && typeof altStored === "object") {
 		return altKey;
 	}
 	return stateKey;
 }
 
-async function loadWorkflowResumeState(env: Record<string, string | undefined>, stateKey: string) {
-	let stored = await readStateJson({ env, key: stateKey });
+async function loadWorkflowResumeState(
+	env: Record<string, string | undefined>,
+	stateKey: string,
+	signal?: AbortSignal,
+) {
+	let stored = await readStateJsonWithLock({ env, key: stateKey, signal });
 	if (isConsumedResumeState(stored)) {
 		throw new Error("Workflow resume state not found");
 	}
 	if ((!stored || typeof stored !== "object") && typeof stateKey === "string") {
 		const altKey = alternateWorkflowResumeStateKey(stateKey);
 		if (altKey) {
-			stored = await readStateJson({ env, key: altKey });
+			stored = await readStateJsonWithLock({ env, key: altKey, signal });
 			if (isConsumedResumeState(stored)) {
 				throw new Error("Workflow resume state not found");
 			}

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -13,6 +13,7 @@ import {
 	cleanupApprovalIndexByStateKey,
 	consumeResumeState,
 	createApprovalIndex,
+	deleteStateJsonWithBoundedResumeCleanup,
 	deleteResumeStateWithRollback,
 	deleteStateJson,
 	deleteUnconsumedResumeState,
@@ -1682,15 +1683,24 @@ export async function runWorkflowFile({
 	} catch (err) {
 		if (resumedExecutionStarted && consumedResumeStateKey) {
 			try {
-				await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-				await cleanupApprovalIndexByStateKey({
-					env: ctx.env,
-					stateKey: consumedResumeStateKey,
-				});
+				if (ctx.signal?.aborted) {
+					await deleteStateJsonWithBoundedResumeCleanup({
+						env: ctx.env,
+						key: consumedResumeStateKey,
+					});
+				} else {
+					await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+				}
 			} catch {
 				// Leave the tombstone in place if cleanup fails: it is the durable
 				// record that prevents the consumed token from replaying an effect.
 			}
+			// A consumed marker remains non-replayable even when its bounded cleanup
+			// times out, so its short approval ID can be retired independently.
+			await cleanupApprovalIndexByStateKey({
+				env: ctx.env,
+				stateKey: consumedResumeStateKey,
+			}).catch(() => {});
 		}
 		throw err;
 	} finally {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -905,10 +905,12 @@ export async function runWorkflowFile({
 							ctx.signal,
 						);
 
-						if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
-							await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-						}
-						ctx.signal?.throwIfAborted();
+						await replaceWorkflowResumeState({
+							env: ctx.env,
+							previousStateKey: consumedResumeStateKey,
+							replacementStateKey: stateKey,
+							signal: ctx.signal,
+						});
 
 						const resumeToken = encodeToken({
 							protocolVersion: 1,
@@ -926,6 +928,11 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (err) {
+						await restoreWorkflowResumeState({
+							env: ctx.env,
+							stateKey: consumedResumeStateKey,
+							state: resumeState,
+						});
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
@@ -1388,10 +1395,12 @@ export async function runWorkflowFile({
 							ctx.signal,
 						);
 
-						if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
-							await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-						}
-						ctx.signal?.throwIfAborted();
+						await replaceWorkflowResumeState({
+							env: ctx.env,
+							previousStateKey: consumedResumeStateKey,
+							replacementStateKey: stateKey,
+							signal: ctx.signal,
+						});
 
 						const resumeToken = encodeToken({
 							protocolVersion: 1,
@@ -1409,6 +1418,11 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (stateError) {
+						await restoreWorkflowResumeState({
+							env: ctx.env,
+							stateKey: consumedResumeStateKey,
+							state: resumeState,
+						});
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw stateError;
 					}
@@ -1489,10 +1503,12 @@ export async function runWorkflowFile({
 
 						const approvalId = await createApprovalIndex({ env: ctx.env, stateKey });
 						ctx.signal?.throwIfAborted();
-						if (consumedResumeStateKey && consumedResumeStateKey !== stateKey) {
-							await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
-						}
-						ctx.signal?.throwIfAborted();
+						await replaceWorkflowResumeState({
+							env: ctx.env,
+							previousStateKey: consumedResumeStateKey,
+							replacementStateKey: stateKey,
+							signal: ctx.signal,
+						});
 
 						const resumeToken = encodeToken({
 							protocolVersion: 1,
@@ -1511,6 +1527,11 @@ export async function runWorkflowFile({
 							},
 						};
 					} catch (err) {
+						await restoreWorkflowResumeState({
+							env: ctx.env,
+							stateKey: consumedResumeStateKey,
+							state: resumeState,
+						});
 						if (stateKey) await discardWorkflowResumeState(ctx.env, stateKey);
 						throw err;
 					}
@@ -1535,10 +1556,22 @@ export async function runWorkflowFile({
 			}
 		}
 
-		ctx.signal?.throwIfAborted();
 		const output = lastStepId ? toOutputItems(results[lastStepId]) : [];
 		if (consumedResumeStateKey) {
-			await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+			try {
+				ctx.signal?.throwIfAborted();
+				await deleteStateJson({ env: ctx.env, key: consumedResumeStateKey });
+				ctx.signal?.throwIfAborted();
+			} catch (err) {
+				await restoreWorkflowResumeState({
+					env: ctx.env,
+					stateKey: consumedResumeStateKey,
+					state: resumeState,
+				});
+				throw err;
+			}
+		} else {
+			ctx.signal?.throwIfAborted();
 		}
 		const runResult: WorkflowRunResult = { status: "ok", output };
 		if (costTracker.hasUsage()) {
@@ -1867,6 +1900,36 @@ async function saveWorkflowResumeState(
 		if (signal?.aborted) await discardWorkflowResumeState(env, stateKey);
 		throw err;
 	}
+}
+
+async function replaceWorkflowResumeState({
+	env,
+	previousStateKey,
+	replacementStateKey,
+	signal,
+}: {
+	env: Record<string, string | undefined>;
+	previousStateKey: string | null;
+	replacementStateKey: string;
+	signal?: AbortSignal;
+}) {
+	if (previousStateKey && previousStateKey !== replacementStateKey) {
+		await deleteStateJson({ env, key: previousStateKey });
+	}
+	signal?.throwIfAborted();
+}
+
+async function restoreWorkflowResumeState({
+	env,
+	stateKey,
+	state,
+}: {
+	env: Record<string, string | undefined>;
+	stateKey: string | null;
+	state: WorkflowResumeState | WorkflowResumePayload | null;
+}) {
+	if (!stateKey || !state) return;
+	await writeStateJson({ env, key: stateKey, value: state });
 }
 
 async function discardWorkflowResumeState(

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1167,18 +1167,19 @@ export async function runWorkflowFile({
 				// Combine external cancellation and optional per-step timeout into one signal.
 				let stepSignal: AbortSignal | undefined = ctx.signal;
 				let timeoutId: ReturnType<typeof setTimeout> | undefined;
+				let stepTimeoutController: AbortController | undefined;
 				if (step.timeout_ms) {
-					const timeoutController = new AbortController();
+					stepTimeoutController = new AbortController();
 					timeoutId = setTimeout(
 						() =>
-							timeoutController.abort(
+							stepTimeoutController!.abort(
 								new Error(`Step '${step.id}' timed out after ${step.timeout_ms}ms`),
 							),
 						step.timeout_ms,
 					);
 					stepSignal = ctx.signal
-						? AbortSignal.any([ctx.signal, timeoutController.signal])
-						: timeoutController.signal;
+						? AbortSignal.any([ctx.signal, stepTimeoutController.signal])
+						: stepTimeoutController.signal;
 				}
 
 				let result: WorkflowStepResult;
@@ -1193,7 +1194,10 @@ export async function runWorkflowFile({
 							? AbortSignal.any([stepSignal, parallelTimeoutController.signal])
 							: parallelTimeoutController.signal;
 						const branchSignal = AbortSignal.any([parallelSignal, branchAbortController.signal]);
-						const shouldForceKill = Boolean(step.timeout_ms || parallel.timeout_ms);
+						const timeoutKillSignal = () =>
+							stepTimeoutController?.signal.aborted || parallelTimeoutController.signal.aborted
+								? ("SIGKILL" as NodeJS.Signals)
+								: undefined;
 						const runBranch = async (
 							branch: ParallelBranch,
 						): Promise<{ branchId: string; result: WorkflowStepResult }> => {
@@ -1225,7 +1229,7 @@ export async function runWorkflowFile({
 									env: branchEnv,
 									cwd: branchCwd,
 									signal: branchSignal,
-									...(shouldForceKill ? { killSignal: "SIGKILL" as NodeJS.Signals } : {}),
+									killSignal: timeoutKillSignal,
 								});
 								return {
 									branchId: branch.id,
@@ -1394,7 +1398,8 @@ export async function runWorkflowFile({
 							env,
 							cwd,
 							signal: stepSignal,
-							...(step.timeout_ms ? { killSignal: "SIGKILL" as NodeJS.Signals } : {}),
+							killSignal: () =>
+								stepTimeoutController?.signal.aborted ? ("SIGKILL" as NodeJS.Signals) : undefined,
 						});
 						result = { id: step.id, stdout, json: parseJson(stdout) };
 					} else if (execution.kind === "pipeline") {
@@ -3105,7 +3110,7 @@ async function runShellCommand({
 	env: Record<string, string | undefined>;
 	cwd?: string;
 	signal?: AbortSignal;
-	killSignal?: NodeJS.Signals;
+	killSignal?: NodeJS.Signals | (() => NodeJS.Signals | undefined);
 }) {
 	signal?.throwIfAborted();
 	signal?.throwIfAborted();

--- a/src/workflows/github_pr_monitor.ts
+++ b/src/workflows/github_pr_monitor.ts
@@ -143,7 +143,12 @@ export async function runGithubPrMonitorWorkflow({ args, ctx }) {
 		throw new Error("gh returned non-JSON output");
 	}
 
-	const { changed, before } = await diffAndStore({ env: ctx.env, key, value: current });
+	const { changed, before } = await diffAndStore({
+		env: ctx.env,
+		key,
+		value: current,
+		signal: ctx.signal,
+	});
 
 	if (changesOnly && !changed) {
 		return {

--- a/src/workflows/github_pr_monitor.ts
+++ b/src/workflows/github_pr_monitor.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 
+const ABORT_FORCE_KILL_AFTER_MS = 250;
+
 function runProcess(command, argv, { env, cwd, signal }) {
 	return new Promise((resolve, reject) => {
 		const child = spawn(command, argv, {
@@ -11,6 +13,9 @@ function runProcess(command, argv, { env, cwd, signal }) {
 
 		let stdout = "";
 		let stderr = "";
+		let abortError;
+		let forceKillTimer;
+		let settled = false;
 
 		child.stdout.setEncoding("utf8");
 		child.stderr.setEncoding("utf8");
@@ -23,14 +28,31 @@ function runProcess(command, argv, { env, cwd, signal }) {
 		});
 
 		child.on("error", (err: any) => {
+			if (err?.name === "AbortError") {
+				abortError = err;
+				forceKillTimer = setTimeout(() => {
+					if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+				}, ABORT_FORCE_KILL_AFTER_MS);
+				forceKillTimer.unref();
+				return;
+			}
 			if (err?.code === "ENOENT") {
+				settled = true;
 				reject(new Error("gh not found on PATH (install GitHub CLI)"));
 				return;
 			}
+			settled = true;
 			reject(err);
 		});
 
 		child.on("close", (code) => {
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+			if (settled) return;
+			settled = true;
+			if (abortError) {
+				reject(abortError);
+				return;
+			}
 			if (code === 0) return resolve({ stdout, stderr });
 			reject(new Error(`gh failed (${code}): ${stderr.trim() || stdout.trim()}`));
 		});

--- a/src/workflows/github_pr_monitor.ts
+++ b/src/workflows/github_pr_monitor.ts
@@ -1,8 +1,13 @@
 import { spawn } from "node:child_process";
 
-function runProcess(command, argv, { env, cwd }) {
+function runProcess(command, argv, { env, cwd, signal }) {
 	return new Promise((resolve, reject) => {
-		const child = spawn(command, argv, { env, cwd, stdio: ["ignore", "pipe", "pipe"] });
+		const child = spawn(command, argv, {
+			env,
+			cwd,
+			signal,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
 
 		let stdout = "";
 		let stderr = "";
@@ -83,6 +88,7 @@ function formatPrChangeMessage({ repo, pr, changedFields, prInfo }) {
 }
 
 export async function runGithubPrMonitorWorkflow({ args, ctx }) {
+	ctx.signal?.throwIfAborted();
 	const repo = args.repo;
 	const pr = args.pr;
 	if (!repo || !pr) throw new Error("github.pr.monitor requires args.repo and args.pr");
@@ -101,7 +107,12 @@ export async function runGithubPrMonitorWorkflow({ args, ctx }) {
 		"number,title,url,state,isDraft,mergeable,reviewDecision,author,baseRefName,headRefName,updatedAt",
 	];
 
-	const { stdout } = (await runProcess("gh", argv, { env: ctx.env, cwd: process.cwd() })) as any;
+	const { stdout } = (await runProcess("gh", argv, {
+		env: ctx.env,
+		cwd: process.cwd(),
+		signal: ctx.signal,
+	})) as any;
+	ctx.signal?.throwIfAborted();
 
 	let current;
 	try {

--- a/src/workflows/github_pr_monitor.ts
+++ b/src/workflows/github_pr_monitor.ts
@@ -1,12 +1,13 @@
 import { runAbortableProcess } from "../abortable_process.js";
 
-async function runProcess(command, argv, { env, cwd, signal }) {
+async function runProcess(command, argv, { env, cwd, signal, forceTerminationSignal }) {
 	const { stdout, stderr, code } = await runAbortableProcess({
 		command,
 		argv,
 		env,
 		cwd,
 		signal,
+		forceTerminationSignal,
 		notFoundMessage: "gh not found on PATH (install GitHub CLI)",
 	});
 	if (code === 0) return { stdout, stderr };
@@ -87,6 +88,7 @@ export async function runGithubPrMonitorWorkflow({ args, ctx }) {
 		env: ctx.env,
 		cwd: process.cwd(),
 		signal: ctx.signal,
+		forceTerminationSignal: ctx.forceTerminationSignal,
 	})) as any;
 	ctx.signal?.throwIfAborted();
 

--- a/src/workflows/github_pr_monitor.ts
+++ b/src/workflows/github_pr_monitor.ts
@@ -1,62 +1,16 @@
-import { spawn } from "node:child_process";
+import { runAbortableProcess } from "../abortable_process.js";
 
-const ABORT_FORCE_KILL_AFTER_MS = 250;
-
-function runProcess(command, argv, { env, cwd, signal }) {
-	return new Promise((resolve, reject) => {
-		const child = spawn(command, argv, {
-			env,
-			cwd,
-			signal,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-
-		let stdout = "";
-		let stderr = "";
-		let abortError;
-		let forceKillTimer;
-		let settled = false;
-
-		child.stdout.setEncoding("utf8");
-		child.stderr.setEncoding("utf8");
-
-		child.stdout.on("data", (d) => {
-			stdout += d;
-		});
-		child.stderr.on("data", (d) => {
-			stderr += d;
-		});
-
-		child.on("error", (err: any) => {
-			if (err?.name === "AbortError") {
-				abortError = err;
-				forceKillTimer = setTimeout(() => {
-					if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
-				}, ABORT_FORCE_KILL_AFTER_MS);
-				forceKillTimer.unref();
-				return;
-			}
-			if (err?.code === "ENOENT") {
-				settled = true;
-				reject(new Error("gh not found on PATH (install GitHub CLI)"));
-				return;
-			}
-			settled = true;
-			reject(err);
-		});
-
-		child.on("close", (code) => {
-			if (forceKillTimer) clearTimeout(forceKillTimer);
-			if (settled) return;
-			settled = true;
-			if (abortError) {
-				reject(abortError);
-				return;
-			}
-			if (code === 0) return resolve({ stdout, stderr });
-			reject(new Error(`gh failed (${code}): ${stderr.trim() || stdout.trim()}`));
-		});
+async function runProcess(command, argv, { env, cwd, signal }) {
+	const { stdout, stderr, code } = await runAbortableProcess({
+		command,
+		argv,
+		env,
+		cwd,
+		signal,
+		notFoundMessage: "gh not found on PATH (install GitHub CLI)",
 	});
+	if (code === 0) return { stdout, stderr };
+	throw new Error(`gh failed (${code}): ${stderr.trim() || stdout.trim()}`);
 }
 
 import { diffAndStore } from "../state/store.js";

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { access, chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -340,6 +341,45 @@ test("cancellation while draining terminal lazy output returns cancellation", as
 
 	assertCancellationEnvelope(envelope);
 	assert.equal(outputDrained, true, "terminal output must finish before cancellation is reported");
+});
+
+test("cancellation while draining lazy input prevents a downstream OpenClaw call", async () => {
+	const controller = new AbortController();
+	let requests = 0;
+	const server = createServer((_req, res) => {
+		requests += 1;
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(JSON.stringify({ ok: true, result: { sent: true } }));
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+	try {
+		const address = server.address();
+		if (!address || typeof address === "string") throw new Error("Missing server address");
+		const source = {
+			name: "test.lazy-abort-source",
+			async run() {
+				return {
+					output: (async function* () {
+						yield { value: 1 };
+						controller.abort(new Error("aborted during lazy stage handoff"));
+					})(),
+				};
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), source);
+		const envelope = await runToolRequest({
+			pipeline: `test.lazy-abort-source | openclaw.invoke --url http://127.0.0.1:${address.port} --tool messages --action send`,
+			ctx: { registry, signal: controller.signal },
+		});
+
+		assert.equal(requests, 0, "cancellation must prevent the downstream POST");
+		assertCancellationEnvelope(envelope);
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((err) => (err ? reject(err) : resolve()));
+		});
+	}
 });
 
 test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send", async () => {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -694,6 +694,55 @@ test("workflow resume state is consumed when cancellation uses a custom reason",
 	}
 });
 
+test("workflow on_error cannot swallow cancellation with a custom reason", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-on-error-custom-abort-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCustomAbortSideEffect();
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "effect",
+						pipeline: "test.custom-abort-side-effect",
+						on_error: "continue",
+					},
+					{
+						id: "later",
+						input: {
+							prompt: "This input must not start",
+							responseSchema: { type: "boolean" },
+						},
+					},
+				],
+			}),
+			"utf8",
+		);
+		const controller = new AbortController();
+		const run = runToolRequest({
+			filePath,
+			ctx: { cwd: dir, registry, signal: controller.signal, env },
+		});
+		await sideEffect.started;
+		controller.abort(new Error("shutdown"));
+
+		const envelope = await run;
+
+		assert.equal(envelope.ok, false);
+		assert.match(envelope.error?.message ?? "", /shutdown/);
+		assert.equal(
+			sideEffect.invocations,
+			1,
+			"custom cancellation must stop the workflow before later steps",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("approval resume token remains retryable after a non-abort failure", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-retry-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -462,6 +462,57 @@ test("cancellation observed before terminal drain is reported after output clean
 	assert.equal(outputDrained, true, "terminal output cleanup must complete before cancellation");
 });
 
+test("cancellation during lazy handoff stops yielding items to the downstream stage", async () => {
+	const controller = new AbortController();
+	const delivered: number[] = [];
+	let sourceClosed = false;
+	const source = {
+		name: "test.lazy-item-source",
+		async run() {
+			return {
+				output: (async function* () {
+					try {
+						yield 1;
+						yield 2;
+						yield 3;
+					} finally {
+						sourceClosed = true;
+					}
+				})(),
+			};
+		},
+	};
+	const downstream = {
+		name: "test.per-item-side-effect",
+		async run({ input }: { input: AsyncIterable<unknown> }) {
+			return {
+				output: (async function* () {
+					for await (const item of input) {
+						delivered.push(item as number);
+						if (delivered.length === 1) {
+							controller.abort(new Error("abort after first lazy item"));
+						}
+						yield item;
+					}
+				})(),
+			};
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.lazy-item-source | test.per-item-side-effect",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), source, downstream),
+			signal: controller.signal,
+		},
+	});
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(envelope.error?.message, "abort after first lazy item");
+	assert.deepEqual(delivered, [1], "cancelled handoff must not deliver later items");
+	assert.equal(sourceClosed, true, "cancelling the handoff must close the source iterator");
+});
+
 test("cancellation while draining lazy input prevents a downstream OpenClaw call", async () => {
 	const controller = new AbortController();
 	let requests = 0;

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -343,6 +343,64 @@ test("pre-aborted workflow approval resume remains retryable", async () => {
 	}
 });
 
+test("workflow approval resume remains retryable when cancellation occurs during setup", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-setup-abort-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCountingSideEffect("test.setup-abort-workflow-side-effect");
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{
+						id: "effect",
+						pipeline: "test.setup-abort-workflow-side-effect",
+						when: "$confirm.approved",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, registry, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 1) {
+					controller.abort(new Error("abort during workflow resume setup"));
+				}
+				throwIfAborted();
+			},
+		});
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, registry, signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(sideEffect.invocations, 0);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(sideEffect.invocations, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("cancellation while draining terminal lazy output returns cancellation", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -119,6 +119,55 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 	}
 });
 
+test("cancellation after Gmail search completion stops the next pipeline stage", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-search-handoff-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 3) controller.abort();
+				throwIfAborted();
+			},
+		});
+
+		let downstreamStarted = false;
+		const downstream = {
+			name: "test.side-effect",
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				downstreamStarted = true;
+				for await (const _item of input) {
+					// Drain search output before reporting success.
+				}
+				return { output: streamOf([{ ok: true }]) };
+			},
+		};
+		const envelope = await runToolRequest({
+			pipeline: "gog.gmail.search --query newer_than:1d | test.side-effect",
+			ctx: {
+				registry: withCommand(createDefaultRegistry(), downstream),
+				signal,
+				env: {
+					...process.env,
+					GOG_BIN: mockGog,
+					MOCK_GOG_COMPLETION_DELAY_MS: "0",
+				},
+			},
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(signalChecks, 3);
+		assert.equal(downstreamStarted, false, "cancellation must stop downstream side effects");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("an in-flight gog.gmail.send completes with a definitive result after parent cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-send-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { access, chmod, copyFile, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -70,6 +70,128 @@ function assertCancellationEnvelope(envelope: Awaited<ReturnType<typeof runToolR
 	assert.equal(envelope.error?.type, "runtime_error");
 	assert.match(envelope.error?.message ?? "", /abort/i);
 }
+
+function createCustomAbortSideEffect() {
+	let invocations = 0;
+	let markStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		markStarted = resolve;
+	});
+	return {
+		command: {
+			name: "test.custom-abort-side-effect",
+			async run({ input, ctx }: { input: AsyncIterable<unknown>; ctx: { signal?: AbortSignal } }) {
+				const items = [];
+				for await (const item of input) items.push(item);
+				invocations += 1;
+				if (invocations === 1) {
+					assert.ok(ctx.signal);
+					markStarted();
+					await new Promise<void>((resolve) =>
+						ctx.signal!.addEventListener("abort", () => resolve(), { once: true }),
+					);
+					ctx.signal.throwIfAborted();
+				}
+				return { output: streamOf(items) };
+			},
+		},
+		started,
+		get invocations() {
+			return invocations;
+		},
+	};
+}
+
+test("pre-aborted tool pipeline does not start its first stage", async () => {
+	const controller = new AbortController();
+	controller.abort();
+	let sideEffectStarted = false;
+	const sideEffect = {
+		name: "test.side-effect",
+		async run() {
+			sideEffectStarted = true;
+			return { output: streamOf([{ ok: true }]) };
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.side-effect",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), sideEffect),
+			signal: controller.signal,
+		},
+	});
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(sideEffectStarted, false, "pre-aborted requests must not start side effects");
+});
+
+test("pre-aborted workflow pipeline does not start its first stage", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-pre-abort-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [{ id: "side-effect", pipeline: "test.side-effect" }],
+			}),
+			"utf8",
+		);
+		let sideEffectStarted = false;
+		const sideEffect = {
+			name: "test.side-effect",
+			async run() {
+				sideEffectStarted = true;
+				return { output: streamOf([{ ok: true }]) };
+			},
+		};
+		const controller = new AbortController();
+		controller.abort();
+
+		const envelope = await runToolRequest({
+			filePath,
+			ctx: {
+				cwd: dir,
+				registry: withCommands(createDefaultRegistry(), sideEffect),
+				signal: controller.signal,
+			},
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(sideEffectStarted, false, "pre-aborted workflows must not start side effects");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("cancellation while draining terminal lazy output returns cancellation", async () => {
+	const controller = new AbortController();
+	let outputDrained = false;
+	const terminal = {
+		name: "test.terminal-output",
+		async run() {
+			return {
+				output: (async function* () {
+					yield { before: "abort" };
+					controller.abort();
+					yield { after: "abort" };
+					outputDrained = true;
+				})(),
+			};
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.terminal-output",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), terminal),
+			signal: controller.signal,
+		},
+	});
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(outputDrained, true, "terminal output must finish before cancellation is reported");
+});
 
 test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-search-"));
@@ -294,6 +416,95 @@ test("an in-flight gog.gmail.send completes and halts the pipeline after cancell
 	}
 });
 
+test("workflow pipeline halts after an in-flight send completes under cancellation", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-cancel-send-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const filePath = join(dir, "workflow.lobster");
+		const sendStarted = join(dir, "send-started");
+		const sendTerminated = join(dir, "send-terminated");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "draft",
+						run: "node -e \"process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))\"",
+					},
+					{
+						id: "send",
+						pipeline: "gog.gmail.send | test.nested-side-effect",
+						stdin: "$draft.json",
+					},
+					{ id: "later", pipeline: "test.workflow-side-effect" },
+				],
+			}),
+			"utf8",
+		);
+		let nestedStarted = false;
+		const nestedSideEffect = {
+			name: "test.nested-side-effect",
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				nestedStarted = true;
+				const items = [];
+				for await (const item of input) items.push(item);
+				return { output: streamOf(items) };
+			},
+		};
+		let laterStarted = false;
+		const workflowSideEffect = {
+			name: "test.workflow-side-effect",
+			async run() {
+				laterStarted = true;
+				return { output: streamOf([{ ok: true }]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), nestedSideEffect, workflowSideEffect);
+		const controller = new AbortController();
+		const run = runToolRequest({
+			filePath,
+			ctx: {
+				cwd: dir,
+				registry,
+				signal: controller.signal,
+				env: {
+					...process.env,
+					LOBSTER_STATE_DIR: join(dir, "state"),
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_TERMINATED_FILE: sendTerminated,
+					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+					MOCK_GOG_COMPLETION_DELAY_MS: "100",
+				},
+			},
+		});
+
+		await waitForFile(sendStarted);
+		controller.abort();
+		const immediate = await observeSettlement(run, 50);
+		const envelope = await run;
+
+		assert.equal(
+			immediate.settled,
+			false,
+			"an already-started workflow send must return a definitive result",
+		);
+		assertCancellationEnvelope(envelope);
+		await waitForFile(sendCompleted, 500);
+		assert.equal(nestedStarted, false, "cancellation must stop the next nested pipeline stage");
+		assert.equal(laterStarted, false, "cancellation must stop later workflow steps");
+		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+		assert.equal(await fileExists(sendTerminated), false);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("approval resume token cannot replay a send after downstream cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-cancel-replay-"));
 	try {
@@ -381,6 +592,108 @@ test("approval resume token cannot replay a send after downstream cancellation",
 	}
 });
 
+test("pipeline resume state is consumed when cancellation uses a custom reason", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-custom-abort-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const source = {
+			name: "item",
+			async run() {
+				return { output: streamOf([{ value: 1 }]) };
+			},
+		};
+		const sideEffect = createCustomAbortSideEffect();
+		const registry = withCommands(createDefaultRegistry(), source, sideEffect.command);
+		const first = await runToolRequest({
+			pipeline: "item | approve --prompt Continue? | test.custom-abort-side-effect",
+			ctx: { registry, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { registry, signal: controller.signal, env },
+		});
+		await sideEffect.started;
+		controller.abort(new Error("shutdown"));
+		const aborted = await resumed;
+		assert.equal(aborted.ok, false);
+		assert.match(aborted.error?.message ?? "", /shutdown/);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { registry, env },
+		});
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Pipeline resume state not found/);
+		assert.equal(
+			sideEffect.invocations,
+			1,
+			"a custom abort reason must not leave the side effect replayable",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow resume state is consumed when cancellation uses a custom reason", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-custom-abort-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCustomAbortSideEffect();
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{
+						id: "effect",
+						pipeline: "test.custom-abort-side-effect",
+						when: "$confirm.approved",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, registry, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, registry, signal: controller.signal, env },
+		});
+		await sideEffect.started;
+		controller.abort(new Error("shutdown"));
+		const aborted = await resumed;
+		assert.equal(aborted.ok, false);
+		assert.match(aborted.error?.message ?? "", /shutdown/);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Workflow resume state not found/);
+		assert.equal(
+			sideEffect.invocations,
+			1,
+			"a custom abort reason must not leave the side effect replayable",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("approval resume token remains retryable after a non-abort failure", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-retry-"));
 	try {
@@ -431,6 +744,340 @@ test("approval resume token remains retryable after a non-abort failure", async 
 	}
 });
 
+test("next-stage input resume remains retryable after a non-abort failure", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-input-resume-retry-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		let attempts = 0;
+		const failOnce = {
+			name: "test.fail-once",
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				attempts += 1;
+				if (attempts === 1) throw new Error("retryable failure");
+				const items = [];
+				for await (const item of input) items.push(item);
+				return { output: streamOf(items) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), failOnce);
+		const responseSchema = JSON.stringify({
+			type: "object",
+			properties: { value: { type: "number" } },
+			required: ["value"],
+		});
+		const first = await runToolRequest({
+			pipeline: `ask --emit --prompt Continue? --schema '${responseSchema}' | test.fail-once`,
+			ctx: { registry, env },
+		});
+
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+		const failed = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { value: 1 },
+			ctx: { registry, env },
+		});
+		assert.equal(failed.ok, false);
+		assert.match(failed.error?.message ?? "", /retryable failure/);
+		const retried = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { value: 1 },
+			ctx: { registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.deepEqual(retried.output, [{ value: 1 }]);
+		assert.equal(attempts, 2);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow resume remains retryable after a non-abort failure", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-resume-retry-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		let attempts = 0;
+		const failOnce = {
+			name: "test.fail-once",
+			async run() {
+				attempts += 1;
+				if (attempts === 1) throw new Error("retryable failure");
+				return { output: streamOf([{ ok: true }]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), failOnce);
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{
+						id: "finish",
+						pipeline: "test.fail-once",
+						when: "$confirm.approved",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({
+			filePath,
+			ctx: { cwd: dir, registry, env },
+		});
+
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const failed = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(failed.ok, false);
+		assert.match(failed.error?.message ?? "", /retryable failure/);
+		const retried = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(attempts, 2);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("next-stage input resume cannot replay a send after downstream cancellation", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-input-resume-cancel-replay-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const stateDir = join(dir, "state");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		const searchStarted = join(dir, "search-started");
+		const searchTerminated = join(dir, "search-terminated");
+		const env = {
+			...process.env,
+			LOBSTER_STATE_DIR: stateDir,
+			GOG_BIN: mockGog,
+			MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+			MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+			MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+			MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+			MOCK_GOG_COMPLETION_DELAY_MS: "100",
+		};
+		const responseSchema = JSON.stringify({
+			type: "object",
+			properties: {
+				to: { type: "string" },
+				subject: { type: "string" },
+				body: { type: "string" },
+			},
+			required: ["to", "subject", "body"],
+		});
+		const pipeline = `ask --emit --prompt Draft --schema '${responseSchema}' | gog.gmail.send | gog.gmail.search --query newer_than:1d`;
+		const response = { to: "user@example.com", subject: "Hello", body: "World" };
+		const first = await runToolRequest({ pipeline, ctx: { env } });
+
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response,
+			ctx: { signal: controller.signal, env },
+		});
+		await waitForFile(searchStarted, 3000);
+		controller.abort();
+		const envelope = await resumed;
+
+		assertCancellationEnvelope(envelope);
+		await waitForFile(sendCompleted, 1000);
+		await waitForFile(searchTerminated, 1000);
+		let invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response,
+			ctx: { env: { ...env, MOCK_GOG_COMPLETION_DELAY_MS: "0" } },
+		});
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Pipeline resume state not found/);
+		invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1, "retrying an aborted input token must not resend");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow approval resume cannot replay a send after downstream cancellation", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-approval-cancel-replay-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const filePath = join(dir, "workflow.lobster");
+		const stateDir = join(dir, "state");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		const searchStarted = join(dir, "search-started");
+		const searchTerminated = join(dir, "search-terminated");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "draft",
+						run: "node -e \"process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))\"",
+					},
+					{ id: "confirm", approval: "Send?", stdin: "$draft.json" },
+					{
+						id: "send",
+						pipeline: "gog.gmail.send",
+						stdin: "$draft.json",
+						when: "$confirm.approved",
+					},
+					{
+						id: "search",
+						pipeline: "gog.gmail.search --query newer_than:1d",
+						when: "$confirm.approved",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const env = {
+			...process.env,
+			LOBSTER_STATE_DIR: stateDir,
+			GOG_BIN: mockGog,
+			MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+			MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+			MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+			MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+			MOCK_GOG_COMPLETION_DELAY_MS: "100",
+		};
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		assert.ok(first.requiresApproval.approvalId);
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, signal: controller.signal, env },
+		});
+		await waitForFile(searchStarted, 3000);
+		controller.abort();
+		const envelope = await resumed;
+
+		assertCancellationEnvelope(envelope);
+		await waitForFile(sendCompleted, 1000);
+		await waitForFile(searchTerminated, 1000);
+		let invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+
+		const replayById = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env: { ...env, MOCK_GOG_COMPLETION_DELAY_MS: "0" } },
+		});
+		assert.equal(replayById.ok, false);
+		assert.match(replayById.error?.message ?? "", /not found or expired/);
+		const replayByToken = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, env: { ...env, MOCK_GOG_COMPLETION_DELAY_MS: "0" } },
+		});
+		assert.equal(replayByToken.ok, false);
+		assert.match(replayByToken.error?.message ?? "", /Workflow resume state not found/);
+		invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1, "retrying an aborted workflow approval must not resend");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow input resume cannot replay a send after downstream cancellation", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-input-cancel-replay-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const filePath = join(dir, "workflow.lobster");
+		const stateDir = join(dir, "state");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		const searchStarted = join(dir, "search-started");
+		const searchTerminated = join(dir, "search-terminated");
+		const responseSchema = {
+			type: "object",
+			properties: {
+				to: { type: "string" },
+				subject: { type: "string" },
+				body: { type: "string" },
+			},
+			required: ["to", "subject", "body"],
+		};
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "draft", input: { prompt: "Draft?", responseSchema } },
+					{ id: "send", pipeline: "gog.gmail.send", stdin: "$draft.response" },
+					{
+						id: "search",
+						pipeline: "gog.gmail.search --query newer_than:1d",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const env = {
+			...process.env,
+			LOBSTER_STATE_DIR: stateDir,
+			GOG_BIN: mockGog,
+			MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+			MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+			MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+			MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+			MOCK_GOG_COMPLETION_DELAY_MS: "100",
+		};
+		const response = { to: "user@example.com", subject: "Hello", body: "World" };
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response,
+			ctx: { cwd: dir, signal: controller.signal, env },
+		});
+		await waitForFile(searchStarted, 3000);
+		controller.abort();
+		const envelope = await resumed;
+
+		assertCancellationEnvelope(envelope);
+		await waitForFile(sendCompleted, 1000);
+		await waitForFile(searchTerminated, 1000);
+		let invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response,
+			ctx: { cwd: dir, env: { ...env, MOCK_GOG_COMPLETION_DELAY_MS: "0" } },
+		});
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Workflow resume state not found/);
+		invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1, "retrying an aborted workflow input must not resend");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test(
 	"parent cancellation terminates the default github.pr.monitor subprocess",
 	{ skip: process.platform === "win32" },
@@ -463,7 +1110,7 @@ test(
 				},
 			});
 
-			await waitForFile(started);
+			await waitForFile(started, 5000);
 			const childPid = Number(await readFile(started, "utf8"));
 			controller.abort();
 			const immediate = await observeSettlement(run, 50);

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -8,7 +8,9 @@ import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
 import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
+import { decodeResumeToken } from "../src/resume.js";
 import { keyToPath } from "../src/state/store.js";
+import { encodeToken } from "../src/token.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -430,6 +432,36 @@ test("cancellation while draining terminal lazy output returns cancellation", as
 	assert.equal(outputDrained, true, "terminal output must finish before cancellation is reported");
 });
 
+test("cancellation observed before terminal drain is reported after output cleanup", async () => {
+	const controller = new AbortController();
+	let outputDrained = false;
+	const terminal = {
+		name: "test.pre-drain-abort-output",
+		async run() {
+			controller.abort(new Error("abort before terminal drain"));
+			return {
+				halt: true,
+				output: (async function* () {
+					yield { cleanup: true };
+					outputDrained = true;
+				})(),
+			};
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.pre-drain-abort-output",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), terminal),
+			signal: controller.signal,
+		},
+	});
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(envelope.error?.message, "abort before terminal drain");
+	assert.equal(outputDrained, true, "terminal output cleanup must complete before cancellation");
+});
+
 test("cancellation while draining lazy input prevents a downstream OpenClaw call", async () => {
 	const controller = new AbortController();
 	let requests = 0;
@@ -615,8 +647,7 @@ test("cancellation during eager stage cleanup stops the next tool stage", async 
 	});
 
 	assert.equal(controller.signal.aborted, true);
-	assert.equal(envelope.ok, true);
-	assert.deepEqual(envelope.output, [{ ok: true }]);
+	assertCancellationEnvelope(envelope);
 	assert.equal(downstreamStarted, false, "cleanup cancellation must stop the next stage");
 });
 
@@ -679,8 +710,7 @@ test("an in-flight gog.gmail.send completes and halts the pipeline after cancell
 			false,
 			"an already-started send must not report an ambiguous abort",
 		);
-		assert.equal(envelope.ok, true);
-		assert.deepEqual(envelope.output, [{ ok: true }]);
+		assertCancellationEnvelope(envelope);
 		assert.equal(downstreamStarted, false, "cancellation must stop later pipeline stages");
 		await waitForFile(sendCompleted, 500);
 		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
@@ -965,6 +995,168 @@ test("workflow resume state is consumed when cancellation uses a custom reason",
 			1,
 			"a custom abort reason must not leave the side effect replayable",
 		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("aliased workflow resume state is consumed after cancellation starts execution", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-alias-custom-abort-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCustomAbortSideEffect();
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{
+						id: "effect",
+						pipeline: "test.custom-abort-side-effect",
+						when: "$confirm.approved",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, registry, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		assert.equal(payload.kind, "workflow-file");
+		assert.ok(payload.stateKey?.startsWith("workflow_resume_"));
+		const aliasedStateKey = payload.stateKey.replace("workflow_resume_", "workflow-resume_");
+		const aliasedToken = encodeToken({ ...payload, stateKey: aliasedStateKey });
+
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: aliasedToken,
+			approved: true,
+			ctx: { cwd: dir, registry, signal: controller.signal, env },
+		});
+		await sideEffect.started;
+		controller.abort(new Error("abort aliased workflow resume"));
+		const aborted = await resumed;
+		assertCancellationEnvelope(aborted);
+
+		const replayById = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(replayById.ok, false);
+		assert.match(replayById.error?.message ?? "", /not found or expired/);
+
+		const replayByToken = await resumeToolRequest({
+			token: aliasedToken,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(replayByToken.ok, false);
+		assert.match(replayByToken.error?.message ?? "", /Workflow resume state not found/);
+		assert.equal(sideEffect.invocations, 1, "the canonical workflow state must not be replayable");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("explicit cancellation consumes an aliased workflow resume state", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-alias-explicit-cancel-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [{ id: "confirm", approval: "Continue?" }],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		assert.equal(payload.kind, "workflow-file");
+		assert.ok(payload.stateKey?.startsWith("workflow_resume_"));
+		const aliasedToken = encodeToken({
+			...payload,
+			stateKey: payload.stateKey.replace("workflow_resume_", "workflow-resume_"),
+		});
+		const cancelled = await resumeToolRequest({
+			token: aliasedToken,
+			cancel: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(cancelled.ok, true);
+		assert.equal(cancelled.status, "cancelled");
+
+		const replayById = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(replayById.ok, false);
+		assert.match(replayById.error?.message ?? "", /not found or expired/);
+		const replayByToken = await resumeToolRequest({
+			token: aliasedToken,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(replayByToken.ok, false);
+		assert.match(replayByToken.error?.message ?? "", /Workflow resume state not found/);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("explicit cancellation removes a corrupt workflow state through an aliased token", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-alias-corrupt-cancel-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [{ id: "confirm", approval: "Continue?" }],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		assert.equal(payload.kind, "workflow-file");
+		assert.ok(payload.stateKey?.startsWith("workflow_resume_"));
+		await writeFile(keyToPath(stateDir, payload.stateKey), '{"corrupt"', "utf8");
+		const aliasedToken = encodeToken({
+			...payload,
+			stateKey: payload.stateKey.replace("workflow_resume_", "workflow-resume_"),
+		});
+
+		const cancelled = await resumeToolRequest({
+			token: aliasedToken,
+			cancel: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(cancelled.ok, true);
+		assert.equal(cancelled.status, "cancelled");
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), false);
+		const replayById = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(replayById.ok, false);
+		assert.match(replayById.error?.message ?? "", /not found or expired/);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
-import { runToolRequest } from "../src/core/tool_runtime.js";
+import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -289,6 +289,143 @@ test("an in-flight gog.gmail.send completes and halts the pipeline after cancell
 		assert.equal(invocations.length, 1, "cancellation must prevent the second send from starting");
 		assert.equal(await fileExists(sendTerminated), false);
 		assert.equal(await fileExists(sendCompleted), true);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("approval resume token cannot replay a send after downstream cancellation", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-cancel-replay-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const stateDir = join(dir, "state");
+		const sendStarted = join(dir, "send-started");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		const searchStarted = join(dir, "search-started");
+		const searchTerminated = join(dir, "search-terminated");
+		const defaultRegistry = createDefaultRegistry();
+		const source = {
+			name: "draft",
+			async run() {
+				return {
+					output: streamOf([{ to: "user@example.com", subject: "Hello", body: "World" }]),
+				};
+			},
+		};
+		const registry = withCommands(defaultRegistry, source);
+		const env = {
+			...process.env,
+			LOBSTER_STATE_DIR: stateDir,
+			GOG_BIN: mockGog,
+			MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+			MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+			MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+			MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+			MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+			MOCK_GOG_COMPLETION_DELAY_MS: "100",
+		};
+		const first = await runToolRequest({
+			pipeline:
+				"draft | approve --prompt Send? | gog.gmail.send | gog.gmail.search --query newer_than:1d",
+			ctx: { registry, env },
+		});
+
+		assert.equal(first.ok, true);
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		assert.ok(first.requiresApproval.approvalId);
+
+		const controller = new AbortController();
+		const resumed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { registry, signal: controller.signal, env },
+		});
+		await waitForFile(searchStarted, 3000);
+		controller.abort();
+		const envelope = await resumed;
+
+		assertCancellationEnvelope(envelope);
+		await waitForFile(sendCompleted, 1000);
+		await waitForFile(searchTerminated, 1000);
+		let invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+
+		const replayById = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: {
+				registry,
+				env: { ...env, MOCK_GOG_COMPLETION_DELAY_MS: "0" },
+			},
+		});
+		assert.equal(replayById.ok, false);
+		assert.match(replayById.error?.message ?? "", /not found or expired/);
+
+		const replayByToken = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: {
+				registry,
+				env: { ...env, MOCK_GOG_COMPLETION_DELAY_MS: "0" },
+			},
+		});
+		assert.equal(replayByToken.ok, false);
+		assert.match(replayByToken.error?.message ?? "", /Pipeline resume state not found/);
+		invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1, "retrying an aborted resume token must not resend");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("approval resume token remains retryable after a non-abort failure", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-retry-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		let attempts = 0;
+		const source = {
+			name: "item",
+			async run() {
+				return { output: streamOf([{ value: 1 }]) };
+			},
+		};
+		const failOnce = {
+			name: "test.fail-once",
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				attempts += 1;
+				if (attempts === 1) throw new Error("retryable failure");
+				const items = [];
+				for await (const item of input) items.push(item);
+				return { output: streamOf(items) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), source, failOnce);
+		const first = await runToolRequest({
+			pipeline: "item | approve --prompt Continue? | test.fail-once",
+			ctx: { registry, env },
+		});
+
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const failed = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { registry, env },
+		});
+		assert.equal(failed.ok, false);
+		assert.match(failed.error?.message ?? "", /retryable failure/);
+
+		const retried = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.deepEqual(retried.output, [{ value: 1 }]);
+		assert.equal(attempts, 2);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,13 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { access, chmod, copyFile, mkdtemp, readdir, rm } from "node:fs/promises";
+import { access, chmod, copyFile, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
 import { runToolRequest } from "../src/core/tool_runtime.js";
-import { finalizePipelineToolRun } from "../src/pipeline_resume_state.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -45,6 +44,15 @@ async function observeSettlement<T>(promise: Promise<T>, timeoutMs: number) {
 	]);
 }
 
+function processIsRunning(pid: number) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function withCommand(defaultRegistry: ReturnType<typeof createDefaultRegistry>, command: any) {
 	return {
 		get(name: string) {
@@ -58,23 +66,6 @@ function assertCancellationEnvelope(envelope: Awaited<ReturnType<typeof runToolR
 	assert.equal(envelope.status, undefined);
 	assert.equal(envelope.error?.type, "runtime_error");
 	assert.match(envelope.error?.message ?? "", /abort/i);
-}
-
-function abortOnCheck(controller: AbortController, abortAtCall: number) {
-	let checks = 0;
-	return {
-		get aborted() {
-			return controller.signal.aborted;
-		},
-		get reason() {
-			return controller.signal.reason;
-		},
-		throwIfAborted() {
-			checks += 1;
-			if (checks === abortAtCall) controller.abort();
-			controller.signal.throwIfAborted();
-		},
-	} as AbortSignal;
 }
 
 test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send", async () => {
@@ -100,19 +91,24 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 					MOCK_GOG_SEARCH_COMPLETED_FILE: searchCompleted,
 					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
 					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
 				},
 			},
 		});
 
 		await waitForFile(searchStarted);
+		const childPid = Number(await readFile(searchStarted, "utf8"));
 		const abortedAt = Date.now();
 		controller.abort();
+		const immediate = await observeSettlement(run, 50);
 		const observed = await observeSettlement(run, 500);
 		const envelope = observed.settled ? observed.value : await run;
 
+		assert.equal(immediate.settled, false, "workflow must wait for the child to exit");
 		assert.equal(observed.settled, true, "workflow should settle promptly after parent abort");
 		assertCancellationEnvelope(envelope);
 		await waitForFile(searchTerminated, 500);
+		assert.equal(processIsRunning(childPid), false);
 		assert.equal(await fileExists(searchTerminated), true);
 		assert.equal(await fileExists(searchCompleted), false);
 		assert.equal(await fileExists(sendStarted), false);
@@ -123,7 +119,7 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 	}
 });
 
-test("parent cancellation terminates an in-flight gog.gmail.send", async () => {
+test("an in-flight gog.gmail.send completes with a definitive result after parent cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-send-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -131,13 +127,17 @@ test("parent cancellation terminates an in-flight gog.gmail.send", async () => {
 		const sendStarted = join(dir, "send-started");
 		const sendTerminated = join(dir, "send-terminated");
 		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
 		const controller = new AbortController();
 		const defaultRegistry = createDefaultRegistry();
 		const source = {
 			name: "draft",
 			async run() {
 				return {
-					output: streamOf([{ to: "user@example.com", subject: "Reply", body: "Hello" }]),
+					output: streamOf([
+						{ to: "first@example.com", subject: "First", body: "Hello" },
+						{ to: "second@example.com", subject: "Second", body: "Hello again" },
+					]),
 				};
 			},
 		};
@@ -152,72 +152,32 @@ test("parent cancellation terminates an in-flight gog.gmail.send", async () => {
 					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
 					MOCK_GOG_SEND_TERMINATED_FILE: sendTerminated,
 					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+					MOCK_GOG_COMPLETION_DELAY_MS: "100",
 				},
 			},
 		});
 
 		await waitForFile(sendStarted);
 		controller.abort();
-		const observed = await observeSettlement(run, 500);
-		const envelope = observed.settled ? observed.value : await run;
+		const immediate = await observeSettlement(run, 50);
+		const envelope = await run;
 
-		assert.equal(observed.settled, true, "send should settle promptly after parent abort");
-		assertCancellationEnvelope(envelope);
-		await waitForFile(sendTerminated, 500);
-		assert.equal(await fileExists(sendTerminated), true);
-		assert.equal(await fileExists(sendCompleted), false);
+		assert.equal(
+			immediate.settled,
+			false,
+			"an already-started send must not report an ambiguous abort",
+		);
+		assert.equal(envelope.ok, true);
+		assert.deepEqual(envelope.output, [{ ok: true }]);
+		await waitForFile(sendCompleted, 500);
+		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1, "cancellation must prevent the second send from starting");
+		assert.equal(await fileExists(sendTerminated), false);
+		assert.equal(await fileExists(sendCompleted), true);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
-});
-
-test("an abort between pipeline stages prevents the next stage from starting", async () => {
-	let slowStarted!: () => void;
-	const started = new Promise<void>((resolve) => {
-		slowStarted = resolve;
-	});
-	let sideEffectRan = false;
-	const controller = new AbortController();
-	const commands = new Map([
-		[
-			"slow",
-			{
-				name: "slow",
-				async run() {
-					slowStarted();
-					await new Promise((resolve) => setTimeout(resolve, 100));
-					return { output: streamOf(["ready"]) };
-				},
-			},
-		],
-		[
-			"side-effect",
-			{
-				name: "side-effect",
-				async run({ input }: any) {
-					for await (const _item of input) {
-						// Drain input before the side effect.
-					}
-					sideEffectRan = true;
-					return { output: streamOf([]) };
-				},
-			},
-		],
-	]);
-	const run = runToolRequest({
-		pipeline: "slow | side-effect",
-		ctx: {
-			signal: controller.signal,
-			registry: { get: (name: string) => commands.get(name) },
-		},
-	});
-
-	await started;
-	controller.abort();
-	const envelope = await run;
-
-	assertCancellationEnvelope(envelope);
-	assert.equal(sideEffectRan, false);
 });
 
 test(
@@ -247,18 +207,23 @@ test(
 						MOCK_GH_STARTED_FILE: started,
 						MOCK_GH_TERMINATED_FILE: terminated,
 						MOCK_GH_COMPLETED_FILE: completed,
+						MOCK_GH_TERMINATION_DELAY_MS: "1000",
 					},
 				},
 			});
 
 			await waitForFile(started);
+			const childPid = Number(await readFile(started, "utf8"));
 			controller.abort();
+			const immediate = await observeSettlement(run, 50);
 			const observed = await observeSettlement(run, 500);
 			const envelope = observed.settled ? observed.value : await run;
 
+			assert.equal(immediate.settled, false, "workflow must wait for gh to exit");
 			assert.equal(observed.settled, true, "workflow subprocess should stop after abort");
 			assertCancellationEnvelope(envelope);
 			await waitForFile(terminated, 500);
+			assert.equal(processIsRunning(childPid), false);
 			assert.equal(await fileExists(terminated), true);
 			assert.equal(await fileExists(completed), false);
 		} finally {
@@ -266,125 +231,3 @@ test(
 		}
 	},
 );
-
-test("parent cancellation wins over a terminal input suspension", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-input-"));
-	try {
-		const stateDir = join(dir, "state");
-		let generatorStarted!: () => void;
-		const started = new Promise<void>((resolve) => {
-			generatorStarted = resolve;
-		});
-		const controller = new AbortController();
-		const terminal = {
-			name: "terminal-input",
-			async run({ ctx }: any) {
-				return {
-					output: (async function* () {
-						yield* [];
-						generatorStarted();
-						await new Promise((resolve) => setTimeout(resolve, 100));
-						await ctx.requestInput({
-							prompt: "Continue?",
-							responseSchema: { type: "object" },
-						});
-					})(),
-				};
-			},
-		};
-		const run = runToolRequest({
-			pipeline: "terminal-input",
-			ctx: {
-				signal: controller.signal,
-				registry: { get: (name: string) => (name === terminal.name ? terminal : undefined) },
-				env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
-			},
-		});
-
-		await started;
-		controller.abort();
-		const envelope = await run;
-		const stateEntries = (await fileExists(stateDir))
-			? await readdir(stateDir, { recursive: true })
-			: [];
-
-		assertCancellationEnvelope(envelope);
-		assert.equal(stateEntries.length, 0);
-	} finally {
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("input finalization removes resume state when cancellation wins the write race", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-input-finalize-"));
-	try {
-		const stateDir = join(dir, "state");
-		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
-		const controller = new AbortController();
-
-		await assert.rejects(
-			() =>
-				finalizePipelineToolRun({
-					env,
-					pipeline: [{ name: "ask", args: {}, raw: "ask" }],
-					output: {
-						halted: true,
-						haltedAt: { index: 0 },
-						items: [
-							{
-								type: "input_request",
-								prompt: "Continue?",
-								responseSchema: { type: "object" },
-							},
-						],
-					},
-					signal: abortOnCheck(controller, 2),
-				}),
-			(err: any) => err?.name === "AbortError",
-		);
-
-		const stateEntries = (await fileExists(stateDir))
-			? await readdir(stateDir, { recursive: true })
-			: [];
-		assert.equal(stateEntries.length, 0);
-	} finally {
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("approval finalization removes resume state and index when cancellation wins", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-approval-finalize-"));
-	try {
-		const stateDir = join(dir, "state");
-		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
-		const controller = new AbortController();
-
-		await assert.rejects(
-			() =>
-				finalizePipelineToolRun({
-					env,
-					pipeline: [{ name: "approve", args: {}, raw: "approve" }],
-					output: {
-						halted: true,
-						haltedAt: { index: 0 },
-						items: [
-							{
-								type: "approval_request",
-								prompt: "Approve?",
-								items: [{ id: 1 }],
-							},
-						],
-					},
-					signal: abortOnCheck(controller, 3),
-				}),
-			(err: any) => err?.name === "AbortError",
-		);
-
-		const stateEntries = (await fileExists(stateDir))
-			? await readdir(stateDir, { recursive: true })
-			: [];
-		assert.equal(stateEntries.length, 0);
-	} finally {
-		await rm(dir, { recursive: true, force: true });
-	}
-});

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -102,6 +102,24 @@ function createCustomAbortSideEffect() {
 	};
 }
 
+function createCountingSideEffect(name: string) {
+	let invocations = 0;
+	return {
+		command: {
+			name,
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				invocations += 1;
+				const items = [];
+				for await (const item of input) items.push(item);
+				return { output: streamOf(items.length > 0 ? items : [{ ok: true }]) };
+			},
+		},
+		get invocations() {
+			return invocations;
+		},
+	};
+}
+
 test("pre-aborted tool pipeline does not start its first stage", async () => {
 	const controller = new AbortController();
 	controller.abort();
@@ -159,6 +177,137 @@ test("pre-aborted workflow pipeline does not start its first stage", async () =>
 
 		assertCancellationEnvelope(envelope);
 		assert.equal(sideEffectStarted, false, "pre-aborted workflows must not start side effects");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pre-aborted pipeline approval resume remains retryable", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-approval-resume-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCountingSideEffect("test.pre-abort-approval-side-effect");
+		const source = {
+			name: "test.pre-abort-source",
+			async run() {
+				return { output: streamOf([{ value: 1 }]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), source, sideEffect.command);
+		const first = await runToolRequest({
+			pipeline:
+				"test.pre-abort-source | approve --prompt Continue? | test.pre-abort-approval-side-effect",
+			ctx: { registry, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted approval resume"));
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { registry, signal: controller.signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(sideEffect.invocations, 0);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.deepEqual(retried.output, [{ value: 1 }]);
+		assert.equal(sideEffect.invocations, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pre-aborted pipeline input resume remains retryable", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-input-resume-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCountingSideEffect("test.pre-abort-input-side-effect");
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		const responseSchema = JSON.stringify({
+			type: "object",
+			properties: { value: { type: "number" } },
+			required: ["value"],
+		});
+		const first = await runToolRequest({
+			pipeline: `ask --emit --prompt Continue? --schema '${responseSchema}' | test.pre-abort-input-side-effect`,
+			ctx: { registry, env },
+		});
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted input resume"));
+		const aborted = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { value: 1 },
+			ctx: { registry, signal: controller.signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(sideEffect.invocations, 0);
+
+		const retried = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { value: 1 },
+			ctx: { registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.deepEqual(retried.output, [{ value: 1 }]);
+		assert.equal(sideEffect.invocations, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pre-aborted workflow approval resume remains retryable", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const sideEffect = createCountingSideEffect("test.pre-abort-workflow-side-effect");
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{
+						id: "effect",
+						pipeline: "test.pre-abort-workflow-side-effect",
+						when: "$confirm.approved",
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, registry, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted workflow resume"));
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, registry, signal: controller.signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(sideEffect.invocations, 0);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, registry, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(sideEffect.invocations, 1);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,0 +1,390 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { access, chmod, copyFile, mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createDefaultRegistry } from "../src/commands/registry.js";
+import { runToolRequest } from "../src/core/tool_runtime.js";
+import { finalizePipelineToolRun } from "../src/pipeline_resume_state.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function streamOf(items: unknown[]) {
+	return (async function* () {
+		for (const item of items) yield item;
+	})();
+}
+
+async function fileExists(path: string) {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForFile(path: string, timeoutMs = 2000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await fileExists(path)) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for ${path}`);
+}
+
+async function observeSettlement<T>(promise: Promise<T>, timeoutMs: number) {
+	return Promise.race([
+		promise.then((value) => ({ settled: true as const, value, settledAt: Date.now() })),
+		new Promise<{ settled: false }>((resolve) =>
+			setTimeout(() => resolve({ settled: false }), timeoutMs),
+		),
+	]);
+}
+
+function withCommand(defaultRegistry: ReturnType<typeof createDefaultRegistry>, command: any) {
+	return {
+		get(name: string) {
+			return name === command.name ? command : defaultRegistry.get(name);
+		},
+	};
+}
+
+function assertCancellationEnvelope(envelope: Awaited<ReturnType<typeof runToolRequest>>) {
+	assert.equal(envelope.ok, false);
+	assert.equal(envelope.status, undefined);
+	assert.equal(envelope.error?.type, "runtime_error");
+	assert.match(envelope.error?.message ?? "", /abort/i);
+}
+
+function abortOnCheck(controller: AbortController, abortAtCall: number) {
+	let checks = 0;
+	return {
+		get aborted() {
+			return controller.signal.aborted;
+		},
+		get reason() {
+			return controller.signal.reason;
+		},
+		throwIfAborted() {
+			checks += 1;
+			if (checks === abortAtCall) controller.abort();
+			controller.signal.throwIfAborted();
+		},
+	} as AbortSignal;
+}
+
+test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-search-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const searchStarted = join(dir, "search-started");
+		const searchTerminated = join(dir, "search-terminated");
+		const searchCompleted = join(dir, "search-completed");
+		const sendStarted = join(dir, "send-started");
+		const sendCompleted = join(dir, "send-completed");
+		const controller = new AbortController();
+		const run = runToolRequest({
+			pipeline: "gog.gmail.search --query newer_than:1d | gog.gmail.send",
+			ctx: {
+				signal: controller.signal,
+				env: {
+					...process.env,
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+					MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+					MOCK_GOG_SEARCH_COMPLETED_FILE: searchCompleted,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+				},
+			},
+		});
+
+		await waitForFile(searchStarted);
+		const abortedAt = Date.now();
+		controller.abort();
+		const observed = await observeSettlement(run, 500);
+		const envelope = observed.settled ? observed.value : await run;
+
+		assert.equal(observed.settled, true, "workflow should settle promptly after parent abort");
+		assertCancellationEnvelope(envelope);
+		await waitForFile(searchTerminated, 500);
+		assert.equal(await fileExists(searchTerminated), true);
+		assert.equal(await fileExists(searchCompleted), false);
+		assert.equal(await fileExists(sendStarted), false);
+		assert.equal(await fileExists(sendCompleted), false);
+		if (observed.settled) assert.ok(observed.settledAt - abortedAt < 500);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("parent cancellation terminates an in-flight gog.gmail.send", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-send-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const sendStarted = join(dir, "send-started");
+		const sendTerminated = join(dir, "send-terminated");
+		const sendCompleted = join(dir, "send-completed");
+		const controller = new AbortController();
+		const defaultRegistry = createDefaultRegistry();
+		const source = {
+			name: "draft",
+			async run() {
+				return {
+					output: streamOf([{ to: "user@example.com", subject: "Reply", body: "Hello" }]),
+				};
+			},
+		};
+		const run = runToolRequest({
+			pipeline: "draft | gog.gmail.send",
+			ctx: {
+				registry: withCommand(defaultRegistry, source),
+				signal: controller.signal,
+				env: {
+					...process.env,
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_TERMINATED_FILE: sendTerminated,
+					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+				},
+			},
+		});
+
+		await waitForFile(sendStarted);
+		controller.abort();
+		const observed = await observeSettlement(run, 500);
+		const envelope = observed.settled ? observed.value : await run;
+
+		assert.equal(observed.settled, true, "send should settle promptly after parent abort");
+		assertCancellationEnvelope(envelope);
+		await waitForFile(sendTerminated, 500);
+		assert.equal(await fileExists(sendTerminated), true);
+		assert.equal(await fileExists(sendCompleted), false);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("an abort between pipeline stages prevents the next stage from starting", async () => {
+	let slowStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		slowStarted = resolve;
+	});
+	let sideEffectRan = false;
+	const controller = new AbortController();
+	const commands = new Map([
+		[
+			"slow",
+			{
+				name: "slow",
+				async run() {
+					slowStarted();
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					return { output: streamOf(["ready"]) };
+				},
+			},
+		],
+		[
+			"side-effect",
+			{
+				name: "side-effect",
+				async run({ input }: any) {
+					for await (const _item of input) {
+						// Drain input before the side effect.
+					}
+					sideEffectRan = true;
+					return { output: streamOf([]) };
+				},
+			},
+		],
+	]);
+	const run = runToolRequest({
+		pipeline: "slow | side-effect",
+		ctx: {
+			signal: controller.signal,
+			registry: { get: (name: string) => commands.get(name) },
+		},
+	});
+
+	await started;
+	controller.abort();
+	const envelope = await run;
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(sideEffectRan, false);
+});
+
+test(
+	"parent cancellation terminates the default github.pr.monitor subprocess",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-gh-"));
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGh = join(repoRoot, "test", "fixtures", "mock-gh-cancellation.mjs");
+			const ghBin = join(dir, "gh");
+			const started = join(dir, "gh-started");
+			const terminated = join(dir, "gh-terminated");
+			const completed = join(dir, "gh-completed");
+			await copyFile(mockGh, ghBin);
+			await chmod(ghBin, 0o755);
+			const controller = new AbortController();
+			const run = runToolRequest({
+				pipeline:
+					'workflows.run --name github.pr.monitor --args-json \'{"repo":"openclaw/lobster","pr":1}\'',
+				ctx: {
+					signal: controller.signal,
+					env: {
+						...process.env,
+						PATH: `${dir}:${process.env.PATH ?? ""}`,
+						LOBSTER_STATE_DIR: join(dir, "state"),
+						MOCK_GH_STARTED_FILE: started,
+						MOCK_GH_TERMINATED_FILE: terminated,
+						MOCK_GH_COMPLETED_FILE: completed,
+					},
+				},
+			});
+
+			await waitForFile(started);
+			controller.abort();
+			const observed = await observeSettlement(run, 500);
+			const envelope = observed.settled ? observed.value : await run;
+
+			assert.equal(observed.settled, true, "workflow subprocess should stop after abort");
+			assertCancellationEnvelope(envelope);
+			await waitForFile(terminated, 500);
+			assert.equal(await fileExists(terminated), true);
+			assert.equal(await fileExists(completed), false);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test("parent cancellation wins over a terminal input suspension", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-input-"));
+	try {
+		const stateDir = join(dir, "state");
+		let generatorStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			generatorStarted = resolve;
+		});
+		const controller = new AbortController();
+		const terminal = {
+			name: "terminal-input",
+			async run({ ctx }: any) {
+				return {
+					output: (async function* () {
+						yield* [];
+						generatorStarted();
+						await new Promise((resolve) => setTimeout(resolve, 100));
+						await ctx.requestInput({
+							prompt: "Continue?",
+							responseSchema: { type: "object" },
+						});
+					})(),
+				};
+			},
+		};
+		const run = runToolRequest({
+			pipeline: "terminal-input",
+			ctx: {
+				signal: controller.signal,
+				registry: { get: (name: string) => (name === terminal.name ? terminal : undefined) },
+				env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+			},
+		});
+
+		await started;
+		controller.abort();
+		const envelope = await run;
+		const stateEntries = (await fileExists(stateDir))
+			? await readdir(stateDir, { recursive: true })
+			: [];
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(stateEntries.length, 0);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("input finalization removes resume state when cancellation wins the write race", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-input-finalize-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const controller = new AbortController();
+
+		await assert.rejects(
+			() =>
+				finalizePipelineToolRun({
+					env,
+					pipeline: [{ name: "ask", args: {}, raw: "ask" }],
+					output: {
+						halted: true,
+						haltedAt: { index: 0 },
+						items: [
+							{
+								type: "input_request",
+								prompt: "Continue?",
+								responseSchema: { type: "object" },
+							},
+						],
+					},
+					signal: abortOnCheck(controller, 2),
+				}),
+			(err: any) => err?.name === "AbortError",
+		);
+
+		const stateEntries = (await fileExists(stateDir))
+			? await readdir(stateDir, { recursive: true })
+			: [];
+		assert.equal(stateEntries.length, 0);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("approval finalization removes resume state and index when cancellation wins", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-approval-finalize-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const controller = new AbortController();
+
+		await assert.rejects(
+			() =>
+				finalizePipelineToolRun({
+					env,
+					pipeline: [{ name: "approve", args: {}, raw: "approve" }],
+					output: {
+						halted: true,
+						haltedAt: { index: 0 },
+						items: [
+							{
+								type: "approval_request",
+								prompt: "Approve?",
+								items: [{ id: 1 }],
+							},
+						],
+					},
+					signal: abortOnCheck(controller, 3),
+				}),
+			(err: any) => err?.name === "AbortError",
+		);
+
+		const stateEntries = (await fileExists(stateDir))
+			? await readdir(stateDir, { recursive: true })
+			: [];
+		assert.equal(stateEntries.length, 0);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
-import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
+import { runToolRequest } from "../src/core/tool_runtime.js";
 import { finalizePipelineToolRun } from "../src/pipeline_resume_state.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -384,77 +384,6 @@ test("approval finalization removes resume state and index when cancellation win
 			? await readdir(stateDir, { recursive: true })
 			: [];
 		assert.equal(stateEntries.length, 0);
-	} finally {
-		await rm(dir, { recursive: true, force: true });
-	}
-});
-
-test("external cancellation invalidates a resumed pipeline after side effects may have started", async () => {
-	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-resume-replay-"));
-	try {
-		const stateDir = join(dir, "state");
-		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
-		const controller = new AbortController();
-		const defaultRegistry = createDefaultRegistry();
-		let sideEffectRuns = 0;
-		let sideEffectStarted!: () => void;
-		const started = new Promise<void>((resolve) => {
-			sideEffectStarted = resolve;
-		});
-		const sideEffect = {
-			name: "side-effect",
-			async run({ ctx }: any) {
-				sideEffectRuns += 1;
-				if (sideEffectRuns === 1) {
-					sideEffectStarted();
-					await new Promise<void>((resolve, reject) => {
-						if (ctx.signal?.aborted) {
-							reject(ctx.signal.reason);
-							return;
-						}
-						ctx.signal?.addEventListener("abort", () => reject(ctx.signal.reason), {
-							once: true,
-						});
-					});
-				}
-				return { output: [] };
-			},
-		};
-		const registry = withCommand(defaultRegistry, sideEffect);
-		const first = await runToolRequest({
-			pipeline: "approve | side-effect",
-			ctx: { env, registry },
-		});
-
-		assert.equal(first.status, "needs_approval");
-		assert.ok(first.requiresApproval?.resumeToken);
-		assert.ok(first.requiresApproval?.approvalId);
-
-		const resumed = resumeToolRequest({
-			token: first.requiresApproval.resumeToken,
-			approved: true,
-			ctx: { env, registry, signal: controller.signal },
-		});
-		await started;
-		controller.abort();
-		assertCancellationEnvelope(await resumed);
-
-		const approvalReplay = await resumeToolRequest({
-			approvalId: first.requiresApproval.approvalId,
-			approved: true,
-			ctx: { env, registry },
-		});
-		assert.equal(approvalReplay.ok, false);
-		assert.match(approvalReplay.error?.message ?? "", /not found|expired/i);
-
-		const tokenReplay = await resumeToolRequest({
-			token: first.requiresApproval.resumeToken,
-			approved: true,
-			ctx: { env, registry },
-		});
-		assert.equal(tokenReplay.ok, false);
-		assert.match(tokenReplay.error?.message ?? "", /state not found/i);
-		assert.equal(sideEffectRuns, 1);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
 import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
+import { keyToPath } from "../src/state/store.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -178,6 +179,34 @@ test("pre-aborted workflow pipeline does not start its first stage", async () =>
 
 		assertCancellationEnvelope(envelope);
 		assert.equal(sideEffectStarted, false, "pre-aborted workflows must not start side effects");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pre-aborted workflow shell does not start its process", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-shell-pre-abort-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const started = join(dir, "shell-started");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [{ id: "shell", run: `printf started > ${started}` }],
+			}),
+			"utf8",
+		);
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted workflow shell"));
+
+		const envelope = await runToolRequest({
+			filePath,
+			ctx: { cwd: dir, signal: controller.signal },
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(envelope.error?.message, "pre-aborted workflow shell");
+		assert.equal(await fileExists(started), false, "pre-aborted workflow must not spawn a shell");
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
@@ -1362,6 +1391,60 @@ test(
 			assert.equal(processIsRunning(childPid), false);
 			assert.equal(await fileExists(terminated), true);
 			assert.equal(await fileExists(completed), false);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"cancellation before github.pr.monitor persistence does not advance state",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-gh-state-"));
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGh = join(repoRoot, "test", "fixtures", "mock-gh-cancellation.mjs");
+			const ghBin = join(dir, "gh");
+			const stateDir = join(dir, "state");
+			await copyFile(mockGh, ghBin);
+			await chmod(ghBin, 0o755);
+			const controller = new AbortController();
+			const signal = controller.signal;
+			const throwIfAborted = signal.throwIfAborted.bind(signal);
+			let signalChecks = 0;
+			Object.defineProperty(signal, "throwIfAborted", {
+				value() {
+					signalChecks += 1;
+					if (signalChecks === 4) {
+						controller.abort(new Error("abort before monitor state write"));
+					}
+					throwIfAborted();
+				},
+			});
+			const key = "github.pr:openclaw/lobster#1";
+
+			const envelope = await runToolRequest({
+				pipeline:
+					'workflows.run --name github.pr.monitor --args-json \'{"repo":"openclaw/lobster","pr":1,"changesOnly":true}\'',
+				ctx: {
+					signal,
+					env: {
+						...process.env,
+						PATH: `${dir}:${process.env.PATH ?? ""}`,
+						LOBSTER_STATE_DIR: stateDir,
+						MOCK_GH_COMPLETION_DELAY_MS: "0",
+					},
+				},
+			});
+
+			assertCancellationEnvelope(envelope);
+			assert.equal(signalChecks, 4);
+			assert.equal(
+				await fileExists(keyToPath(stateDir, key)),
+				false,
+				"cancelled monitor must not persist its snapshot",
+			);
 		} finally {
 			await rm(dir, { recursive: true, force: true });
 		}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -53,10 +53,13 @@ function processIsRunning(pid: number) {
 	}
 }
 
-function withCommand(defaultRegistry: ReturnType<typeof createDefaultRegistry>, command: any) {
+function withCommands(
+	defaultRegistry: ReturnType<typeof createDefaultRegistry>,
+	...commands: any[]
+) {
 	return {
 		get(name: string) {
-			return name === command.name ? command : defaultRegistry.get(name);
+			return commands.find((command) => command.name === name) ?? defaultRegistry.get(name);
 		},
 	};
 }
@@ -150,7 +153,7 @@ test("cancellation after Gmail search completion stops the next pipeline stage",
 		const envelope = await runToolRequest({
 			pipeline: "gog.gmail.search --query newer_than:1d | test.side-effect",
 			ctx: {
-				registry: withCommand(createDefaultRegistry(), downstream),
+				registry: withCommands(createDefaultRegistry(), downstream),
 				signal,
 				env: {
 					...process.env,
@@ -168,7 +171,58 @@ test("cancellation after Gmail search completion stops the next pipeline stage",
 	}
 });
 
-test("an in-flight gog.gmail.send completes with a definitive result after parent cancellation", async () => {
+test("cancellation during eager stage cleanup stops the next tool stage", async () => {
+	const controller = new AbortController();
+	const source = {
+		name: "test.source",
+		async run() {
+			return {
+				output: (async function* () {
+					try {
+						yield { source: true };
+						yield { ignored: true };
+					} finally {
+						controller.abort();
+					}
+				})(),
+			};
+		},
+	};
+	const eager = {
+		name: "test.eager",
+		async run({ input }: { input: AsyncIterable<unknown> }) {
+			const iterator = input[Symbol.asyncIterator]();
+			const first = await iterator.next();
+			assert.equal(first.done, false);
+			return { output: [{ ok: true }] };
+		},
+	};
+	let downstreamStarted = false;
+	const downstream = {
+		name: "test.side-effect",
+		async run({ input }: { input: AsyncIterable<unknown> }) {
+			downstreamStarted = true;
+			const items = [];
+			for await (const item of input) items.push(item);
+			return { output: streamOf(items) };
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.source | test.eager | test.side-effect",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), source, eager, downstream),
+			signal: controller.signal,
+		},
+	});
+
+	assert.equal(controller.signal.aborted, true);
+	assert.equal(envelope.ok, true);
+	assert.deepEqual(envelope.output, [{ ok: true }]);
+	assert.equal(downstreamStarted, false, "cleanup cancellation must stop the next stage");
+});
+
+test("an in-flight gog.gmail.send completes and halts the pipeline after cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-send-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -190,10 +244,20 @@ test("an in-flight gog.gmail.send completes with a definitive result after paren
 				};
 			},
 		};
+		let downstreamStarted = false;
+		const downstream = {
+			name: "test.side-effect",
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				downstreamStarted = true;
+				const items = [];
+				for await (const item of input) items.push(item);
+				return { output: streamOf(items) };
+			},
+		};
 		const run = runToolRequest({
-			pipeline: "draft | gog.gmail.send",
+			pipeline: "draft | gog.gmail.send | test.side-effect",
 			ctx: {
-				registry: withCommand(defaultRegistry, source),
+				registry: withCommands(defaultRegistry, source, downstream),
 				signal: controller.signal,
 				env: {
 					...process.env,
@@ -219,6 +283,7 @@ test("an in-flight gog.gmail.send completes with a definitive result after paren
 		);
 		assert.equal(envelope.ok, true);
 		assert.deepEqual(envelope.output, [{ ok: true }]);
+		assert.equal(downstreamStarted, false, "cancellation must stop later pipeline stages");
 		await waitForFile(sendCompleted, 500);
 		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
 		assert.equal(invocations.length, 1, "cancellation must prevent the second send from starting");

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -773,6 +773,84 @@ test("an in-flight gog.gmail.send completes and halts the pipeline after cancell
 	}
 });
 
+test("cancellation after a Gmail send interrupts a blocked next draft read", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-send-input-"));
+	let releaseBlockedRead!: () => void;
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		const controller = new AbortController();
+		let markBlockedReadStarted!: () => void;
+		const blockedReadStarted = new Promise<void>((resolve) => {
+			markBlockedReadStarted = resolve;
+		});
+		const blockedRead = new Promise<IteratorResult<unknown>>((resolve) => {
+			releaseBlockedRead = () => resolve({ done: true, value: undefined });
+		});
+		const source = {
+			name: "draft",
+			async run() {
+				return {
+					output: {
+						[Symbol.asyncIterator]() {
+							let reads = 0;
+							return {
+								async next() {
+									reads += 1;
+									if (reads === 1) {
+										return {
+											done: false,
+											value: {
+												to: "first@example.com",
+												subject: "First",
+												body: "Hello",
+											},
+										};
+									}
+									markBlockedReadStarted();
+									return blockedRead;
+								},
+							};
+						},
+					},
+				};
+			},
+		};
+		const run = runToolRequest({
+			pipeline: "draft | gog.gmail.send",
+			ctx: {
+				registry: withCommands(createDefaultRegistry(), source),
+				signal: controller.signal,
+				env: {
+					...process.env,
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+					MOCK_GOG_COMPLETION_DELAY_MS: "0",
+				},
+			},
+		});
+
+		await waitForFile(sendCompleted);
+		await blockedReadStarted;
+		controller.abort(new Error("abort while waiting for another draft"));
+		const observed = await observeSettlement(run, 100);
+		releaseBlockedRead();
+		const envelope = observed.settled ? observed.value : await run;
+
+		assert.equal(observed.settled, true, "cancellation must interrupt the blocked input read");
+		assertCancellationEnvelope(envelope);
+		assert.equal(envelope.error?.message, "abort while waiting for another draft");
+		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1, "cancellation must not start another send");
+	} finally {
+		releaseBlockedRead?.();
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("workflow pipeline halts after an in-flight send completes under cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-cancel-send-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
-import { runToolRequest } from "../src/core/tool_runtime.js";
+import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
 import { finalizePipelineToolRun } from "../src/pipeline_resume_state.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -384,6 +384,77 @@ test("approval finalization removes resume state and index when cancellation win
 			? await readdir(stateDir, { recursive: true })
 			: [];
 		assert.equal(stateEntries.length, 0);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("external cancellation invalidates a resumed pipeline after side effects may have started", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-resume-replay-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const controller = new AbortController();
+		const defaultRegistry = createDefaultRegistry();
+		let sideEffectRuns = 0;
+		let sideEffectStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			sideEffectStarted = resolve;
+		});
+		const sideEffect = {
+			name: "side-effect",
+			async run({ ctx }: any) {
+				sideEffectRuns += 1;
+				if (sideEffectRuns === 1) {
+					sideEffectStarted();
+					await new Promise<void>((resolve, reject) => {
+						if (ctx.signal?.aborted) {
+							reject(ctx.signal.reason);
+							return;
+						}
+						ctx.signal?.addEventListener("abort", () => reject(ctx.signal.reason), {
+							once: true,
+						});
+					});
+				}
+				return { output: [] };
+			},
+		};
+		const registry = withCommand(defaultRegistry, sideEffect);
+		const first = await runToolRequest({
+			pipeline: "approve | side-effect",
+			ctx: { env, registry },
+		});
+
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const resumed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { env, registry, signal: controller.signal },
+		});
+		await started;
+		controller.abort();
+		assertCancellationEnvelope(await resumed);
+
+		const approvalReplay = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env, registry },
+		});
+		assert.equal(approvalReplay.ok, false);
+		assert.match(approvalReplay.error?.message ?? "", /not found|expired/i);
+
+		const tokenReplay = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { env, registry },
+		});
+		assert.equal(tokenReplay.ok, false);
+		assert.match(tokenReplay.error?.message ?? "", /state not found/i);
+		assert.equal(sideEffectRuns, 1);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -19,6 +19,7 @@ import { PassThrough } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
+import { runAbortableProcess } from "../src/abortable_process.js";
 import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
 import { decodeResumeToken } from "../src/resume.js";
 import { runPipeline } from "../src/runtime.js";
@@ -33,6 +34,19 @@ function streamOf(items: unknown[]) {
 		for (const item of items) yield item;
 	})();
 }
+
+test("runAbortableProcess preserves UTF-8 characters split across pipe chunks", async () => {
+	const result = await runAbortableProcess({
+		command: process.execPath,
+		argv: [
+			"-e",
+			"process.stdout.write(Buffer.from([0xe2])); setTimeout(() => process.stdout.write(Buffer.from([0x82, 0xac])), 20)",
+		],
+		env: process.env,
+		notFoundMessage: "node missing",
+	});
+	assert.equal(result.stdout, "€");
+});
 
 async function fileExists(path: string) {
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -59,6 +59,43 @@ async function waitForFile(path: string, timeoutMs = 2000) {
 	throw new Error(`Timed out waiting for ${path}`);
 }
 
+function startLobsterCli({
+	args,
+	cwd,
+	env,
+}: {
+	args: string[];
+	cwd: string;
+	env: NodeJS.ProcessEnv;
+}) {
+	const repoRoot = join(__dirname, "..", "..");
+	const child = spawn(process.execPath, [join(repoRoot, "bin", "lobster.js"), ...args], {
+		cwd,
+		env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	let stdout = "";
+	let stderr = "";
+	child.stdout?.setEncoding("utf8");
+	child.stdout?.on("data", (chunk) => {
+		stdout += chunk;
+	});
+	child.stderr?.setEncoding("utf8");
+	child.stderr?.on("data", (chunk) => {
+		stderr += chunk;
+	});
+	const result = new Promise<{
+		code: number | null;
+		signal: NodeJS.Signals | null;
+		stdout: string;
+		stderr: string;
+	}>((resolve, reject) => {
+		child.once("error", reject);
+		child.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+	});
+	return { child, result };
+}
+
 async function observeSettlement<T>(promise: Promise<T>, timeoutMs: number) {
 	return Promise.race([
 		promise.then((value) => ({ settled: true as const, value, settledAt: Date.now() })),
@@ -957,6 +994,230 @@ test(
 			);
 		} finally {
 			cli?.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"CLI SIGINT prevents later pipeline stages from writing state",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sigint-pipeline-handoff-"));
+		let cli: ReturnType<typeof startLobsterCli> | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+			const stateDir = join(dir, "state");
+			const sendStarted = join(dir, "send-started");
+			const producer = `printf '${JSON.stringify([
+				{ to: "user@example.com", subject: "Hello", body: "World" },
+			])}'`;
+			const pipeline = `exec --json --shell ${JSON.stringify(producer)} | gog.gmail.send | state.set cli_after_abort`;
+			cli = startLobsterCli({
+				args: [pipeline],
+				cwd: dir,
+				env: {
+					...process.env,
+					LOBSTER_STATE_DIR: stateDir,
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_COMPLETION_DELAY_MS: "100",
+				},
+			});
+			await waitForFile(sendStarted, 5000);
+			assert.equal(cli.child.kill("SIGINT"), true);
+			const exited = await cli.result;
+
+			assert.equal(exited.signal, null);
+			assert.equal(exited.code, 130, "CLI must retain the conventional SIGINT exit status");
+			assert.equal(await fileExists(keyToPath(stateDir, "cli_after_abort")), false);
+		} finally {
+			cli?.child.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"CLI SIGINT consumes a pipeline approval resume after execution starts",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sigint-pipeline-resume-"));
+		let resumed: ReturnType<typeof startLobsterCli> | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+			const stateDir = join(dir, "state");
+			const sendInvocations = join(dir, "send-invocations");
+			const sendCompleted = join(dir, "send-completed");
+			const searchStarted = join(dir, "search-started");
+			const searchTerminated = join(dir, "search-terminated");
+			const producer = `printf '${JSON.stringify([
+				{ to: "user@example.com", subject: "Hello", body: "World" },
+			])}'`;
+			const pipeline = `exec --json --shell ${JSON.stringify(producer)} | approve --prompt Send? | gog.gmail.send | gog.gmail.search --query newer_than:1d`;
+			const env = {
+				...process.env,
+				LOBSTER_STATE_DIR: stateDir,
+				GOG_BIN: mockGog,
+				MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+				MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+				MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+				MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+				MOCK_GOG_COMPLETION_DELAY_MS: "100",
+			};
+			const first = startLobsterCli({ args: ["run", "--mode", "tool", pipeline], cwd: dir, env });
+			const initial = await first.result;
+			assert.equal(initial.code, 0, initial.stderr);
+			const approval = JSON.parse(initial.stdout).requiresApproval;
+			assert.ok(approval?.resumeToken);
+			assert.ok(approval?.approvalId);
+
+			resumed = startLobsterCli({
+				args: ["resume", "--token", approval.resumeToken, "--approve", "yes"],
+				cwd: dir,
+				env,
+			});
+			await waitForFile(searchStarted, 5000);
+			assert.equal(resumed.child.kill("SIGINT"), true);
+			const exited = await resumed.result;
+
+			assert.equal(exited.signal, null);
+			assert.equal(exited.code, 130);
+			await waitForFile(sendCompleted, 1000);
+			await waitForFile(searchTerminated, 1000);
+			assert.equal((await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/).length, 1);
+			assert.equal(
+				(await listStateFiles(stateDir)).some((name) => /^(approval_|pipeline_resume_)/.test(name)),
+				false,
+			);
+
+			const replayById = startLobsterCli({
+				args: ["resume", "--id", approval.approvalId, "--approve", "yes"],
+				cwd: dir,
+				env,
+			});
+			const idReplay = await replayById.result;
+			assert.equal(idReplay.code, 2);
+			assert.match(idReplay.stdout, /not found or expired/);
+			const replayByToken = startLobsterCli({
+				args: ["resume", "--token", approval.resumeToken, "--approve", "yes"],
+				cwd: dir,
+				env,
+			});
+			const tokenReplay = await replayByToken.result;
+			assert.equal(tokenReplay.code, 1);
+			assert.match(tokenReplay.stdout, /Pipeline resume state not found/);
+			assert.equal(
+				(await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/).length,
+				1,
+				"retrying an interrupted CLI resume must not resend",
+			);
+		} finally {
+			resumed?.child.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"CLI SIGINT consumes a workflow approval resume after execution starts",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sigint-workflow-resume-"));
+		let resumed: ReturnType<typeof startLobsterCli> | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+			const workflow = join(dir, "workflow.lobster");
+			const stateDir = join(dir, "state");
+			const sendInvocations = join(dir, "send-invocations");
+			const sendCompleted = join(dir, "send-completed");
+			const searchStarted = join(dir, "search-started");
+			const searchTerminated = join(dir, "search-terminated");
+			const producer = `printf '${JSON.stringify([
+				{ to: "user@example.com", subject: "Hello", body: "World" },
+			])}'`;
+			await writeFile(
+				workflow,
+				JSON.stringify({
+					steps: [
+						{ id: "confirm", approval: "Send?" },
+						{
+							id: "send",
+							pipeline: `exec --json --shell ${JSON.stringify(producer)} | gog.gmail.send | gog.gmail.search --query newer_than:1d`,
+							when: "$confirm.approved",
+						},
+					],
+				}),
+				"utf8",
+			);
+			const env = {
+				...process.env,
+				LOBSTER_STATE_DIR: stateDir,
+				GOG_BIN: mockGog,
+				MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+				MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+				MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+				MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+				MOCK_GOG_COMPLETION_DELAY_MS: "100",
+			};
+			const first = startLobsterCli({
+				args: ["run", "--mode", "tool", "--file", workflow],
+				cwd: dir,
+				env,
+			});
+			const initial = await first.result;
+			assert.equal(initial.code, 0, initial.stderr);
+			const approval = JSON.parse(initial.stdout).requiresApproval;
+			assert.ok(approval?.resumeToken);
+			assert.ok(approval?.approvalId);
+
+			resumed = startLobsterCli({
+				args: ["resume", "--token", approval.resumeToken, "--approve", "yes"],
+				cwd: dir,
+				env,
+			});
+			await waitForFile(searchStarted, 5000);
+			assert.equal(resumed.child.kill("SIGINT"), true);
+			const exited = await resumed.result;
+
+			assert.equal(exited.signal, null);
+			assert.equal(exited.code, 130);
+			await waitForFile(sendCompleted, 1000);
+			await waitForFile(searchTerminated, 1000);
+			assert.equal((await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/).length, 1);
+			assert.equal(
+				(await listStateFiles(stateDir)).some((name) =>
+					/^(approval_|workflow[-_]resume_)/.test(name),
+				),
+				false,
+			);
+
+			const replayById = startLobsterCli({
+				args: ["resume", "--id", approval.approvalId, "--approve", "yes"],
+				cwd: dir,
+				env,
+			});
+			const idReplay = await replayById.result;
+			assert.equal(idReplay.code, 2);
+			assert.match(idReplay.stdout, /not found or expired/);
+			const replayByToken = startLobsterCli({
+				args: ["resume", "--token", approval.resumeToken, "--approve", "yes"],
+				cwd: dir,
+				env,
+			});
+			const tokenReplay = await replayByToken.result;
+			assert.equal(tokenReplay.code, 1);
+			assert.match(tokenReplay.stdout, /Workflow resume state not found/);
+			assert.equal(
+				(await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/).length,
+				1,
+				"retrying an interrupted workflow resume must not resend",
+			);
+		} finally {
+			resumed?.child.kill("SIGKILL");
 			await rm(dir, { recursive: true, force: true });
 		}
 	},

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1599,6 +1599,197 @@ test("terminal workflow approval resume restores its original capability when cl
 	}
 });
 
+test("a cancelled stale pipeline resume cannot restore a capability settled by another resume", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-stale-pipeline-resume-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		let delayedStageEntered!: () => void;
+		const delayedStageReady = new Promise<void>((resolve) => {
+			delayedStageEntered = resolve;
+		});
+		let releaseDelayedStage!: () => void;
+		const delayedStageReleased = new Promise<void>((resolve) => {
+			releaseDelayedStage = resolve;
+		});
+		let runs = 0;
+		let effects = 0;
+		const terminal = {
+			name: "test.stale-safe-terminal",
+			meta: { resumeSafeBeforeInput: true },
+			async run() {
+				runs += 1;
+				if (runs === 1) {
+					delayedStageEntered();
+					await delayedStageReleased;
+				} else {
+					effects += 1;
+				}
+				return { output: [] };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), terminal);
+		const first = await runToolRequest({
+			pipeline: "approve --prompt First? | test.stale-safe-terminal",
+			ctx: { env, registry },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const delayed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { env, registry, signal: controller.signal },
+		});
+		await delayedStageReady;
+
+		const winner = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { env, registry },
+		});
+		assert.equal(winner.status, "ok");
+		assert.equal(effects, 1);
+		assert.equal(await fileExists(statePath), false);
+
+		const originalUnlink = fsp.unlink;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				try {
+					return await originalUnlink(filePath);
+				} finally {
+					if (String(filePath) === statePath && !controller.signal.aborted) {
+						controller.abort(new Error("cancel stale pipeline terminal cleanup"));
+					}
+				}
+			},
+		});
+		let stale;
+		try {
+			releaseDelayedStage();
+			stale = await delayed;
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assert.equal(stale.ok, false);
+		assert.equal(await fileExists(statePath), false);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { env, registry },
+		});
+		assert.equal(replay.ok, false);
+		assert.equal(effects, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("a cancelled stale workflow resume cannot restore a capability settled by another resume", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-stale-workflow-resume-"));
+	try {
+		const stateDir = join(dir, "state");
+		const effectPath = join(dir, "effects.log");
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{
+						id: "effect",
+						run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n')" ${JSON.stringify(effectPath)}`,
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+
+		let delayedPathEntered!: () => void;
+		const delayedPathReady = new Promise<void>((resolve) => {
+			delayedPathEntered = resolve;
+		});
+		let releaseDelayedPath!: () => void;
+		const delayedPathReleased = new Promise<void>((resolve) => {
+			releaseDelayedPath = resolve;
+		});
+		const controller = new AbortController();
+		const originalRealpath = fsp.realpath;
+		let delayedPathPaused = false;
+		Object.defineProperty(fsp, "realpath", {
+			configurable: true,
+			writable: true,
+			async value(...args: Parameters<typeof fsp.realpath>) {
+				if (!delayedPathPaused && String(args[0]) === filePath) {
+					delayedPathPaused = true;
+					delayedPathEntered();
+					await delayedPathReleased;
+				}
+				return originalRealpath(...args);
+			},
+		});
+		let stale;
+		try {
+			const delayed = resumeToolRequest({
+				token: first.requiresApproval.resumeToken,
+				approved: true,
+				ctx: { cwd: dir, env, signal: controller.signal },
+			});
+			await delayedPathReady;
+			Object.defineProperty(fsp, "realpath", {
+				configurable: true,
+				writable: true,
+				value: originalRealpath,
+			});
+
+			const winner = await resumeToolRequest({
+				token: first.requiresApproval.resumeToken,
+				approved: true,
+				ctx: { cwd: dir, env },
+			});
+			assert.equal(winner.status, "ok");
+			assert.equal(await fileExists(statePath), false);
+			controller.abort(new Error("cancel stale workflow setup after winner settled"));
+			releaseDelayedPath();
+			stale = await delayed;
+		} finally {
+			Object.defineProperty(fsp, "realpath", {
+				configurable: true,
+				writable: true,
+				value: originalRealpath,
+			});
+		}
+		assert.equal(stale.ok, false);
+		assert.equal(await fileExists(statePath), false);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(replay.ok, false);
+		assert.equal((await readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("cancellation stops terminal lazy output before reading its next item", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -2847,6 +2847,75 @@ test("workflow pipeline halts after an in-flight send completes under cancellati
 	}
 });
 
+test("parallel timeout waits for in-flight sends before retrying", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-parallel-timeout-send-settlement-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const filePath = join(dir, "workflow.lobster");
+		const sendStarted = join(dir, "send-started");
+		const sendCompleted = join(dir, "send-completed");
+		const sendInvocations = join(dir, "send-invocations");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "draft",
+						run: `${JSON.stringify(process.execPath)} -e "process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))"`,
+					},
+					{
+						id: "send",
+						retry: { max: 2, delay_ms: 0 },
+						parallel: {
+							timeout_ms: 80,
+							branches: [
+								{
+									id: "mail",
+									pipeline: "gog.gmail.send",
+									stdin: "$draft.json",
+								},
+							],
+						},
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		const run = runToolRequest({
+			filePath,
+			ctx: {
+				cwd: dir,
+				registry: createDefaultRegistry(),
+				env: {
+					...process.env,
+					LOBSTER_STATE_DIR: join(dir, "state"),
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+					MOCK_GOG_COMPLETION_DELAY_MS: "300",
+				},
+			},
+		});
+
+		await waitForFile(sendStarted);
+		const result = await run;
+		assert.equal(result.ok, false);
+		assert.match(result.error?.message ?? "", /timed out|timeout|abort|cancel/i);
+		assert.equal(
+			await fileExists(sendCompleted),
+			true,
+			"a timeout must wait for its in-flight send before retry policy returns",
+		);
+		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 2);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("approval resume token cannot replay a send after downstream cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-cancel-replay-"));
 	try {
@@ -3321,6 +3390,276 @@ test("workflow approval rejection keeps its approval ID when state cleanup is ca
 		assert.equal(await fileExists(approvalIndexPath), true);
 		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
 		await rm(lockPath, { recursive: true, force: true });
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("terminal pipeline resume cleanup stops waiting for a state lock", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-terminal-pipeline-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: "approve --prompt Continue?",
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		controller.abort(new Error("terminal pipeline cleanup stopped while waiting for a state lock"));
+		const early = await observeSettlement(pending, 75);
+		if (!early.settled) await rm(lockPath, { recursive: true, force: true });
+		const settled = early.settled ? early : await observeSettlement(pending, 75);
+
+		assert.equal(settled.settled, true, "terminal cleanup must not remain blocked on a state lock");
+		if (settled.settled) {
+			assert.equal(settled.value.ok, false);
+			assert.match(
+				settled.value.error?.message ?? "",
+				/terminal pipeline cleanup stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(await fileExists(approvalIndexPath), true);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "ok");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pipeline gate replacement stops waiting for a state lock", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pipeline-gate-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: "approve --prompt First? | approve --prompt Second?",
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const originalMkdir = fsp.mkdir;
+		let signalLockAttempt: ((value: boolean) => void) | undefined;
+		const lockAttempted = new Promise<boolean>((resolve) => {
+			signalLockAttempt = resolve;
+		});
+		let sawLockAttempt = false;
+		Object.defineProperty(fsp, "mkdir", {
+			configurable: true,
+			writable: true,
+			async value(
+				filePath: Parameters<typeof fsp.mkdir>[0],
+				options?: Parameters<typeof fsp.mkdir>[1],
+			) {
+				if (!sawLockAttempt && String(filePath) === lockPath) {
+					sawLockAttempt = true;
+					signalLockAttempt?.(true);
+				}
+				return originalMkdir(filePath, options);
+			},
+		});
+		let settled;
+		try {
+			const pending = resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { cwd: dir, env, signal: controller.signal },
+			});
+			const reachedLock = await Promise.race([
+				lockAttempted,
+				new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 500)),
+			]);
+			assert.equal(reachedLock, true, "resume must reach the held state lock");
+			controller.abort(
+				new Error("pipeline gate replacement stopped while waiting for a state lock"),
+			);
+			const early = await observeSettlement(pending, 75);
+			if (!early.settled) await rm(lockPath, { recursive: true, force: true });
+			settled = early.settled ? early : await observeSettlement(pending, 75);
+		} finally {
+			Object.defineProperty(fsp, "mkdir", {
+				configurable: true,
+				writable: true,
+				value: originalMkdir,
+			});
+		}
+
+		assert.equal(
+			settled?.settled,
+			true,
+			"gate replacement must not remain blocked on a state lock",
+		);
+		if (settled?.settled) {
+			assert.equal(settled.value.ok, false);
+			assert.match(
+				settled.value.error?.message ?? "",
+				/pipeline gate replacement stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(await fileExists(approvalIndexPath), true);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "needs_approval");
+		assert.equal(retried.requiresApproval?.prompt, "Second?");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("terminal workflow resume cleanup stops waiting for a state lock", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-terminal-workflow-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "approve", approval: "Continue?" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		controller.abort(new Error("terminal workflow cleanup stopped while waiting for a state lock"));
+		const early = await observeSettlement(pending, 75);
+		if (!early.settled) await rm(lockPath, { recursive: true, force: true });
+		const settled = early.settled ? early : await observeSettlement(pending, 75);
+		assert.equal(
+			settled.settled,
+			true,
+			"terminal workflow cleanup must not remain blocked on a state lock",
+		);
+		if (settled.settled) {
+			assert.equal(settled.value.ok, false);
+			assert.match(
+				settled.value.error?.message ?? "",
+				/terminal workflow cleanup stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(await fileExists(approvalIndexPath), true);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "ok");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow gate replacement stops waiting for a state lock", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-gate-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "first", approval: "First?" },
+					{ id: "second", approval: "Second?" },
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		controller.abort(new Error("workflow gate replacement stopped while waiting for a state lock"));
+		const early = await observeSettlement(pending, 75);
+		if (!early.settled) await rm(lockPath, { recursive: true, force: true });
+		const settled = early.settled ? early : await observeSettlement(pending, 75);
+		assert.equal(settled.settled, true, "gate replacement must not remain blocked on a state lock");
+		if (settled.settled) {
+			assert.equal(settled.value.ok, false);
+			assert.match(
+				settled.value.error?.message ?? "",
+				/workflow gate replacement stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(await fileExists(approvalIndexPath), true);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "needs_approval");
+		assert.equal(retried.requiresApproval?.prompt, "Second?");
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,7 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { access, chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+	access,
+	chmod,
+	copyFile,
+	mkdtemp,
+	readFile,
+	readdir,
+	rm,
+	writeFile,
+} from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -29,6 +38,15 @@ async function fileExists(path: string) {
 		return true;
 	} catch {
 		return false;
+	}
+}
+
+async function listStateFiles(stateDir: string) {
+	try {
+		return await readdir(stateDir);
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return [];
+		throw err;
 	}
 }
 
@@ -218,6 +236,164 @@ test("pre-aborted workflow shell does not start its process", async () => {
 		assertCancellationEnvelope(envelope);
 		assert.equal(envelope.error?.message, "pre-aborted workflow shell");
 		assert.equal(await fileExists(started), false, "pre-aborted workflow must not spawn a shell");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pipeline input cancellation after state publication does not return a live resume token", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pipeline-gate-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 6) {
+					controller.abort(new Error("abort after pipeline input state publication"));
+				}
+				throwIfAborted();
+			},
+		});
+
+		const envelope = await runToolRequest({
+			pipeline: `ask --emit --prompt Continue? --schema '${JSON.stringify({ type: "object" })}'`,
+			ctx: { env: { ...process.env, LOBSTER_STATE_DIR: stateDir }, signal },
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(signalChecks, 6);
+		assert.deepEqual(await listStateFiles(stateDir), [], "cancelled input state must be removed");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pipeline approval cancellation after index publication removes the state and index", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pipeline-approval-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 9) {
+					controller.abort(new Error("abort after pipeline approval index publication"));
+				}
+				throwIfAborted();
+			},
+		});
+		const source = {
+			name: "test.gate-source",
+			async run() {
+				return { output: streamOf([{ value: 1 }]) };
+			},
+		};
+
+		const envelope = await runToolRequest({
+			pipeline: "test.gate-source | approve --prompt Continue?",
+			ctx: {
+				env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+				signal,
+				registry: withCommands(createDefaultRegistry(), source),
+			},
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(signalChecks, 9);
+		assert.deepEqual(
+			await listStateFiles(stateDir),
+			[],
+			"cancelled approval state must be removed",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow input cancellation after state publication does not return a live resume token", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-gate-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "answer", input: { prompt: "Continue?", responseSchema: { type: "object" } } },
+				],
+			}),
+			"utf8",
+		);
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 4) {
+					controller.abort(new Error("abort after workflow input state publication"));
+				}
+				throwIfAborted();
+			},
+		});
+
+		const envelope = await runToolRequest({
+			filePath,
+			ctx: { env: { ...process.env, LOBSTER_STATE_DIR: stateDir }, signal },
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(signalChecks, 4);
+		assert.deepEqual(await listStateFiles(stateDir), [], "cancelled input state must be removed");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow approval cancellation after index publication removes the state and index", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-approval-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "gate", approval: "Continue?" }] }),
+			"utf8",
+		);
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 5) {
+					controller.abort(new Error("abort after workflow approval index publication"));
+				}
+				throwIfAborted();
+			},
+		});
+
+		const envelope = await runToolRequest({
+			filePath,
+			ctx: { env: { ...process.env, LOBSTER_STATE_DIR: stateDir }, signal },
+		});
+
+		assertCancellationEnvelope(envelope);
+		assert.equal(signalChecks, 5);
+		assert.deepEqual(
+			await listStateFiles(stateDir),
+			[],
+			"cancelled approval state must be removed",
+		);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
@@ -725,6 +901,66 @@ test("exec cancellation terminates descendant processes", async () => {
 		await rm(dir, { recursive: true, force: true });
 	}
 });
+
+test(
+	"CLI SIGINT terminates a detached workflow process tree before exiting",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sigint-process-tree-"));
+		let cli: ReturnType<typeof spawn> | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+			const workflow = join(dir, "workflow.lobster");
+			const searchStarted = join(dir, "search-started");
+			const descendantStarted = join(dir, "descendant-started");
+			const descendantCompleted = join(dir, "descendant-completed");
+			const command = [process.execPath, mockGog, "gmail", "search"]
+				.map((arg) => JSON.stringify(arg))
+				.join(" ");
+			await writeFile(workflow, JSON.stringify({ steps: [{ id: "shell", run: command }] }), "utf8");
+
+			cli = spawn(
+				process.execPath,
+				[join(repoRoot, "bin", "lobster.js"), "run", "--file", workflow],
+				{
+					cwd: dir,
+					env: {
+						...process.env,
+						MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+						MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+						MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+						MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+					},
+					stdio: "ignore",
+				},
+			);
+			await waitForFile(searchStarted, 5000);
+			await waitForFile(descendantStarted, 5000);
+			const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+			assert.equal(cli.kill("SIGINT"), true);
+			const exited = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+				(resolve, reject) => {
+					cli!.once("error", reject);
+					cli!.once("exit", (code, signal) => resolve({ code, signal }));
+				},
+			);
+
+			assert.equal(exited.signal, null);
+			assert.equal(exited.code, 130, "CLI must retain the conventional SIGINT exit status");
+			await new Promise((resolve) => setTimeout(resolve, 900));
+			assert.equal(processIsRunning(descendantPid), false);
+			assert.equal(
+				await fileExists(descendantCompleted),
+				false,
+				"a detached workflow descendant must not finish after Ctrl+C",
+			);
+		} finally {
+			cli?.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
 
 test("cancellation after Gmail search completion stops the next pipeline stage", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-search-handoff-"));

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -924,12 +924,14 @@ test("workflow approval resume remains retryable when child workflow setup is ca
 		const controller = new AbortController();
 		const originalRealpath = fsp.realpath;
 		let childSetupObserved = false;
+		let childRealpathCalls = 0;
 		Object.defineProperty(fsp, "realpath", {
 			configurable: true,
 			writable: true,
 			async value(filePath: Parameters<typeof fsp.realpath>[0]) {
 				const resolved = await originalRealpath(filePath);
-				if (String(filePath) === childPath && !controller.signal.aborted) {
+				if (String(filePath) === childPath) childRealpathCalls += 1;
+				if (childRealpathCalls === 2 && !controller.signal.aborted) {
 					childSetupObserved = true;
 					controller.abort(new Error("abort during child workflow setup"));
 				}
@@ -952,11 +954,71 @@ test("workflow approval resume remains retryable when child workflow setup is ca
 		}
 		assertCancellationEnvelope(aborted!);
 		assert.equal(childSetupObserved, true);
+		assert.equal(childRealpathCalls, 2);
 
 		const retried = await resumeToolRequest({
 			approvalId: first.requiresApproval.approvalId,
 			approved: true,
 			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(retried.status, "ok");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("terminal pipeline approval resume restores its original approval ID when cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-terminal-pipeline-cleanup-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: "approve --prompt First?",
+			ctx: { env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const previousStatePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const originalUnlink = fsp.unlink;
+		let previousStateDeleted = false;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				const result = await originalUnlink(filePath);
+				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
+					previousStateDeleted = true;
+					controller.abort(new Error("abort during terminal pipeline approval cleanup"));
+				}
+				return result;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { env, signal: controller.signal },
+			});
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(previousStateDeleted, true);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env },
 		});
 		assert.equal(retried.ok, true);
 		assert.equal(retried.status, "ok");

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1374,6 +1374,45 @@ test("cancellation observed before terminal drain is reported after output clean
 	assert.equal(outputDrained, true, "terminal output cleanup must complete before cancellation");
 });
 
+test("cancellation drains a halted lazy output before a later pipeline stage", async () => {
+	const controller = new AbortController();
+	let outputDrained = false;
+	let downstreamRan = false;
+	const terminal = {
+		name: "test.halted-output-before-later-stage",
+		async run() {
+			controller.abort(new Error("abort before halted output drain"));
+			return {
+				halt: true,
+				output: (async function* () {
+					yield { cleanup: true };
+					outputDrained = true;
+				})(),
+			};
+		},
+	};
+	const downstream = {
+		name: "test.halted-output-unreached",
+		async run() {
+			downstreamRan = true;
+			return { output: [] };
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.halted-output-before-later-stage | test.halted-output-unreached",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), terminal, downstream),
+			signal: controller.signal,
+		},
+	});
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(envelope.error?.message, "abort before halted output drain");
+	assert.equal(outputDrained, true, "halted output cleanup must complete before cancellation");
+	assert.equal(downstreamRan, false, "a halted stage must not dispatch later pipeline stages");
+});
+
 test("cancellation before a non-terminal lazy handoff does not wait for its next item", async () => {
 	const controller = new AbortController();
 	const source = {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -4599,6 +4599,104 @@ test("terminal workflow resume cleanup stops waiting for a state lock", async ()
 	}
 });
 
+test("started pipeline and workflow cleanup never retries an interrupted state lock without its signal", async () => {
+	for (const workflow of [false, true]) {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-started-cleanup-lock-abort-"));
+		try {
+			const stateDir = join(dir, "state");
+			const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+			let lockPath = "";
+			let effectFinished!: () => void;
+			const effectFinishedPromise = new Promise<void>((resolve) => {
+				effectFinished = resolve;
+			});
+			let invocations = 0;
+			const effect = {
+				name: "test.started-cleanup-effect",
+				async run({ input }: { input: AsyncIterable<unknown> }) {
+					for await (const _item of input) {
+						// Drain the approval output before returning the effect result.
+					}
+					invocations += 1;
+					await fsp.mkdir(lockPath);
+					await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+					effectFinished();
+					return { output: streamOf([{ ok: true }]) };
+				},
+			};
+			const registry = withCommands(createDefaultRegistry(), effect);
+			const filePath = join(dir, "workflow.lobster");
+			if (workflow) {
+				await writeFile(
+					filePath,
+					JSON.stringify({
+						steps: [
+							{ id: "approve", approval: "Continue?" },
+							{ id: "effect", pipeline: "test.started-cleanup-effect" },
+						],
+					}),
+					"utf8",
+				);
+			}
+			const first = await (workflow
+				? runToolRequest({ filePath, ctx: { cwd: dir, env, registry } })
+				: runToolRequest({
+						pipeline: "approve --prompt Continue? | test.started-cleanup-effect",
+						ctx: { cwd: dir, env, registry },
+					}));
+			assert.equal(first.status, "needs_approval");
+			assert.ok(first.requiresApproval?.resumeToken);
+			assert.ok(first.requiresApproval?.approvalId);
+			const payload = decodeResumeToken(first.requiresApproval.resumeToken!);
+			lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+			const approvalIndexPath = join(
+				stateDir,
+				`approval_${first.requiresApproval.approvalId}.json`,
+			);
+
+			const controller = new AbortController();
+			const pending = resumeToolRequest({
+				token: first.requiresApproval.resumeToken,
+				approved: true,
+				ctx: { cwd: dir, env, registry, signal: controller.signal },
+			});
+			await effectFinishedPromise;
+			controller.abort(new Error("started cleanup stopped while waiting for a state lock"));
+			const settled = await observeSettlement(pending, 500);
+
+			assert.equal(
+				settled.settled,
+				true,
+				`${workflow ? "workflow" : "pipeline"} cleanup must not re-enter a held lock after cancellation`,
+			);
+			if (settled.settled) {
+				assert.equal(settled.value.ok, false);
+				assert.match(
+					settled.value.error?.message ?? "",
+					/started cleanup stopped while waiting for a state lock/,
+				);
+			}
+			assert.equal(invocations, 1);
+			assert.equal(
+				await fileExists(approvalIndexPath),
+				false,
+				"a started effect must retire its approval ID even when tombstone cleanup times out",
+			);
+			await rm(lockPath, { recursive: true, force: true });
+
+			const replay = await resumeToolRequest({
+				token: first.requiresApproval.resumeToken,
+				approved: true,
+				ctx: { cwd: dir, env, registry },
+			});
+			assert.equal(replay.ok, false);
+			assert.match(replay.error?.message ?? "", /resume state not found/i);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+});
+
 test("workflow gate replacement stops waiting for a state lock", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-gate-lock-abort-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -48,6 +48,30 @@ test("runAbortableProcess preserves UTF-8 characters split across pipe chunks", 
 	assert.equal(result.stdout, "€");
 });
 
+test("runAbortableProcess does not spawn when its signal is already aborted", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-aborted-process-"));
+	try {
+		const marker = join(dir, "spawned");
+		const controller = new AbortController();
+		controller.abort(new Error("abort before spawn"));
+
+		await assert.rejects(
+			runAbortableProcess({
+				command: process.execPath,
+				argv: ["-e", `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'spawned')`],
+				env: process.env,
+				signal: controller.signal,
+				notFoundMessage: "node missing",
+			}),
+			/abort before spawn/,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		assert.equal(await fileExists(marker), false);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 async function fileExists(path: string) {
 	try {
 		await access(path);
@@ -1130,6 +1154,51 @@ test("pipeline cancellation after side effects does not restore the consumed app
 	}
 });
 
+test("same-stage resumed input consumes its capability before a custom command acts on it", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-resumed-input-side-effect-cancel-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const controller = new AbortController();
+		let sideEffects = 0;
+		const sideEffectAfterInput = {
+			name: "test.side-effect-after-input",
+			meta: { resumeSafeBeforeInput: true },
+			async run({ ctx }: any) {
+				await ctx.requestInput({ prompt: "Continue?", responseSchema: { type: "object" } });
+				sideEffects += 1;
+				controller.abort(new Error("abort after resumed input side effect"));
+				return { output: streamOf([]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), sideEffectAfterInput);
+		const first = await runToolRequest({
+			pipeline: "test.side-effect-after-input",
+			ctx: { env, registry },
+		});
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+
+		const aborted = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: {},
+			ctx: { env, registry, signal: controller.signal },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(sideEffects, 1);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: {},
+			ctx: { env, registry },
+		});
+		assert.equal(replay.ok, false);
+		assert.notEqual(replay.status, "needs_input");
+		assert.equal(sideEffects, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("workflow approval resume restores its original capability after next-input cleanup is cancelled", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-input-gate-cleanup-abort-workflow-resume-"));
 	try {
@@ -1446,6 +1515,123 @@ test("cancellation before a non-terminal lazy handoff does not wait for its next
 	);
 	assert.equal(settled.settled, true, "cancellation must not wait for the stalled lazy handoff");
 	if (settled.settled) assertCancellationEnvelope(settled.value);
+});
+
+test("cancellable lazy output releases a pending read before cancellation returns", async () => {
+	const controller = new AbortController();
+	let readStarted!: () => void;
+	const pendingReadStarted = new Promise<void>((resolve) => {
+		readStarted = resolve;
+	});
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let resolveNext!: (value: IteratorResult<unknown>) => void;
+	let abortCalled = false;
+	const source = {
+		name: "test.cancellable-lazy-output",
+		async run() {
+			return {
+				output: {
+					abort() {
+						abortCalled = true;
+						if (timer) clearTimeout(timer);
+						resolveNext({ done: true, value: undefined });
+					},
+					[Symbol.asyncIterator]() {
+						return {
+							next() {
+								readStarted();
+								return new Promise<IteratorResult<unknown>>((resolve) => {
+									resolveNext = resolve;
+									timer = setTimeout(() => resolve({ done: true, value: undefined }), 2000);
+								});
+							},
+							async return() {
+								return { done: true, value: undefined };
+							},
+						};
+					},
+				},
+			};
+		},
+	};
+	const downstream = {
+		name: "test.cancellable-lazy-downstream",
+		async run({ input }: { input: AsyncIterable<unknown> }) {
+			for await (const _item of input) {
+				// Draining begins the source's pending read.
+			}
+			return { output: streamOf([]) };
+		},
+	};
+
+	try {
+		const run = runToolRequest({
+			pipeline: "test.cancellable-lazy-output | test.cancellable-lazy-downstream",
+			ctx: {
+				registry: withCommands(createDefaultRegistry(), source, downstream),
+				signal: controller.signal,
+			},
+		});
+		await pendingReadStarted;
+		controller.abort(new Error("abort cancellable lazy output"));
+		const settled = await observeSettlement(run, 500);
+		assert.equal(settled.settled, true, "cancellation must release the pending lazy read");
+		if (settled.settled) assertCancellationEnvelope(settled.value);
+		assert.equal(abortCalled, true);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+});
+
+test("native lazy generators finish their pending cleanup before cancellation returns", async () => {
+	const controller = new AbortController();
+	let readStarted!: () => void;
+	const pendingReadStarted = new Promise<void>((resolve) => {
+		readStarted = resolve;
+	});
+	let sourceClosed = false;
+	const source = {
+		name: "test.native-lazy-output",
+		async run() {
+			return {
+				output: (async function* () {
+					try {
+						readStarted();
+						await new Promise((resolve) => setTimeout(resolve, 25));
+					} finally {
+						sourceClosed = true;
+					}
+				})(),
+			};
+		},
+	};
+	const downstream = {
+		name: "test.native-lazy-downstream",
+		async run({ input }: { input: AsyncIterable<unknown> }) {
+			for await (const _item of input) {
+				// Draining begins the source's pending read.
+			}
+			return { output: streamOf([]) };
+		},
+	};
+
+	const run = runToolRequest({
+		pipeline: "test.native-lazy-output | test.native-lazy-downstream",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), source, downstream),
+			signal: controller.signal,
+		},
+	});
+	await pendingReadStarted;
+	controller.abort(new Error("abort native lazy output"));
+	const settled = await observeSettlement(run, 500);
+	assert.equal(settled.settled, true, "cancellation must wait for native generator cleanup");
+	if (settled.settled) assertCancellationEnvelope(settled.value);
+	assert.equal(
+		sourceClosed,
+		true,
+		"native generator cleanup must finish before cancellation returns",
+	);
 });
 
 test("cancellation during lazy handoff stops yielding items to the downstream stage", async () => {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -72,6 +72,48 @@ test("runAbortableProcess does not spawn when its signal is already aborted", as
 	}
 });
 
+test(
+	"runAbortableProcess without a signal keeps direct children in the terminal process group",
+	{ skip: process.platform !== "linux" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-terminal-direct-process-"));
+		let terminal: ReturnType<typeof spawn> | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const runner = join(repoRoot, "dist", "src", "abortable_process.js");
+			const wrapper = join(repoRoot, "test", "fixtures", "abortable-process-terminal-direct.mjs");
+			const groupFile = join(dir, "process-group");
+			const startedFile = join(dir, "started");
+			const completedFile = join(dir, "completed");
+			const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+			const command = `exec ${[process.execPath, wrapper, runner].map(quote).join(" ")}`;
+			terminal = spawn("script", ["-qefc", command, "/dev/null"], {
+				env: {
+					...process.env,
+					LOBSTER_TERMINAL_DIRECT_GROUP_FILE: groupFile,
+					LOBSTER_TERMINAL_DIRECT_STARTED_FILE: startedFile,
+					LOBSTER_TERMINAL_DIRECT_COMPLETED_FILE: completedFile,
+				},
+				stdio: ["ignore", "ignore", "ignore"],
+			});
+			await waitForFile(groupFile, 5000);
+			await waitForFile(startedFile, 5000);
+			const processGroup = Number(await readFile(groupFile, "utf8"));
+			assert.ok(Number.isInteger(processGroup) && processGroup > 0);
+			process.kill(-processGroup, "SIGINT");
+			await new Promise((resolve) => setTimeout(resolve, 900));
+			assert.equal(
+				await fileExists(completedFile),
+				false,
+				"a direct child must not complete after terminal interruption",
+			);
+		} finally {
+			terminal?.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
 async function fileExists(path: string) {
 	try {
 		await access(path);
@@ -3808,6 +3850,113 @@ test("pipeline approval token and short ID cannot fork a next input gate", async
 test("workflow approval token and short ID cannot fork a next input gate", async () => {
 	for (const resumeBy of ["token", "approvalId"] as const) {
 		await assertApprovalGateHandoffIsExclusive({ workflow: true, resumeBy });
+	}
+});
+
+async function assertCancellationCannotRetireClaimedSuccessor({
+	workflow,
+	rejectApproval,
+}: {
+	workflow: boolean;
+	rejectApproval: boolean;
+}) {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-claimed-successor-"));
+	const originalRename = fsp.rename;
+	let releaseClaim!: () => void;
+	const claimReleased = new Promise<void>((resolve) => {
+		releaseClaim = resolve;
+	});
+	let claimPublished!: () => void;
+	const claimReached = new Promise<void>((resolve) => {
+		claimPublished = resolve;
+	});
+	let claimPaused = false;
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		let first: any;
+		if (workflow) {
+			const filePath = join(dir, "workflow.lobster");
+			await writeFile(
+				filePath,
+				JSON.stringify({
+					steps: [
+						{ id: "approve", approval: "Continue?" },
+						{ id: "next-input", pipeline: "ask --prompt Next?" },
+					],
+				}),
+				"utf8",
+			);
+			first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		} else {
+			first = await runToolRequest({
+				pipeline: "approve --prompt Continue? | ask --prompt Next?",
+				ctx: { cwd: dir, env },
+			});
+		}
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken!);
+		const predecessorPath = keyToPath(stateDir, payload.stateKey);
+
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+				const result = await originalRename(from, to);
+				if (String(to) === predecessorPath && !claimPaused) {
+					claimPaused = true;
+					claimPublished();
+					await claimReleased;
+				}
+				return result;
+			},
+		});
+
+		const resumed = resumeToolRequest({
+			token: first.requiresApproval.resumeToken!,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		await claimReached;
+		const cancelled = resumeToolRequest({
+			token: first.requiresApproval.resumeToken!,
+			...(rejectApproval ? { approved: false } : { cancel: true }),
+			ctx: { cwd: dir, env },
+		});
+		releaseClaim();
+
+		const [resumedResult, cancelledResult] = await Promise.all([resumed, cancelled]);
+		assert.equal(resumedResult.ok, true);
+		assert.equal(resumedResult.status, "needs_input");
+		assert.ok(resumedResult.requiresInput?.resumeToken);
+		assert.equal(
+			cancelledResult.ok,
+			false,
+			"cancellation must reject a predecessor already claimed for a successor",
+		);
+		assert.match(cancelledResult.error?.message ?? "", /resume state not found/i);
+		const successor = decodeResumeToken(resumedResult.requiresInput.resumeToken!);
+		assert.notEqual(
+			await fsp.readFile(keyToPath(stateDir, successor.stateKey), "utf8"),
+			"",
+			"the returned successor must remain live",
+		);
+	} finally {
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			value: originalRename,
+		});
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+test("cancellation and rejection cannot retire a claimed pipeline or workflow successor", async () => {
+	for (const workflow of [false, true]) {
+		for (const rejectApproval of [false, true]) {
+			await assertCancellationCannotRetireClaimedSuccessor({ workflow, rejectApproval });
+		}
 	}
 });
 

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -678,6 +678,91 @@ test("workflow approval resume remains retryable when cancellation occurs during
 	}
 });
 
+test("pre-aborted terminal workflow approval resume remains retryable", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-terminal-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "confirm", approval: "Continue?" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted terminal workflow resume"));
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, signal: controller.signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.ok, true);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow approval resume remains retryable when cancellation creates its next input gate", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-input-gate-abort-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{ id: "answer", input: { prompt: "Continue?", responseSchema: { type: "object" } } },
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 3) {
+					controller.abort(new Error("abort while creating next workflow input gate"));
+				}
+				throwIfAborted();
+			},
+		});
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(signalChecks, 3);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "needs_input");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("cancellation while draining terminal lazy output returns cancellation", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;
@@ -1728,7 +1813,7 @@ test("workflow pipeline halts after an in-flight send completes under cancellati
 				steps: [
 					{
 						id: "draft",
-						run: "node -e \"process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))\"",
+						run: `${JSON.stringify(process.execPath)} -e "process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))"`,
 					},
 					{
 						id: "send",
@@ -2436,7 +2521,7 @@ test("workflow approval resume cannot replay a send after downstream cancellatio
 				steps: [
 					{
 						id: "draft",
-						run: "node -e \"process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))\"",
+						run: `${JSON.stringify(process.execPath)} -e "process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))"`,
 					},
 					{ id: "confirm", approval: "Send?", stdin: "$draft.json" },
 					{

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1579,6 +1579,57 @@ test("cancellation before a non-terminal lazy handoff does not wait for its next
 	if (settled.settled) assertCancellationEnvelope(settled.value);
 });
 
+test("cancellation before a terminal lazy read invokes its iterator abort hook", async () => {
+	const controller = new AbortController();
+	let readStarted!: () => void;
+	const pendingReadStarted = new Promise<void>((resolve) => {
+		readStarted = resolve;
+	});
+	let resolveNext!: (value: IteratorResult<unknown>) => void;
+	let abortCalled = false;
+	const terminal = {
+		name: "test.cancellable-terminal-lazy-output",
+		async run() {
+			return {
+				halt: true,
+				output: {
+					[Symbol.asyncIterator]() {
+						return {
+							abort() {
+								abortCalled = true;
+								resolveNext({ done: true, value: undefined });
+							},
+							next() {
+								readStarted();
+								return new Promise<IteratorResult<unknown>>((resolve) => {
+									resolveNext = resolve;
+								});
+							},
+							async return() {
+								return { done: true, value: undefined };
+							},
+						};
+					},
+				},
+			};
+		},
+	};
+
+	const run = runToolRequest({
+		pipeline: "test.cancellable-terminal-lazy-output",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), terminal),
+			signal: controller.signal,
+		},
+	});
+	await pendingReadStarted;
+	controller.abort(new Error("abort cancellable terminal lazy output"));
+	const settled = await observeSettlement(run, 500);
+	assert.equal(settled.settled, true, "cancellation must release the terminal lazy read");
+	if (settled.settled) assertCancellationEnvelope(settled.value);
+	assert.equal(abortCalled, true);
+});
+
 test("cancellable lazy output releases a pending read before cancellation returns", async () => {
 	const controller = new AbortController();
 	let readStarted!: () => void;
@@ -3126,6 +3177,161 @@ test("explicit cancellation stops waiting for a state lock without orphaning its
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
+});
+
+test("approval rejection stops waiting for a state lock without orphaning its approval ID", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-approval-rejection-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: "approve --prompt Continue?",
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: false,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		});
+		const completion = pending.then(
+			() => ({ kind: "success" as const }),
+			(error) => ({ kind: "error" as const, error }),
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+		controller.abort(new Error("approval rejection stopped while waiting for a state lock"));
+		const early = await Promise.race([
+			completion,
+			new Promise<{ kind: "timeout" }>((resolve) =>
+				setTimeout(() => resolve({ kind: "timeout" }), 75),
+			),
+		]);
+		if (early.kind === "timeout") await rm(lockPath, { recursive: true, force: true });
+		const settled = early.kind === "timeout" ? await completion : early;
+
+		assert.notEqual(
+			early.kind,
+			"timeout",
+			"approval rejection must not remain blocked on a state lock",
+		);
+		assert.equal(settled.kind, "error");
+		if (settled.kind === "error") {
+			assert.match(
+				settled.error?.message ?? "",
+				/approval rejection stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(
+			await fileExists(approvalIndexPath),
+			true,
+			"the approval ID must remain usable after cancelled rejection cleanup",
+		);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow approval rejection keeps its approval ID when state cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-approval-rejection-lock-abort-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "confirm", approval: "Continue?" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: false,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		controller.abort(new Error("workflow rejection stopped while waiting for a state lock"));
+		const result = await observeSettlement(pending, 500);
+		assert.equal(result.settled, true, "workflow rejection must stop waiting for the state lock");
+		if (result.settled) {
+			assert.equal(result.value.ok, false);
+			assert.match(
+				result.value.error?.message ?? "",
+				/workflow rejection stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(await fileExists(approvalIndexPath), true);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("lazy output iterator acquisition failure closes the active stage", async () => {
+	let inputClosed = false;
+	const input = {
+		[Symbol.asyncIterator]() {
+			return {
+				async next() {
+					return { done: false, value: { item: 1 } };
+				},
+				async return() {
+					inputClosed = true;
+					return { done: true, value: undefined };
+				},
+			};
+		},
+	};
+	const command = {
+		name: "test.throw-on-iterator-acquisition",
+		async run({ input: stageInput }: { input: AsyncIterable<unknown> }) {
+			await stageInput[Symbol.asyncIterator]().next();
+			return {
+				output: {
+					[Symbol.asyncIterator]() {
+						throw new Error("iterator acquisition failed");
+					},
+				},
+			};
+		},
+	};
+
+	await assert.rejects(
+		runPipeline({
+			pipeline: [{ name: command.name, args: {} }],
+			registry: withCommands(createDefaultRegistry(), command),
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env: process.env,
+			input,
+		}),
+		/iterator acquisition failed/,
+	);
+	assert.equal(inputClosed, true, "iterator acquisition failure must finish and close the stage");
 });
 
 test("explicit cancellation removes a corrupt workflow state through an aliased token", async () => {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -2661,7 +2661,11 @@ test(
 			const command = [process.execPath, mockGog, "gmail", "search"]
 				.map((arg) => JSON.stringify(arg))
 				.join(" ");
-			await writeFile(workflow, JSON.stringify({ steps: [{ id: "shell", run: command }] }), "utf8");
+			await writeFile(
+				workflow,
+				JSON.stringify({ steps: [{ id: "shell", run: command, timeout_ms: 10_000 }] }),
+				"utf8",
+			);
 
 			cli = spawn(
 				process.execPath,
@@ -2723,7 +2727,11 @@ test(
 			const command = [process.execPath, mockGog, "gmail", "search"]
 				.map((arg) => JSON.stringify(arg))
 				.join(" ");
-			await writeFile(workflow, JSON.stringify({ steps: [{ id: "shell", run: command }] }), "utf8");
+			await writeFile(
+				workflow,
+				JSON.stringify({ steps: [{ id: "shell", run: command, timeout_ms: 10_000 }] }),
+				"utf8",
+			);
 
 			cli = spawn(
 				process.execPath,

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1774,6 +1774,56 @@ test("cancellation before a terminal lazy read invokes its iterator abort hook",
 	assert.equal(abortCalled, true);
 });
 
+test("cancellation falls back to an iterable-owned lazy abort hook", async () => {
+	const controller = new AbortController();
+	let readStarted!: () => void;
+	const pendingReadStarted = new Promise<void>((resolve) => {
+		readStarted = resolve;
+	});
+	let resolveNext!: (value: IteratorResult<unknown>) => void;
+	let abortCalled = false;
+	const source = {
+		name: "test.iterable-owned-lazy-abort",
+		async run() {
+			return {
+				output: {
+					abort() {
+						abortCalled = true;
+						resolveNext({ done: true, value: undefined });
+					},
+					[Symbol.asyncIterator]() {
+						return {
+							next() {
+								readStarted();
+								return new Promise<IteratorResult<unknown>>((resolve) => {
+									resolveNext = resolve;
+								});
+							},
+							async return() {
+								return { done: true, value: undefined };
+							},
+						};
+					},
+				},
+			};
+		},
+	};
+
+	const pending = runToolRequest({
+		pipeline: "test.iterable-owned-lazy-abort",
+		ctx: { registry: withCommands(createDefaultRegistry(), source), signal: controller.signal },
+	});
+	await pendingReadStarted;
+	controller.abort(new Error("cancel iterable-owned lazy output"));
+	const settled = await observeSettlement(pending, 500);
+	assert.equal(settled.settled, true);
+	if (settled.settled) {
+		assert.equal(settled.value.ok, false);
+		assert.equal(settled.value.error?.type, "runtime_error");
+	}
+	assert.equal(abortCalled, true);
+});
+
 test("cancellation does not pull another lazy output item after an in-flight read aborts", async () => {
 	const controller = new AbortController();
 	let afterAbortEffects = 0;
@@ -2504,6 +2554,53 @@ test(
 				1,
 				"retrying an interrupted CLI resume must not resend",
 			);
+		} finally {
+			resumed?.child.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"CLI SIGINT reports a tool envelope while resume cleanup waits on a state lock",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sigint-resume-cleanup-lock-"));
+		let resumed: ReturnType<typeof startLobsterCli> | undefined;
+		try {
+			const stateDir = join(dir, "state");
+			const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+			const first = startLobsterCli({
+				args: ["run", "--mode", "tool", "approve --prompt Continue?"],
+				cwd: dir,
+				env,
+			});
+			const initial = await first.result;
+			assert.equal(initial.code, 0, initial.stderr);
+			const approval = JSON.parse(initial.stdout).requiresApproval;
+			assert.ok(approval?.resumeToken);
+
+			const payload = decodeResumeToken(approval.resumeToken);
+			const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+			await fsp.mkdir(lockPath);
+			await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+			resumed = startLobsterCli({
+				args: ["resume", "--token", approval.resumeToken, "--cancel"],
+				cwd: dir,
+				env,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 1500));
+			assert.equal(resumed.child.kill("SIGINT"), true);
+			const exited = await resumed.result;
+
+			assert.equal(exited.signal, null);
+			assert.equal(exited.code, 130);
+			const envelope = JSON.parse(exited.stdout);
+			assert.equal(envelope.ok, false);
+			assert.equal(envelope.error?.type, "runtime_error");
+			assert.match(envelope.error?.message ?? "", /Received SIGINT/);
+			await rm(lockPath, { recursive: true, force: true });
 		} finally {
 			resumed?.child.kill("SIGKILL");
 			await rm(dir, { recursive: true, force: true });
@@ -3428,6 +3525,111 @@ test("explicit cancellation stops waiting for a state lock without orphaning its
 	}
 });
 
+test("workflow explicit cancellation keeps canonical state when its alternate spelling is locked", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-alternate-cancel-lock-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "confirm", approval: "Continue?" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		assert.ok(payload.stateKey?.startsWith("workflow_resume_"));
+		const alternateStateKey = payload.stateKey.replace("workflow_resume_", "workflow-resume_");
+		const alternateLock = `${keyToPath(stateDir, alternateStateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(alternateLock);
+		await fsp.writeFile(join(alternateLock, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			cancel: true,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		}).then(
+			(value) => ({ kind: "value" as const, value }),
+			(error) => ({ kind: "error" as const, error }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		controller.abort(new Error("alternate cleanup lock interrupted cancellation"));
+		const settled = await observeSettlement(pending, 500);
+		assert.equal(settled.settled, true);
+		if (settled.settled) {
+			assert.equal(settled.value.kind, "error");
+			if (settled.value.kind === "error") {
+				assert.match(settled.value.error?.message ?? "", /alternate cleanup lock interrupted/);
+			}
+		}
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		assert.equal(await fileExists(approvalIndexPath), true);
+		await rm(alternateLock, { recursive: true, force: true });
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("a failed post-effect resume cleanup leaves a non-replayable pipeline tombstone", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-consumed-pipeline-tombstone-"));
+	const originalUnlink = fsp.unlink;
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const effect = createCountingSideEffect("test.tombstone-effect");
+		const registry = withCommands(createDefaultRegistry(), effect.command);
+		const first = await runToolRequest({
+			pipeline: "approve --prompt Continue? | test.tombstone-effect",
+			ctx: { cwd: dir, env, registry },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				if (String(filePath) === statePath) {
+					throw Object.assign(new Error("injected resume unlink failure"), { code: "EIO" });
+				}
+				return originalUnlink(filePath);
+			},
+		});
+
+		const resumed = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, env, registry },
+		});
+		assert.equal(resumed.ok, false);
+		assert.match(resumed.error?.message ?? "", /injected resume unlink failure/);
+		assert.equal(effect.invocations, 1);
+
+		const replay = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, env, registry },
+		});
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Pipeline resume state not found/);
+		assert.equal(effect.invocations, 1, "a tombstoned token must not repeat its side effect");
+	} finally {
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			value: originalUnlink,
+		});
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("approval rejection stops waiting for a state lock without orphaning its approval ID", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-approval-rejection-lock-abort-"));
 	try {
@@ -3949,7 +4151,7 @@ test("workflow on_error cannot swallow cancellation with a custom reason", async
 	}
 });
 
-test("approval resume token remains retryable after a non-abort failure", async () => {
+test("approval resume token cannot replay after a non-abort failure past an unsafe boundary", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-retry-"));
 	try {
 		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
@@ -3986,20 +4188,20 @@ test("approval resume token remains retryable after a non-abort failure", async 
 		assert.equal(failed.ok, false);
 		assert.match(failed.error?.message ?? "", /retryable failure/);
 
-		const retried = await resumeToolRequest({
+		const replay = await resumeToolRequest({
 			token: first.requiresApproval.resumeToken,
 			approved: true,
 			ctx: { registry, env },
 		});
-		assert.equal(retried.ok, true);
-		assert.deepEqual(retried.output, [{ value: 1 }]);
-		assert.equal(attempts, 2);
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Pipeline resume state not found/);
+		assert.equal(attempts, 1);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
 });
 
-test("next-stage input resume remains retryable after a non-abort failure", async () => {
+test("next-stage input resume cannot replay after a non-abort failure past an unsafe boundary", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-input-resume-retry-"));
 	try {
 		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
@@ -4034,20 +4236,20 @@ test("next-stage input resume remains retryable after a non-abort failure", asyn
 		});
 		assert.equal(failed.ok, false);
 		assert.match(failed.error?.message ?? "", /retryable failure/);
-		const retried = await resumeToolRequest({
+		const replay = await resumeToolRequest({
 			token: first.requiresInput.resumeToken,
 			response: { value: 1 },
 			ctx: { registry, env },
 		});
-		assert.equal(retried.ok, true);
-		assert.deepEqual(retried.output, [{ value: 1 }]);
-		assert.equal(attempts, 2);
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Pipeline resume state not found/);
+		assert.equal(attempts, 1);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
 });
 
-test("workflow resume remains retryable after a non-abort failure", async () => {
+test("workflow resume cannot replay after a non-abort failure past an unsafe boundary", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-resume-retry-"));
 	try {
 		const filePath = join(dir, "workflow.lobster");
@@ -4090,13 +4292,14 @@ test("workflow resume remains retryable after a non-abort failure", async () => 
 		});
 		assert.equal(failed.ok, false);
 		assert.match(failed.error?.message ?? "", /retryable failure/);
-		const retried = await resumeToolRequest({
+		const replay = await resumeToolRequest({
 			token: first.requiresApproval.resumeToken,
 			approved: true,
 			ctx: { cwd: dir, registry, env },
 		});
-		assert.equal(retried.ok, true);
-		assert.equal(attempts, 2);
+		assert.equal(replay.ok, false);
+		assert.match(replay.error?.message ?? "", /Workflow resume state not found/);
+		assert.equal(attempts, 1);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1040,6 +1040,59 @@ test(
 );
 
 test(
+	"CLI SIGINT aborts a stalled OpenClaw HTTP call",
+	{ skip: process.platform === "win32" },
+	async () => {
+		let requestReceived!: () => void;
+		const requestStarted = new Promise<void>((resolve) => {
+			requestReceived = resolve;
+		});
+		const server = createServer((request) => {
+			request.resume();
+			requestReceived();
+			// Intentionally leave the response open so cancellation must abort fetch.
+		});
+		let cli: ReturnType<typeof startLobsterCli> | undefined;
+		try {
+			await new Promise<void>((resolve, reject) => {
+				server.once("error", reject);
+				server.listen(0, "127.0.0.1", resolve);
+			});
+			const address = server.address();
+			assert.ok(address && typeof address !== "string");
+			cli = startLobsterCli({
+				args: [
+					"openclaw.invoke",
+					"--url",
+					`http://127.0.0.1:${address.port}`,
+					"--tool",
+					"test",
+					"--action",
+					"wait",
+				],
+				cwd: tmpdir(),
+				env: process.env,
+			});
+
+			const requestObserved = await observeSettlement(requestStarted, 5000);
+			assert.equal(requestObserved.settled, true, "OpenClaw request must reach the server");
+			assert.equal(cli.child.kill("SIGINT"), true);
+			const exited = await observeSettlement(cli.result, 5000);
+			assert.equal(exited.settled, true, "CLI must exit after one SIGINT");
+			if (!exited.settled) return;
+			assert.equal(exited.value.signal, null);
+			assert.equal(exited.value.code, 130);
+		} finally {
+			cli?.child.kill("SIGKILL");
+			(server as any).closeAllConnections?.();
+			if (server.listening) {
+				await new Promise<void>((resolve) => server.close(() => resolve()));
+			}
+		}
+	},
+);
+
+test(
 	"CLI SIGINT consumes a pipeline approval resume after execution starts",
 	{ skip: process.platform === "win32" },
 	async () => {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -706,6 +706,150 @@ test("same-stage ask resume restores its token when cancellation wins before exe
 	}
 });
 
+test("same-stage input resumes stop waiting on a held state lock", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-same-stage-input-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const workflowPath = join(dir, "workflow.lobster");
+		await writeFile(
+			workflowPath,
+			JSON.stringify({ steps: [{ id: "review", pipeline: "ask --prompt Review?" }] }),
+			"utf8",
+		);
+
+		for (const run of [
+			() => runToolRequest({ pipeline: "ask --prompt Review?", ctx: { cwd: dir, env } }),
+			() => runToolRequest({ filePath: workflowPath, ctx: { cwd: dir, env } }),
+		]) {
+			const first = await run();
+			assert.equal(first.status, "needs_input");
+			assert.ok(first.requiresInput?.resumeToken);
+			const payload = decodeResumeToken(first.requiresInput.resumeToken);
+			const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+			await fsp.mkdir(lockPath);
+			await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+			const controller = new AbortController();
+			const originalMkdir = fsp.mkdir;
+			let signalLockAttempt: (() => void) | undefined;
+			const lockAttempted = new Promise<void>((resolve) => {
+				signalLockAttempt = resolve;
+			});
+			Object.defineProperty(fsp, "mkdir", {
+				configurable: true,
+				writable: true,
+				async value(
+					filePath: Parameters<typeof fsp.mkdir>[0],
+					options?: Parameters<typeof fsp.mkdir>[1],
+				) {
+					if (String(filePath) === lockPath) signalLockAttempt?.();
+					return originalMkdir(filePath, options);
+				},
+			});
+
+			let resumed;
+			try {
+				const pending = resumeToolRequest({
+					token: first.requiresInput.resumeToken,
+					response: { decision: "approve" },
+					ctx: { cwd: dir, env, signal: controller.signal },
+				});
+				await lockAttempted;
+				controller.abort(
+					new Error("same-stage input cleanup stopped while waiting for a state lock"),
+				);
+				resumed = await observeSettlement(pending, 1500);
+			} finally {
+				Object.defineProperty(fsp, "mkdir", {
+					configurable: true,
+					writable: true,
+					value: originalMkdir,
+				});
+			}
+
+			assert.equal(
+				resumed.settled,
+				true,
+				"same-stage cleanup must not remain blocked on a state lock",
+			);
+			if (resumed.settled) {
+				assert.equal(resumed.value.ok, false);
+				assert.equal(resumed.value.error?.type, "runtime_error");
+			}
+			assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+			await rm(lockPath, { recursive: true, force: true });
+
+			const retried = await resumeToolRequest({
+				token: first.requiresInput.resumeToken,
+				response: { decision: "approve" },
+				ctx: { cwd: dir, env },
+			});
+			assert.equal(retried.status, "ok");
+		}
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow pipeline input resume restores its capability before execution starts", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-pipeline-safe-input-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const filePath = join(dir, "workflow.lobster");
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "review", pipeline: "ask --prompt Review?" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+		const payload = decodeResumeToken(first.requiresInput.resumeToken);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const originalUnlink = fsp.unlink;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				const result = await originalUnlink(filePath);
+				if (String(filePath) === statePath && !controller.signal.aborted) {
+					controller.abort(new Error("abort after safe workflow pipeline input cleanup"));
+				}
+				return result;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				token: first.requiresInput.resumeToken,
+				response: { decision: "approve" },
+				ctx: { cwd: dir, env, signal: controller.signal },
+			});
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(await fileExists(statePath), true);
+
+		const retried = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { decision: "approve" },
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "ok");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("pre-aborted workflow approval resume remains retryable", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-workflow-resume-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { access, chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -605,7 +606,9 @@ test("parent cancellation terminates the gog process tree and skips Gmail sends"
 		assert.equal(immediate.settled, false, "workflow must wait for the child to exit");
 		assert.equal(observed.settled, true, "workflow should settle promptly after parent abort");
 		assertCancellationEnvelope(envelope);
-		await waitForFile(searchTerminated, 500);
+		if (process.platform !== "win32") {
+			await waitForFile(searchTerminated, 500);
+		}
 		await new Promise((resolve) => setTimeout(resolve, 700));
 		assert.equal(processIsRunning(childPid), false);
 		assert.equal(
@@ -613,7 +616,9 @@ test("parent cancellation terminates the gog process tree and skips Gmail sends"
 			false,
 			"cancellation must kill child processes too",
 		);
-		assert.equal(await fileExists(searchTerminated), true);
+		if (process.platform !== "win32") {
+			assert.equal(await fileExists(searchTerminated), true);
+		}
 		assert.equal(await fileExists(searchCompleted), false);
 		assert.equal(
 			await fileExists(descendantCompleted),
@@ -725,6 +730,47 @@ test("cancellation during eager stage cleanup stops the next tool stage", async 
 	assert.equal(controller.signal.aborted, true);
 	assertCancellationEnvelope(envelope);
 	assert.equal(downstreamStarted, false, "cleanup cancellation must stop the next stage");
+});
+
+test("process-tree escalation survives a short-lived caller", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-short-lived-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const runner = join(repoRoot, "dist", "src", "abortable_process.js");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const wrapper = join(repoRoot, "test", "fixtures", "abortable-process-short-lived.mjs");
+		const childStarted = join(dir, "search-started");
+		const descendantStarted = join(dir, "descendant-started");
+		const descendantCompleted = join(dir, "descendant-completed");
+		const child = spawn(process.execPath, [wrapper, runner, mockGog], {
+			env: {
+				...process.env,
+				MOCK_GOG_SEARCH_STARTED_FILE: childStarted,
+				MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+				MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+				MOCK_GOG_TERMINATION_DELAY_MS: "0",
+				MOCK_GOG_COMPLETION_DELAY_MS: "5000",
+			},
+			stdio: "inherit",
+		});
+		const exitCode = await new Promise<number | null>((resolve, reject) => {
+			child.once("error", reject);
+			child.once("exit", resolve);
+		});
+
+		assert.equal(exitCode, 0, "the caller should settle cancellation before it exits");
+		await waitForFile(descendantStarted);
+		const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+		await new Promise((resolve) => setTimeout(resolve, 900));
+		assert.equal(processIsRunning(descendantPid), false);
+		assert.equal(
+			await fileExists(descendantCompleted),
+			false,
+			"a descendant must not outlive a caller that exits after cancellation",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
 });
 
 test("an in-flight gog.gmail.send completes and halts the pipeline after cancellation", async () => {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -35,6 +35,22 @@ function streamOf(items: unknown[]) {
 	})();
 }
 
+test("explicit cancellation accepts legacy embedded workflow tokens", async () => {
+	const token = encodeToken({
+		protocolVersion: 1,
+		v: 1,
+		kind: "workflow-file",
+		filePath: "/legacy/workflow.lobster",
+		resumeAtIndex: 1,
+		steps: { gate: { id: "gate", approved: false } },
+		args: {},
+	});
+
+	const result = await resumeToolRequest({ token, cancel: true });
+	assert.equal(result.ok, true);
+	assert.equal(result.status, "cancelled");
+});
+
 test("runAbortableProcess preserves UTF-8 characters split across pipe chunks", async () => {
 	const result = await runAbortableProcess({
 		command: process.execPath,
@@ -5593,7 +5609,7 @@ test(
 				},
 			});
 
-			await waitForFile(started, 5000);
+			await waitForFile(started, 15_000);
 			const childPid = Number(await readFile(started, "utf8"));
 			controller.abort();
 			const immediate = await observeSettlement(run, 50);

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1245,6 +1245,17 @@ test("pipeline approval resume restores its original capability after next-appro
 		}
 		assertCancellationEnvelope(aborted!);
 		assert.equal(previousStateClaimed, true);
+		const stateFilesAfterAbort = await listStateFiles(stateDir);
+		assert.equal(
+			stateFilesAfterAbort.filter((name) => name.startsWith("pipeline_resume_")).length,
+			1,
+			"cancellation must discard the unpublished next approval state",
+		);
+		assert.equal(
+			stateFilesAfterAbort.filter((name) => name.startsWith("approval_")).length,
+			1,
+			"cancellation must discard the unpublished next approval index",
+		);
 
 		const retried = await resumeToolRequest({
 			approvalId: first.requiresApproval.approvalId,
@@ -1304,6 +1315,17 @@ test("pipeline approval resume restores its original capability after next-input
 		}
 		assertCancellationEnvelope(aborted!);
 		assert.equal(previousStateClaimed, true);
+		const stateFilesAfterAbort = await listStateFiles(stateDir);
+		assert.equal(
+			stateFilesAfterAbort.filter((name) => name.startsWith("pipeline_resume_")).length,
+			1,
+			"cancellation must discard the unpublished next input state",
+		);
+		assert.equal(
+			stateFilesAfterAbort.filter((name) => name.startsWith("approval_")).length,
+			1,
+			"cancellation must discard the unpublished next input index",
+		);
 
 		const retried = await resumeToolRequest({
 			approvalId: first.requiresApproval.approvalId,

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -763,6 +763,157 @@ test("workflow approval resume remains retryable when cancellation creates its n
 	}
 });
 
+test("workflow approval resume restores its original capability after next-input cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-input-gate-cleanup-abort-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{ id: "answer", input: { prompt: "Continue?", responseSchema: { type: "object" } } },
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 5) {
+					controller.abort(new Error("abort after next-input state replaced the approval state"));
+				}
+				throwIfAborted();
+			},
+		});
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(signalChecks, 5);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "needs_input");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow approval resume restores its original capability after next-approval cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-approval-gate-cleanup-abort-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "first", approval: "Continue?" },
+					{ id: "second", approval: "Confirm again?" },
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 6) {
+					controller.abort(
+						new Error("abort after next-approval state replaced the approval state"),
+					);
+				}
+				throwIfAborted();
+			},
+		});
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(signalChecks, 6);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.status, "needs_approval");
+		assert.equal(retried.requiresApproval?.prompt, "Confirm again?");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("terminal workflow approval resume restores its original capability when cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-terminal-cleanup-abort-workflow-resume-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		await writeFile(
+			filePath,
+			JSON.stringify({ steps: [{ id: "confirm", approval: "Continue?" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		const signal = controller.signal;
+		const throwIfAborted = signal.throwIfAborted.bind(signal);
+		let signalChecks = 0;
+		Object.defineProperty(signal, "throwIfAborted", {
+			value() {
+				signalChecks += 1;
+				if (signalChecks === 2) {
+					controller.abort(new Error("abort during terminal workflow resume cleanup"));
+				}
+				throwIfAborted();
+			},
+		});
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, signal, env },
+		});
+		assertCancellationEnvelope(aborted);
+		assert.equal(signalChecks, 2);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.ok, true);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("cancellation while draining terminal lazy output returns cancellation", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -4016,6 +4016,79 @@ test("a cancellation immediately after pipeline resume consumption restores the 
 	}
 });
 
+test("resumed pipeline and workflow approvals retain their short ID until the started invocation settles", async () => {
+	for (const workflow of [false, true]) {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-approval-index-dispatch-boundary-"));
+		let releaseEffect!: () => void;
+		const effectReleased = new Promise<void>((resolve) => {
+			releaseEffect = resolve;
+		});
+		let effectStarted!: () => void;
+		const effectEntered = new Promise<void>((resolve) => {
+			effectStarted = resolve;
+		});
+		const effect = {
+			name: "test.hold-before-terminal-cleanup",
+			async run() {
+				effectStarted();
+				await effectReleased;
+				return { output: streamOf([{ ok: true }]) };
+			},
+		};
+		try {
+			const stateDir = join(dir, "state");
+			const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+			const registry = withCommands(createDefaultRegistry(), effect);
+			let first;
+			let filePath: string | undefined;
+			if (workflow) {
+				filePath = join(dir, "workflow.lobster");
+				await writeFile(
+					filePath,
+					JSON.stringify({
+						steps: [
+							{ id: "confirm", approval: "Continue?" },
+							{ id: "effect", pipeline: "test.hold-before-terminal-cleanup" },
+						],
+					}),
+					"utf8",
+				);
+				first = await runToolRequest({ filePath, ctx: { cwd: dir, env, registry } });
+			} else {
+				first = await runToolRequest({
+					pipeline: "approve --prompt Continue? | test.hold-before-terminal-cleanup",
+					ctx: { cwd: dir, env, registry },
+				});
+			}
+			assert.equal(first.status, "needs_approval");
+			assert.ok(first.requiresApproval?.approvalId);
+			const approvalIndexPath = join(
+				stateDir,
+				`approval_${first.requiresApproval.approvalId}.json`,
+			);
+
+			const resumed = resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { cwd: dir, env, registry },
+			});
+			await effectEntered;
+			assert.equal(
+				await fileExists(approvalIndexPath),
+				true,
+				"the short approval ID must survive until the resumed invocation reaches a terminal outcome",
+			);
+			releaseEffect();
+			const settled = await resumed;
+			assert.equal(settled.status, "ok");
+			assert.equal(await fileExists(approvalIndexPath), false);
+		} finally {
+			releaseEffect();
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+});
+
 test("approval rejection stops waiting for a state lock without orphaning its approval ID", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-approval-rejection-lock-abort-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1593,13 +1593,13 @@ test("cancellable lazy output releases a pending read before cancellation return
 		async run() {
 			return {
 				output: {
-					abort() {
-						abortCalled = true;
-						if (timer) clearTimeout(timer);
-						resolveNext({ done: true, value: undefined });
-					},
 					[Symbol.asyncIterator]() {
 						return {
+							abort() {
+								abortCalled = true;
+								if (timer) clearTimeout(timer);
+								resolveNext({ done: true, value: undefined });
+							},
 							next() {
 								readStarted();
 								return new Promise<IteratorResult<unknown>>((resolve) => {
@@ -3059,6 +3059,70 @@ test("explicit cancellation consumes an aliased workflow resume state", async ()
 		});
 		assert.equal(replayByToken.ok, false);
 		assert.match(replayByToken.error?.message ?? "", /Workflow resume state not found/);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("explicit cancellation stops waiting for a state lock without orphaning its approval ID", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-explicit-cancel-lock-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: "approve --prompt Continue?",
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(stateDir, payload.stateKey)}.lock`;
+		const approvalIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		const pending = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			cancel: true,
+			ctx: { cwd: dir, env, signal: controller.signal },
+		});
+		const completion = pending.then(
+			() => ({ kind: "success" as const }),
+			(error) => ({ kind: "error" as const, error }),
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+		controller.abort(new Error("explicit cancellation stopped while waiting for a state lock"));
+		const early = await Promise.race([
+			completion,
+			new Promise<{ kind: "timeout" }>((resolve) =>
+				setTimeout(() => resolve({ kind: "timeout" }), 75),
+			),
+		]);
+		if (early.kind === "timeout") await rm(lockPath, { recursive: true, force: true });
+		const settled = early.kind === "timeout" ? await completion : early;
+
+		assert.notEqual(
+			early.kind,
+			"timeout",
+			"explicit cancellation must not remain blocked on a state lock",
+		);
+		assert.equal(settled.kind, "error");
+		if (settled.kind === "error") {
+			assert.match(
+				settled.error?.message ?? "",
+				/explicit cancellation stopped while waiting for a state lock/,
+			);
+		}
+		assert.equal(
+			await fileExists(approvalIndexPath),
+			true,
+			"the approval ID must remain usable after cancellation",
+		);
+		assert.equal(await fileExists(keyToPath(stateDir, payload.stateKey)), true);
+		await rm(lockPath, { recursive: true, force: true });
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1173,16 +1173,16 @@ test("pipeline approval resume restores its original capability after next-appro
 		const previousStatePath = keyToPath(stateDir, payload.stateKey);
 
 		const controller = new AbortController();
-		const originalUnlink = fsp.unlink;
-		let previousStateDeleted = false;
-		Object.defineProperty(fsp, "unlink", {
+		const originalRename = fsp.rename;
+		let previousStateClaimed = false;
+		Object.defineProperty(fsp, "rename", {
 			configurable: true,
 			writable: true,
-			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
-				const result = await originalUnlink(filePath);
-				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
-					previousStateDeleted = true;
-					controller.abort(new Error("abort after previous pipeline approval state deletion"));
+			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+				const result = await originalRename(from, to);
+				if (String(to) === previousStatePath && !controller.signal.aborted) {
+					previousStateClaimed = true;
+					controller.abort(new Error("abort after previous pipeline approval state claim"));
 				}
 				return result;
 			},
@@ -1195,14 +1195,14 @@ test("pipeline approval resume restores its original capability after next-appro
 				ctx: { env, signal: controller.signal },
 			});
 		} finally {
-			Object.defineProperty(fsp, "unlink", {
+			Object.defineProperty(fsp, "rename", {
 				configurable: true,
 				writable: true,
-				value: originalUnlink,
+				value: originalRename,
 			});
 		}
 		assertCancellationEnvelope(aborted!);
-		assert.equal(previousStateDeleted, true);
+		assert.equal(previousStateClaimed, true);
 
 		const retried = await resumeToolRequest({
 			approvalId: first.requiresApproval.approvalId,
@@ -1232,16 +1232,16 @@ test("pipeline approval resume restores its original capability after next-input
 		const previousStatePath = keyToPath(stateDir, payload.stateKey);
 
 		const controller = new AbortController();
-		const originalUnlink = fsp.unlink;
-		let previousStateDeleted = false;
-		Object.defineProperty(fsp, "unlink", {
+		const originalRename = fsp.rename;
+		let previousStateClaimed = false;
+		Object.defineProperty(fsp, "rename", {
 			configurable: true,
 			writable: true,
-			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
-				const result = await originalUnlink(filePath);
-				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
-					previousStateDeleted = true;
-					controller.abort(new Error("abort after previous pipeline input state deletion"));
+			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+				const result = await originalRename(from, to);
+				if (String(to) === previousStatePath && !controller.signal.aborted) {
+					previousStateClaimed = true;
+					controller.abort(new Error("abort after previous pipeline input state claim"));
 				}
 				return result;
 			},
@@ -1254,14 +1254,14 @@ test("pipeline approval resume restores its original capability after next-input
 				ctx: { env, signal: controller.signal },
 			});
 		} finally {
-			Object.defineProperty(fsp, "unlink", {
+			Object.defineProperty(fsp, "rename", {
 				configurable: true,
 				writable: true,
-				value: originalUnlink,
+				value: originalRename,
 			});
 		}
 		assertCancellationEnvelope(aborted!);
-		assert.equal(previousStateDeleted, true);
+		assert.equal(previousStateClaimed, true);
 
 		const retried = await resumeToolRequest({
 			approvalId: first.requiresApproval.approvalId,
@@ -1285,11 +1285,16 @@ test("pipeline cancellation after side effects does not restore the consumed app
 			name: "test.side-effect-then-input",
 			async run({ ctx }: any) {
 				sideEffects += 1;
-				await ctx.requestInput({
-					prompt: "Second?",
-					responseSchema: { type: "object" },
-				});
-				return { output: streamOf([]) };
+				try {
+					await ctx.requestInput({
+						prompt: "Second?",
+						responseSchema: { type: "object" },
+					});
+					return { output: streamOf([]) };
+				} catch (err) {
+					controller.abort(new Error("abort after side-effecting pipeline state claim"));
+					throw err;
+				}
 			},
 		};
 		const registry = withCommands(createDefaultRegistry(), sideEffectThenInput);
@@ -1300,36 +1305,12 @@ test("pipeline cancellation after side effects does not restore the consumed app
 		assert.equal(first.status, "needs_approval");
 		assert.ok(first.requiresApproval?.approvalId);
 		assert.ok(first.requiresApproval?.resumeToken);
-		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
-		const previousStatePath = keyToPath(stateDir, payload.stateKey);
-
 		const controller = new AbortController();
-		const originalUnlink = fsp.unlink;
-		Object.defineProperty(fsp, "unlink", {
-			configurable: true,
-			writable: true,
-			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
-				const result = await originalUnlink(filePath);
-				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
-					controller.abort(new Error("abort after side-effecting pipeline state deletion"));
-				}
-				return result;
-			},
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env, registry, signal: controller.signal },
 		});
-		let aborted;
-		try {
-			aborted = await resumeToolRequest({
-				approvalId: first.requiresApproval.approvalId,
-				approved: true,
-				ctx: { env, registry, signal: controller.signal },
-			});
-		} finally {
-			Object.defineProperty(fsp, "unlink", {
-				configurable: true,
-				writable: true,
-				value: originalUnlink,
-			});
-		}
 		assertCancellationEnvelope(aborted!);
 		assert.equal(sideEffects, 1);
 
@@ -3736,6 +3717,97 @@ test("pipeline approval token and short ID each dispatch an effect at most once"
 test("workflow approval token and short ID each dispatch an effect at most once", async () => {
 	for (const resumeBy of ["token", "approvalId"] as const) {
 		await assertApprovalResumeIsExclusive({ workflow: true, resumeBy });
+	}
+});
+
+async function assertApprovalGateHandoffIsExclusive({
+	workflow,
+	resumeBy,
+}: {
+	workflow: boolean;
+	resumeBy: "token" | "approvalId";
+}) {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-exclusive-gate-handoff-"));
+	let invocations = 0;
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const effect = {
+			name: "test.exclusive-gate-handoff-effect",
+			async run() {
+				invocations += 1;
+				return { output: streamOf([{ ok: true }]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), effect);
+		let first;
+		if (workflow) {
+			const filePath = join(dir, "workflow.lobster");
+			await writeFile(
+				filePath,
+				JSON.stringify({
+					steps: [
+						{ id: "first", approval: "First?" },
+						{ id: "second", pipeline: "ask --prompt Second?" },
+						{ id: "effect", pipeline: "test.exclusive-gate-handoff-effect" },
+					],
+				}),
+				"utf8",
+			);
+			first = await runToolRequest({ filePath, ctx: { cwd: dir, env, registry } });
+		} else {
+			first = await runToolRequest({
+				pipeline:
+					"approve --prompt First? | ask --prompt Second? | test.exclusive-gate-handoff-effect",
+				ctx: { cwd: dir, env, registry },
+			});
+		}
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const resumeArgs =
+			resumeBy === "token"
+				? { token: first.requiresApproval.resumeToken! }
+				: { approvalId: first.requiresApproval.approvalId! };
+		const outcomes = await Promise.all([
+			resumeToolRequest({ ...resumeArgs, approved: true, ctx: { cwd: dir, env, registry } }),
+			resumeToolRequest({ ...resumeArgs, approved: true, ctx: { cwd: dir, env, registry } }),
+		]);
+
+		const successor = outcomes.find((outcome) => outcome.ok && outcome.status === "needs_input");
+		assert.ok(successor?.requiresInput?.resumeToken, "exactly one successor gate must be returned");
+		assert.equal(
+			outcomes.filter((outcome) => outcome.ok && outcome.status === "needs_input").length,
+			1,
+		);
+		assert.equal(outcomes.filter((outcome) => !outcome.ok).length, 1);
+		assert.match(
+			outcomes.find((outcome) => !outcome.ok)?.error?.message ?? "",
+			/resume state not found/i,
+		);
+
+		const completed = await resumeToolRequest({
+			token: successor!.requiresInput!.resumeToken!,
+			response: { decision: "approve" },
+			ctx: { cwd: dir, env, registry },
+		});
+		assert.equal(completed.ok, true);
+		assert.equal(completed.status, "ok");
+		assert.equal(invocations, 1, "only the winning successor may reach the effect");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+test("pipeline approval token and short ID cannot fork a next input gate", async () => {
+	for (const resumeBy of ["token", "approvalId"] as const) {
+		await assertApprovalGateHandoffIsExclusive({ workflow: false, resumeBy });
+	}
+});
+
+test("workflow approval token and short ID cannot fork a next input gate", async () => {
+	for (const resumeBy of ["token", "approvalId"] as const) {
+		await assertApprovalGateHandoffIsExclusive({ workflow: true, resumeBy });
 	}
 });
 

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -621,6 +621,67 @@ test("pipeline approval resume remains retryable when a resume-safe stage aborts
 	}
 });
 
+test("same-stage ask resume restores its token when cancellation wins before execution", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-same-stage-ask-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const sideEffect = createCountingSideEffect("test.same-stage-ask-side-effect");
+		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		const first = await runToolRequest({
+			pipeline: "ask --prompt First? | test.same-stage-ask-side-effect",
+			ctx: { env, registry },
+		});
+		assert.equal(first.status, "needs_input");
+		assert.ok(first.requiresInput?.resumeToken);
+		const payload = decodeResumeToken(first.requiresInput.resumeToken);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const originalUnlink = fsp.unlink;
+		let stateDeleted = false;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				const result = await originalUnlink(filePath);
+				if (String(filePath) === statePath && !controller.signal.aborted) {
+					stateDeleted = true;
+					controller.abort(new Error("abort after same-stage ask state cleanup"));
+				}
+				return result;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				token: first.requiresInput.resumeToken,
+				response: { decision: "approve" },
+				ctx: { env, registry, signal: controller.signal },
+			});
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(stateDeleted, true);
+		assert.equal(sideEffect.invocations, 0);
+
+		const retried = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { decision: "approve" },
+			ctx: { env, registry },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(sideEffect.invocations, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("pre-aborted workflow approval resume remains retryable", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-workflow-resume-"));
 	try {
@@ -1311,6 +1372,41 @@ test("cancellation observed before terminal drain is reported after output clean
 	assertCancellationEnvelope(envelope);
 	assert.equal(envelope.error?.message, "abort before terminal drain");
 	assert.equal(outputDrained, true, "terminal output cleanup must complete before cancellation");
+});
+
+test("cancellation before a non-terminal lazy handoff does not wait for its next item", async () => {
+	const controller = new AbortController();
+	const source = {
+		name: "test.abort-before-lazy-handoff",
+		async run() {
+			controller.abort(new Error("abort before lazy handoff"));
+			return {
+				output: {
+					[Symbol.asyncIterator]() {
+						return {
+							next: () => new Promise<IteratorResult<unknown>>(() => {}),
+							async return() {
+								return { done: true, value: undefined };
+							},
+						};
+					},
+				},
+			};
+		},
+	};
+
+	const settled = await observeSettlement(
+		runToolRequest({
+			pipeline: "test.abort-before-lazy-handoff | test.unreached",
+			ctx: {
+				registry: withCommands(createDefaultRegistry(), source),
+				signal: controller.signal,
+			},
+		}),
+		500,
+	);
+	assert.equal(settled.settled, true, "cancellation must not wait for the stalled lazy handoff");
+	if (settled.settled) assertCancellationEnvelope(settled.value);
 });
 
 test("cancellation during lazy handoff stops yielding items to the downstream stage", async () => {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -573,6 +573,54 @@ test("pre-aborted pipeline input resume remains retryable", async () => {
 	}
 });
 
+test("pipeline approval resume remains retryable when a resume-safe stage aborts before input", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-safe-input-setup-abort-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const controller = new AbortController();
+		let abortBeforeInput = true;
+		const safeInput = {
+			name: "test.resume-safe-before-input",
+			meta: { resumeSafeBeforeInput: true },
+			async run({ ctx }: any) {
+				if (abortBeforeInput) {
+					abortBeforeInput = false;
+					controller.abort(new Error("abort before resume-safe input"));
+				}
+				await ctx.requestInput({
+					prompt: "Second?",
+					responseSchema: { type: "object" },
+				});
+				return { output: [] };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), safeInput);
+		const first = await runToolRequest({
+			pipeline: "approve --prompt First? | test.resume-safe-before-input",
+			ctx: { env, registry },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const aborted = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env, registry, signal: controller.signal },
+		});
+		assertCancellationEnvelope(aborted);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env, registry },
+		});
+		assert.equal(retried.status, "needs_input");
+		assert.equal(retried.requiresInput?.prompt, "Second?");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("pre-aborted workflow approval resume remains retryable", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-workflow-resume-"));
 	try {
@@ -1067,6 +1115,40 @@ test("workflow approval resume restores its original capability after next-input
 			ctx: { cwd: dir, env },
 		});
 		assert.equal(retried.status, "needs_input");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow gate replacement retires the superseded approval index", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-gate-index-retirement-"));
+	try {
+		const filePath = join(dir, "workflow.lobster");
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{ id: "answer", input: { prompt: "Second?", responseSchema: { type: "object" } } },
+				],
+			}),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		const oldIndexPath = join(stateDir, `approval_${first.requiresApproval.approvalId}.json`);
+		assert.equal(await fileExists(oldIndexPath), true);
+
+		const resumed = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(resumed.status, "needs_input");
+		assert.equal(await fileExists(oldIndexPath), false);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { promises as fsp, readFileSync } from "node:fs";
 import {
 	access,
 	chmod,
@@ -758,6 +758,193 @@ test("workflow approval resume remains retryable when cancellation creates its n
 			ctx: { cwd: dir, env },
 		});
 		assert.equal(retried.status, "needs_input");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("workflow approval resume remains retryable when child workflow setup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-child-setup-abort-workflow-resume-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const parentPath = join(dir, "parent.lobster");
+		const childPath = join(dir, "child.lobster");
+		await writeFile(
+			parentPath,
+			JSON.stringify({
+				steps: [
+					{ id: "confirm", approval: "Continue?" },
+					{ id: "child", workflow: "child.lobster" },
+				],
+			}),
+			"utf8",
+		);
+		await writeFile(
+			childPath,
+			JSON.stringify({ steps: [{ id: "child-step", run: "true" }] }),
+			"utf8",
+		);
+		const first = await runToolRequest({ filePath: parentPath, ctx: { cwd: dir, env } });
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+
+		const controller = new AbortController();
+		const originalRealpath = fsp.realpath;
+		let childSetupObserved = false;
+		Object.defineProperty(fsp, "realpath", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.realpath>[0]) {
+				const resolved = await originalRealpath(filePath);
+				if (String(filePath) === childPath && !controller.signal.aborted) {
+					childSetupObserved = true;
+					controller.abort(new Error("abort during child workflow setup"));
+				}
+				return resolved;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { cwd: dir, signal: controller.signal, env },
+			});
+		} finally {
+			Object.defineProperty(fsp, "realpath", {
+				configurable: true,
+				writable: true,
+				value: originalRealpath,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(childSetupObserved, true);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { cwd: dir, env },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(retried.status, "ok");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pipeline approval resume restores its original capability after next-approval cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pipeline-approval-cleanup-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: "approve --prompt First? | approve --prompt Second?",
+			ctx: { env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const previousStatePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const originalUnlink = fsp.unlink;
+		let previousStateDeleted = false;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				const result = await originalUnlink(filePath);
+				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
+					previousStateDeleted = true;
+					controller.abort(new Error("abort after previous pipeline approval state deletion"));
+				}
+				return result;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { env, signal: controller.signal },
+			});
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(previousStateDeleted, true);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env },
+		});
+		assert.equal(retried.status, "needs_approval");
+		assert.equal(retried.requiresApproval?.prompt, "Second?");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("pipeline approval resume restores its original capability after next-input cleanup is cancelled", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pipeline-input-cleanup-abort-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runToolRequest({
+			pipeline: `approve --prompt First? | ask --emit --prompt Second? --schema '${JSON.stringify({ type: "object" })}'`,
+			ctx: { env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const previousStatePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const originalUnlink = fsp.unlink;
+		let previousStateDeleted = false;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				const result = await originalUnlink(filePath);
+				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
+					previousStateDeleted = true;
+					controller.abort(new Error("abort after previous pipeline input state deletion"));
+				}
+				return result;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { env, signal: controller.signal },
+			});
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(previousStateDeleted, true);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env },
+		});
+		assert.equal(retried.status, "needs_input");
+		assert.equal(retried.requiresInput?.prompt, "Second?");
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1583,7 +1583,7 @@ test("cancellable lazy output releases a pending read before cancellation return
 	}
 });
 
-test("native lazy generators finish their pending cleanup before cancellation returns", async () => {
+test("a permanently stalled native lazy generator does not block cancellation", async () => {
 	const controller = new AbortController();
 	let readStarted!: () => void;
 	const pendingReadStarted = new Promise<void>((resolve) => {
@@ -1597,7 +1597,7 @@ test("native lazy generators finish their pending cleanup before cancellation re
 				output: (async function* () {
 					try {
 						readStarted();
-						await new Promise((resolve) => setTimeout(resolve, 25));
+						await new Promise<void>(() => {});
 					} finally {
 						sourceClosed = true;
 					}
@@ -1625,12 +1625,12 @@ test("native lazy generators finish their pending cleanup before cancellation re
 	await pendingReadStarted;
 	controller.abort(new Error("abort native lazy output"));
 	const settled = await observeSettlement(run, 500);
-	assert.equal(settled.settled, true, "cancellation must wait for native generator cleanup");
+	assert.equal(settled.settled, true, "cancellation must not wait for native generator cleanup");
 	if (settled.settled) assertCancellationEnvelope(settled.value);
 	assert.equal(
 		sourceClosed,
-		true,
-		"native generator cleanup must finish before cancellation returns",
+		false,
+		"a native generator without an abort hook cannot guarantee prompt cleanup",
 	);
 });
 

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -598,6 +598,46 @@ test("pre-aborted pipeline approval resume remains retryable", async () => {
 	}
 });
 
+test("pre-aborted pipeline resume does not wait for a live state lock", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-resume-live-lock-"));
+	try {
+		const env = { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") };
+		const source = {
+			name: "test.pre-abort-live-lock-source",
+			async run() {
+				return { output: streamOf([{ value: 1 }]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), source);
+		const first = await runToolRequest({
+			pipeline: "test.pre-abort-live-lock-source | approve --prompt Continue?",
+			ctx: { registry, env },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const lockPath = `${keyToPath(env.LOBSTER_STATE_DIR!, payload.stateKey)}.lock`;
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+		const controller = new AbortController();
+		controller.abort(new Error("pre-aborted state lock resume"));
+		const pending = resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { registry, signal: controller.signal, env },
+		});
+		const early = await observeSettlement(pending, 75);
+		if (!early.settled) await fsp.rm(lockPath, { recursive: true, force: true });
+		const envelope = early.settled ? early.value : await pending;
+
+		assert.equal(early.settled, true, "a pre-aborted resume must not wait for a live state lock");
+		assertCancellationEnvelope(envelope);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("pre-aborted pipeline input resume remains retryable", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-pre-abort-input-resume-"));
 	try {
@@ -2454,6 +2494,97 @@ test("exec cancellation terminates descendant processes", async () => {
 	}
 });
 
+test("a configured workflow timeout preserves SIGTERM for external cancellation", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-timeout-external-cancel-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const workflow = join(dir, "workflow.lobster");
+		const started = join(dir, "started");
+		const terminated = join(dir, "terminated");
+		const command = [process.execPath, mockGog, "gmail", "search"]
+			.map((arg) => JSON.stringify(arg))
+			.join(" ");
+		await writeFile(
+			workflow,
+			JSON.stringify({ steps: [{ id: "waiting", run: command, timeout_ms: 10_000 }] }),
+			"utf8",
+		);
+
+		const controller = new AbortController();
+		const run = runToolRequest({
+			filePath: workflow,
+			ctx: {
+				cwd: dir,
+				env: {
+					...process.env,
+					MOCK_GOG_SEARCH_STARTED_FILE: started,
+					MOCK_GOG_SEARCH_TERMINATED_FILE: terminated,
+					MOCK_GOG_TERMINATION_DELAY_MS: "20",
+				},
+				signal: controller.signal,
+			},
+		});
+		await waitForFile(started, 5000);
+		controller.abort(new Error("external abort"));
+		assertCancellationEnvelope(await run);
+		await waitForFile(terminated, 500);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("parallel wait:any preserves SIGTERM for a loser when a timeout is merely configured", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-parallel-any-graceful-cancel-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const workflow = join(dir, "workflow.lobster");
+		const loserStarted = join(dir, "loser-started");
+		const loserTerminated = join(dir, "loser-terminated");
+		const loser = [process.execPath, mockGog, "gmail", "search"]
+			.map((arg) => JSON.stringify(arg))
+			.join(" ");
+		const winner = `while [ ! -f ${JSON.stringify(loserStarted)} ]; do sleep 0.01; done; printf winner`;
+		await writeFile(
+			workflow,
+			JSON.stringify({
+				steps: [
+					{
+						id: "parallel",
+						parallel: {
+							wait: "any",
+							timeout_ms: 10_000,
+							branches: [
+								{ id: "loser", run: loser },
+								{ id: "winner", run: winner },
+							],
+						},
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		const result = await runToolRequest({
+			filePath: workflow,
+			ctx: {
+				cwd: dir,
+				env: {
+					...process.env,
+					MOCK_GOG_SEARCH_STARTED_FILE: loserStarted,
+					MOCK_GOG_SEARCH_TERMINATED_FILE: loserTerminated,
+					MOCK_GOG_TERMINATION_DELAY_MS: "20",
+				},
+			},
+		});
+		assert.equal(result.ok, true, JSON.stringify(result));
+		await waitForFile(loserTerminated, 500);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test(
 	"CLI SIGINT terminates a detached workflow process tree before exiting",
 	{ skip: process.platform === "win32" },
@@ -2509,6 +2640,122 @@ test(
 			);
 		} finally {
 			cli?.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"CLI SIGHUP terminates a detached workflow process tree before exiting",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sighup-process-tree-"));
+		let cli: ReturnType<typeof spawn> | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+			const workflow = join(dir, "workflow.lobster");
+			const searchStarted = join(dir, "search-started");
+			const descendantStarted = join(dir, "descendant-started");
+			const descendantCompleted = join(dir, "descendant-completed");
+			const command = [process.execPath, mockGog, "gmail", "search"]
+				.map((arg) => JSON.stringify(arg))
+				.join(" ");
+			await writeFile(workflow, JSON.stringify({ steps: [{ id: "shell", run: command }] }), "utf8");
+
+			cli = spawn(
+				process.execPath,
+				[join(repoRoot, "bin", "lobster.js"), "run", "--file", workflow],
+				{
+					cwd: dir,
+					env: {
+						...process.env,
+						MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+						MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+						MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+						MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+					},
+					stdio: "ignore",
+				},
+			);
+			await waitForFile(searchStarted, 5000);
+			await waitForFile(descendantStarted, 5000);
+			const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+			assert.equal(cli.kill("SIGHUP"), true);
+			const exited = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+				(resolve, reject) => {
+					cli!.once("error", reject);
+					cli!.once("exit", (code, signal) => resolve({ code, signal }));
+				},
+			);
+
+			assert.equal(exited.signal, null);
+			assert.equal(exited.code, 129, "CLI must retain the conventional SIGHUP exit status");
+			await new Promise((resolve) => setTimeout(resolve, 900));
+			assert.equal(processIsRunning(descendantPid), false);
+			assert.equal(
+				await fileExists(descendantCompleted),
+				false,
+				"a detached workflow descendant must not finish after terminal hangup",
+			);
+		} finally {
+			cli?.kill("SIGKILL");
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);
+
+test(
+	"a second CLI SIGINT immediately force-terminates a detached workflow process tree",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-second-sigint-process-tree-"));
+		let cli: ReturnType<typeof spawn> | undefined;
+		let descendantPid: number | undefined;
+		try {
+			const repoRoot = join(__dirname, "..", "..");
+			const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+			const workflow = join(dir, "workflow.lobster");
+			const searchStarted = join(dir, "search-started");
+			const searchTerminated = join(dir, "search-terminated");
+			const descendantStarted = join(dir, "descendant-started");
+			const descendantCompleted = join(dir, "descendant-completed");
+			const command = [process.execPath, mockGog, "gmail", "search"]
+				.map((arg) => JSON.stringify(arg))
+				.join(" ");
+			await writeFile(workflow, JSON.stringify({ steps: [{ id: "shell", run: command }] }), "utf8");
+
+			cli = spawn(
+				process.execPath,
+				[join(repoRoot, "bin", "lobster.js"), "run", "--file", workflow],
+				{
+					cwd: dir,
+					env: {
+						...process.env,
+						MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+						MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
+						MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+						MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+						MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+					},
+					stdio: "ignore",
+				},
+			);
+			await waitForFile(searchStarted, 5000);
+			await waitForFile(descendantStarted, 5000);
+			descendantPid = Number(await readFile(descendantStarted, "utf8"));
+			assert.equal(cli.kill("SIGINT"), true);
+			await waitForFile(searchTerminated, 5000);
+			assert.equal(cli.kill("SIGINT"), true);
+			await new Promise((resolve) => setTimeout(resolve, 75));
+			assert.equal(
+				processIsRunning(descendantPid),
+				false,
+				"a second interrupt must not wait for the graceful termination window",
+			);
+		} finally {
+			cli?.kill("SIGKILL");
+			if (descendantPid && processIsRunning(descendantPid)) process.kill(descendantPid, "SIGKILL");
 			await rm(dir, { recursive: true, force: true });
 		}
 	},

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { access, chmod, copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -49,6 +50,13 @@ async function observeSettlement<T>(promise: Promise<T>, timeoutMs: number) {
 }
 
 function processIsRunning(pid: number) {
+	try {
+		const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+		const state = stat.slice(stat.lastIndexOf(")") + 2, stat.lastIndexOf(")") + 3);
+		if (state === "Z") return false;
+	} catch {
+		// /proc is unavailable on Windows and the process may already be reaped.
+	}
 	try {
 		process.kill(pid, 0);
 		return true;
@@ -552,7 +560,7 @@ test("cancellation while draining lazy input prevents a downstream OpenClaw call
 	}
 });
 
-test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send", async () => {
+test("parent cancellation terminates the gog process tree and skips Gmail sends", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-search-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -560,6 +568,8 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 		const searchStarted = join(dir, "search-started");
 		const searchTerminated = join(dir, "search-terminated");
 		const searchCompleted = join(dir, "search-completed");
+		const descendantStarted = join(dir, "descendant-started");
+		const descendantCompleted = join(dir, "descendant-completed");
 		const sendStarted = join(dir, "send-started");
 		const sendCompleted = join(dir, "send-completed");
 		const controller = new AbortController();
@@ -573,6 +583,8 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 					MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
 					MOCK_GOG_SEARCH_TERMINATED_FILE: searchTerminated,
 					MOCK_GOG_SEARCH_COMPLETED_FILE: searchCompleted,
+					MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+					MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
 					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
 					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
 					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
@@ -581,7 +593,9 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 		});
 
 		await waitForFile(searchStarted);
+		await waitForFile(descendantStarted);
 		const childPid = Number(await readFile(searchStarted, "utf8"));
+		const descendantPid = Number(await readFile(descendantStarted, "utf8"));
 		const abortedAt = Date.now();
 		controller.abort();
 		const immediate = await observeSettlement(run, 50);
@@ -592,9 +606,20 @@ test("parent cancellation terminates gog.gmail.search and skips gog.gmail.send",
 		assert.equal(observed.settled, true, "workflow should settle promptly after parent abort");
 		assertCancellationEnvelope(envelope);
 		await waitForFile(searchTerminated, 500);
+		await new Promise((resolve) => setTimeout(resolve, 700));
 		assert.equal(processIsRunning(childPid), false);
+		assert.equal(
+			processIsRunning(descendantPid),
+			false,
+			"cancellation must kill child processes too",
+		);
 		assert.equal(await fileExists(searchTerminated), true);
 		assert.equal(await fileExists(searchCompleted), false);
+		assert.equal(
+			await fileExists(descendantCompleted),
+			false,
+			"descendants must not continue after abort",
+		);
 		assert.equal(await fileExists(sendStarted), false);
 		assert.equal(await fileExists(sendCompleted), false);
 		if (observed.settled) assert.ok(observed.settledAt - abortedAt < 500);

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -15,11 +15,13 @@ import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { PassThrough } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
 import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
 import { decodeResumeToken } from "../src/resume.js";
+import { runPipeline } from "../src/runtime.js";
 import { keyToPath } from "../src/state/store.js";
 import { encodeToken } from "../src/token.js";
 
@@ -59,21 +61,49 @@ async function waitForFile(path: string, timeoutMs = 2000) {
 	throw new Error(`Timed out waiting for ${path}`);
 }
 
+async function waitForChildProcess(parentPid: number, timeoutMs = 5000) {
+	const childrenPath = `/proc/${parentPid}/task/${parentPid}/children`;
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const children = (await readFile(childrenPath, "utf8"))
+				.trim()
+				.split(/\s+/)
+				.map(Number)
+				.filter(Number.isInteger);
+			if (children.length === 1) return children[0];
+		} catch {
+			// The pseudo-terminal process may not have spawned the CLI yet.
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for a child process of ${parentPid}`);
+}
+
 function startLobsterCli({
 	args,
 	cwd,
 	env,
+	interactive = false,
 }: {
 	args: string[];
 	cwd: string;
 	env: NodeJS.ProcessEnv;
+	interactive?: boolean;
 }) {
 	const repoRoot = join(__dirname, "..", "..");
-	const child = spawn(process.execPath, [join(repoRoot, "bin", "lobster.js"), ...args], {
-		cwd,
-		env,
-		stdio: ["ignore", "pipe", "pipe"],
-	});
+	const entry = join(repoRoot, "bin", "lobster.js");
+	const shellQuote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+	const command = `exec ${[process.execPath, entry, ...args].map(shellQuote).join(" ")}`;
+	const child = spawn(
+		interactive ? "script" : process.execPath,
+		interactive ? ["-qefc", command, "/dev/null"] : [entry, ...args],
+		{
+			cwd,
+			env,
+			stdio: [interactive ? "pipe" : "ignore", "pipe", "pipe"],
+		},
+	);
 	let stdout = "";
 	let stderr = "";
 	child.stdout?.setEncoding("utf8");
@@ -93,7 +123,16 @@ function startLobsterCli({
 		child.once("error", reject);
 		child.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
 	});
-	return { child, result };
+	return { child, result, getStdout: () => stdout };
+}
+
+async function waitForCliOutput(getStdout: () => string, pattern: RegExp, timeoutMs = 5000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (pattern.test(getStdout())) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for CLI output matching ${pattern}`);
 }
 
 async function observeSettlement<T>(promise: Promise<T>, timeoutMs: number) {
@@ -1088,6 +1127,100 @@ test(
 			if (server.listening) {
 				await new Promise<void>((resolve) => server.close(() => resolve()));
 			}
+		}
+	},
+);
+
+test("interactive ctx.requestInput aborts its input read", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-request-input-abort-"));
+	try {
+		const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+		Object.defineProperty(stdin, "isTTY", { value: true });
+		const stdout = new PassThrough();
+		let promptSeen!: () => void;
+		const prompt = new Promise<void>((resolve) => {
+			promptSeen = resolve;
+		});
+		stdout.once("data", () => promptSeen());
+		const controller = new AbortController();
+		const choose = {
+			name: "test.interactive-input",
+			async run({ ctx }: any) {
+				await ctx.requestInput({
+					prompt: "Choose a value",
+					responseSchema: { type: "object" },
+				});
+				return { output: streamOf([]) };
+			},
+		};
+		const run = runPipeline({
+			pipeline: [{ name: "test.interactive-input", args: { _: [] } }],
+			registry: withCommands(createDefaultRegistry(), choose),
+			input: [],
+			stdin,
+			stdout,
+			stderr: new PassThrough(),
+			env: { ...process.env, LOBSTER_STATE_DIR: join(dir, "state") },
+			mode: "human",
+			signal: controller.signal,
+		});
+
+		await prompt;
+		controller.abort(new Error("input cancelled"));
+		await assert.rejects(run, /input cancelled/);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test(
+	"CLI SIGINT aborts interactive workflow input and approval prompts",
+	{ skip: process.platform !== "linux" },
+	async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lobster-cli-sigint-workflow-prompts-"));
+		try {
+			for (const scenario of [
+				{
+					name: "input",
+					prompt: /Enter JSON response:/,
+					workflow: {
+						steps: [
+							{
+								id: "answer",
+								input: { prompt: "Continue?", responseSchema: { type: "object" } },
+							},
+						],
+					},
+				},
+				{
+					name: "approval",
+					prompt: /Continue\? \[y\/N\]/,
+					workflow: { steps: [{ id: "approve", approval: "Continue?" }] },
+				},
+			]) {
+				const workflowPath = join(dir, `${scenario.name}.lobster`);
+				await writeFile(workflowPath, JSON.stringify(scenario.workflow), "utf8");
+				const cli = startLobsterCli({
+					args: ["run", "--mode", "human", "--file", workflowPath],
+					cwd: dir,
+					env: process.env,
+					interactive: true,
+				});
+				try {
+					await waitForCliOutput(cli.getStdout, scenario.prompt);
+					const cliPid = await waitForChildProcess(cli.child.pid!);
+					process.kill(cliPid, "SIGINT");
+					const exited = await observeSettlement(cli.result, 5000);
+					assert.equal(exited.settled, true, `${scenario.name} prompt must exit after one SIGINT`);
+					if (!exited.settled) continue;
+					assert.equal(exited.value.signal, null);
+					assert.equal(exited.value.code, 130);
+				} finally {
+					cli.child.kill("SIGKILL");
+				}
+			}
+		} finally {
+			await rm(dir, { recursive: true, force: true });
 		}
 	},
 );

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -651,47 +651,33 @@ test("same-stage ask resume restores its token when cancellation wins before exe
 		const stateDir = join(dir, "state");
 		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
 		const sideEffect = createCountingSideEffect("test.same-stage-ask-side-effect");
-		const registry = withCommands(createDefaultRegistry(), sideEffect.command);
+		let activeController: AbortController | undefined;
+		const inputGate = {
+			name: "test.same-stage-ask-gate",
+			meta: { resumeSafeBeforeInput: true, resumeSafeAfterInput: true },
+			async run({ ctx }: any) {
+				await ctx.requestInput({ prompt: "First?", responseSchema: { type: "object" } });
+				activeController?.abort(new Error("abort after same-stage input delivery"));
+				return { output: streamOf([]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), inputGate, sideEffect.command);
 		const first = await runToolRequest({
-			pipeline: "ask --prompt First? | test.same-stage-ask-side-effect",
+			pipeline: "test.same-stage-ask-gate | test.same-stage-ask-side-effect",
 			ctx: { env, registry },
 		});
 		assert.equal(first.status, "needs_input");
 		assert.ok(first.requiresInput?.resumeToken);
-		const payload = decodeResumeToken(first.requiresInput.resumeToken);
-		const statePath = keyToPath(stateDir, payload.stateKey);
 
 		const controller = new AbortController();
-		const originalUnlink = fsp.unlink;
-		let stateDeleted = false;
-		Object.defineProperty(fsp, "unlink", {
-			configurable: true,
-			writable: true,
-			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
-				const result = await originalUnlink(filePath);
-				if (String(filePath) === statePath && !controller.signal.aborted) {
-					stateDeleted = true;
-					controller.abort(new Error("abort after same-stage ask state cleanup"));
-				}
-				return result;
-			},
+		activeController = controller;
+		const aborted = await resumeToolRequest({
+			token: first.requiresInput.resumeToken,
+			response: { decision: "approve" },
+			ctx: { env, registry, signal: controller.signal },
 		});
-		let aborted;
-		try {
-			aborted = await resumeToolRequest({
-				token: first.requiresInput.resumeToken,
-				response: { decision: "approve" },
-				ctx: { env, registry, signal: controller.signal },
-			});
-		} finally {
-			Object.defineProperty(fsp, "unlink", {
-				configurable: true,
-				writable: true,
-				value: originalUnlink,
-			});
-		}
-		assertCancellationEnvelope(aborted!);
-		assert.equal(stateDeleted, true);
+		activeController = undefined;
+		assertCancellationEnvelope(aborted);
 		assert.equal(sideEffect.invocations, 0);
 
 		const retried = await resumeToolRequest({
@@ -3625,6 +3611,185 @@ test("a failed post-effect resume cleanup leaves a non-replayable pipeline tombs
 			configurable: true,
 			writable: true,
 			value: originalUnlink,
+		});
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function assertApprovalResumeIsExclusive({
+	workflow,
+	resumeBy,
+}: {
+	workflow: boolean;
+	resumeBy: "token" | "approvalId";
+}) {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-exclusive-resume-"));
+	const originalRename = fsp.rename;
+	let releaseFirstRename!: () => void;
+	const firstRenameReached = new Promise<void>((resolve) => {
+		releaseFirstRename = resolve;
+	});
+	let renamePaused = false;
+	let releaseFirstEffect!: () => void;
+	const firstEffectMayFinish = new Promise<void>((resolve) => {
+		releaseFirstEffect = resolve;
+	});
+	let invocations = 0;
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const effect = {
+			name: "test.exclusive-resume-effect",
+			async run({ input }: { input: AsyncIterable<unknown> }) {
+				invocations += 1;
+				const items = [];
+				for await (const item of input) items.push(item);
+				if (invocations === 1) await firstEffectMayFinish;
+				return { output: streamOf(items.length ? items : [{ ok: true }]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), effect);
+		let first;
+		if (workflow) {
+			const filePath = join(dir, "workflow.lobster");
+			await writeFile(
+				filePath,
+				JSON.stringify({
+					steps: [
+						{ id: "approve", approval: "Continue?" },
+						{ id: "effect", pipeline: "test.exclusive-resume-effect" },
+					],
+				}),
+				"utf8",
+			);
+			first = await runToolRequest({ filePath, ctx: { cwd: dir, env, registry } });
+		} else {
+			first = await runToolRequest({
+				pipeline: "approve --prompt Continue? | test.exclusive-resume-effect",
+				ctx: { cwd: dir, env, registry },
+			});
+		}
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		assert.ok(first.requiresApproval?.approvalId);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken!);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+				if (String(to) === statePath && !renamePaused) {
+					renamePaused = true;
+					await firstRenameReached;
+				}
+				return originalRename(from, to);
+			},
+		});
+
+		const resumeArgs =
+			resumeBy === "token"
+				? { token: first.requiresApproval.resumeToken! }
+				: { approvalId: first.requiresApproval.approvalId! };
+		const firstResume = resumeToolRequest({
+			...resumeArgs,
+			approved: true,
+			ctx: { cwd: dir, env, registry },
+		});
+		while (!renamePaused) await new Promise((resolve) => setImmediate(resolve));
+		const secondResume = resumeToolRequest({
+			...resumeArgs,
+			approved: true,
+			ctx: { cwd: dir, env, registry },
+		});
+		releaseFirstRename();
+		// The first effect is held open. The second request has enough time to
+		// reach the guarded claim, but cannot be allowed to observe cleanup as a
+		// missing-state retry opportunity.
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		releaseFirstEffect();
+		const outcomes = await Promise.all([firstResume, secondResume]);
+
+		assert.equal(invocations, 1, "one approval may dispatch exactly one effect");
+		assert.equal(outcomes.filter((outcome) => outcome.ok).length, 1);
+		assert.equal(outcomes.filter((outcome) => !outcome.ok).length, 1);
+		assert.match(
+			outcomes.find((outcome) => !outcome.ok)?.error?.message ?? "",
+			/resume state not found/i,
+		);
+	} finally {
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			value: originalRename,
+		});
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+test("pipeline approval token and short ID each dispatch an effect at most once", async () => {
+	for (const resumeBy of ["token", "approvalId"] as const) {
+		await assertApprovalResumeIsExclusive({ workflow: false, resumeBy });
+	}
+});
+
+test("workflow approval token and short ID each dispatch an effect at most once", async () => {
+	for (const resumeBy of ["token", "approvalId"] as const) {
+		await assertApprovalResumeIsExclusive({ workflow: true, resumeBy });
+	}
+});
+
+test("a cancellation immediately after pipeline resume consumption restores the unstarted approval", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-consume-rename-abort-"));
+	const originalRename = fsp.rename;
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const effect = createCountingSideEffect("test.consume-rename-effect");
+		const registry = withCommands(createDefaultRegistry(), effect.command);
+		const first = await runToolRequest({
+			pipeline: "approve --prompt Continue? | test.consume-rename-effect",
+			ctx: { cwd: dir, env, registry },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken!);
+		const statePath = keyToPath(stateDir, payload.stateKey);
+		const controller = new AbortController();
+		let abortedAtConsumption = false;
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+				await originalRename(from, to);
+				if (String(to) === statePath && !abortedAtConsumption) {
+					abortedAtConsumption = true;
+					controller.abort(new Error("abort after consumed resume rename"));
+				}
+			},
+		});
+
+		const cancelled = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, env, registry, signal: controller.signal },
+		});
+		assertCancellationEnvelope(cancelled);
+		assert.equal(effect.invocations, 0);
+		assert.equal(abortedAtConsumption, true);
+
+		const retried = await resumeToolRequest({
+			token: first.requiresApproval.resumeToken,
+			approved: true,
+			ctx: { cwd: dir, env, registry },
+		});
+		assert.equal(retried.ok, true);
+		assert.equal(effect.invocations, 1);
+	} finally {
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			value: originalRename,
 		});
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -1446,7 +1446,7 @@ test("terminal workflow approval resume restores its original capability when cl
 	}
 });
 
-test("cancellation while draining terminal lazy output returns cancellation", async () => {
+test("cancellation stops terminal lazy output before reading its next item", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;
 	const terminal = {
@@ -1472,10 +1472,10 @@ test("cancellation while draining terminal lazy output returns cancellation", as
 	});
 
 	assertCancellationEnvelope(envelope);
-	assert.equal(outputDrained, true, "terminal output must finish before cancellation is reported");
+	assert.equal(outputDrained, false, "terminal cancellation must not read another output item");
 });
 
-test("cancellation observed before terminal drain is reported after output cleanup", async () => {
+test("cancellation observed before terminal output does not start its iterator", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;
 	const terminal = {
@@ -1502,10 +1502,10 @@ test("cancellation observed before terminal drain is reported after output clean
 
 	assertCancellationEnvelope(envelope);
 	assert.equal(envelope.error?.message, "abort before terminal drain");
-	assert.equal(outputDrained, true, "terminal output cleanup must complete before cancellation");
+	assert.equal(outputDrained, false, "pre-aborted terminal output must not be read");
 });
 
-test("cancellation drains a halted lazy output before a later pipeline stage", async () => {
+test("cancellation before halted lazy output skips its iterator and later pipeline stages", async () => {
 	const controller = new AbortController();
 	let outputDrained = false;
 	let downstreamRan = false;
@@ -1540,7 +1540,7 @@ test("cancellation drains a halted lazy output before a later pipeline stage", a
 
 	assertCancellationEnvelope(envelope);
 	assert.equal(envelope.error?.message, "abort before halted output drain");
-	assert.equal(outputDrained, true, "halted output cleanup must complete before cancellation");
+	assert.equal(outputDrained, false, "halted output must not be read after cancellation");
 	assert.equal(downstreamRan, false, "a halted stage must not dispatch later pipeline stages");
 });
 
@@ -1628,6 +1628,41 @@ test("cancellation before a terminal lazy read invokes its iterator abort hook",
 	assert.equal(settled.settled, true, "cancellation must release the terminal lazy read");
 	if (settled.settled) assertCancellationEnvelope(settled.value);
 	assert.equal(abortCalled, true);
+});
+
+test("cancellation does not pull another lazy output item after an in-flight read aborts", async () => {
+	const controller = new AbortController();
+	let afterAbortEffects = 0;
+	const source = {
+		name: "test.abort-does-not-pull-another-output",
+		async run() {
+			return {
+				output: (async function* () {
+					yield { value: 1 };
+					controller.abort(new Error("abort before next lazy output"));
+					afterAbortEffects += 1;
+					yield { value: 2 };
+					afterAbortEffects += 1;
+					yield { value: 3 };
+				})(),
+			};
+		},
+	};
+
+	const envelope = await runToolRequest({
+		pipeline: "test.abort-does-not-pull-another-output",
+		ctx: {
+			registry: withCommands(createDefaultRegistry(), source),
+			signal: controller.signal,
+		},
+	});
+
+	assertCancellationEnvelope(envelope);
+	assert.equal(
+		afterAbortEffects,
+		1,
+		"cancellation must close the in-flight iterator instead of pulling a later item",
+	);
 });
 
 test("cancellable lazy output releases a pending read before cancellation returns", async () => {
@@ -1795,6 +1830,7 @@ test("cancellation during lazy handoff stops yielding items to the downstream st
 	assertCancellationEnvelope(envelope);
 	assert.equal(envelope.error?.message, "abort after first lazy item");
 	assert.deepEqual(delivered, [1], "cancelled handoff must not deliver later items");
+	await new Promise((resolve) => setImmediate(resolve));
 	assert.equal(sourceClosed, true, "cancelling the handoff must close the source iterator");
 });
 

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -950,6 +950,77 @@ test("pipeline approval resume restores its original capability after next-input
 	}
 });
 
+test("pipeline cancellation after side effects does not restore the consumed approval capability", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-pipeline-side-effect-gate-cancel-"));
+	try {
+		const stateDir = join(dir, "state");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		let sideEffects = 0;
+		const sideEffectThenInput = {
+			name: "test.side-effect-then-input",
+			async run({ ctx }: any) {
+				sideEffects += 1;
+				await ctx.requestInput({
+					prompt: "Second?",
+					responseSchema: { type: "object" },
+				});
+				return { output: streamOf([]) };
+			},
+		};
+		const registry = withCommands(createDefaultRegistry(), sideEffectThenInput);
+		const first = await runToolRequest({
+			pipeline: "approve --prompt First? | test.side-effect-then-input",
+			ctx: { env, registry },
+		});
+		assert.equal(first.status, "needs_approval");
+		assert.ok(first.requiresApproval?.approvalId);
+		assert.ok(first.requiresApproval?.resumeToken);
+		const payload = decodeResumeToken(first.requiresApproval.resumeToken);
+		const previousStatePath = keyToPath(stateDir, payload.stateKey);
+
+		const controller = new AbortController();
+		const originalUnlink = fsp.unlink;
+		Object.defineProperty(fsp, "unlink", {
+			configurable: true,
+			writable: true,
+			async value(filePath: Parameters<typeof fsp.unlink>[0]) {
+				const result = await originalUnlink(filePath);
+				if (String(filePath) === previousStatePath && !controller.signal.aborted) {
+					controller.abort(new Error("abort after side-effecting pipeline state deletion"));
+				}
+				return result;
+			},
+		});
+		let aborted;
+		try {
+			aborted = await resumeToolRequest({
+				approvalId: first.requiresApproval.approvalId,
+				approved: true,
+				ctx: { env, registry, signal: controller.signal },
+			});
+		} finally {
+			Object.defineProperty(fsp, "unlink", {
+				configurable: true,
+				writable: true,
+				value: originalUnlink,
+			});
+		}
+		assertCancellationEnvelope(aborted!);
+		assert.equal(sideEffects, 1);
+
+		const retried = await resumeToolRequest({
+			approvalId: first.requiresApproval.approvalId,
+			approved: true,
+			ctx: { env, registry },
+		});
+		assert.equal(retried.ok, false);
+		assert.equal(retried.error?.type, "parse_error");
+		assert.equal(sideEffects, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("workflow approval resume restores its original capability after next-input cleanup is cancelled", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-input-gate-cleanup-abort-workflow-resume-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -633,6 +633,99 @@ test("parent cancellation terminates the gog process tree and skips Gmail sends"
 	}
 });
 
+test("workflow shell cancellation terminates descendant processes", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-workflow-shell-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const filePath = join(dir, "workflow.lobster");
+		const searchStarted = join(dir, "search-started");
+		const descendantStarted = join(dir, "descendant-started");
+		const descendantCompleted = join(dir, "descendant-completed");
+		const controller = new AbortController();
+		const command = [process.execPath, mockGog, "gmail", "search"]
+			.map((arg) => JSON.stringify(arg))
+			.join(" ");
+		await writeFile(filePath, JSON.stringify({ steps: [{ id: "shell", run: command }] }), "utf8");
+
+		const run = runToolRequest({
+			filePath,
+			ctx: {
+				cwd: dir,
+				signal: controller.signal,
+				env: {
+					...process.env,
+					MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+					MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+					MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+				},
+			},
+		});
+
+		await waitForFile(searchStarted);
+		await waitForFile(descendantStarted);
+		const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+		controller.abort();
+		const immediate = await observeSettlement(run, 50);
+		const envelope = await run;
+
+		assert.equal(immediate.settled, false, "workflow must wait for tree termination");
+		assertCancellationEnvelope(envelope);
+		await new Promise((resolve) => setTimeout(resolve, 900));
+		assert.equal(processIsRunning(descendantPid), false);
+		assert.equal(
+			await fileExists(descendantCompleted),
+			false,
+			"a workflow shell descendant must not complete after cancellation",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("exec cancellation terminates descendant processes", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-exec-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const searchStarted = join(dir, "search-started");
+		const descendantStarted = join(dir, "descendant-started");
+		const descendantCompleted = join(dir, "descendant-completed");
+		const controller = new AbortController();
+		const run = runToolRequest({
+			pipeline: `exec ${process.execPath} ${mockGog} gmail search`,
+			ctx: {
+				signal: controller.signal,
+				env: {
+					...process.env,
+					MOCK_GOG_SEARCH_STARTED_FILE: searchStarted,
+					MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+					MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+				},
+			},
+		});
+
+		await waitForFile(searchStarted);
+		await waitForFile(descendantStarted);
+		const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+		controller.abort();
+		const envelope = await run;
+
+		assertCancellationEnvelope(envelope);
+		await new Promise((resolve) => setTimeout(resolve, 900));
+		assert.equal(processIsRunning(descendantPid), false);
+		assert.equal(
+			await fileExists(descendantCompleted),
+			false,
+			"an exec descendant must not complete after cancellation",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("cancellation after Gmail search completion stops the next pipeline stage", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-search-handoff-"));
 	try {

--- a/test/fixtures/abortable-process-short-lived.mjs
+++ b/test/fixtures/abortable-process-short-lived.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { access } from "node:fs/promises";
+
+const [runnerPath, mockGog] = process.argv.slice(2);
+const { runAbortableProcess } = await import(pathToFileURL(runnerPath).href);
+
+async function waitFor(path) {
+	for (let attempt = 0; attempt < 300; attempt += 1) {
+		try {
+			await access(path);
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	}
+	throw new Error(`Timed out waiting for ${path}`);
+}
+
+const controller = new AbortController();
+const run = runAbortableProcess({
+	command: process.execPath,
+	argv: [mockGog, "gmail", "search"],
+	env: process.env,
+	signal: controller.signal,
+	notFoundMessage: "mock gog not found",
+});
+
+await waitFor(process.env.MOCK_GOG_SEARCH_STARTED_FILE);
+await waitFor(process.env.MOCK_GOG_DESCENDANT_STARTED_FILE);
+controller.abort(new Error("cancelled by short-lived caller"));
+await run.catch(() => undefined);

--- a/test/fixtures/abortable-process-terminal-direct.mjs
+++ b/test/fixtures/abortable-process-terminal-direct.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const [runnerPath] = process.argv.slice(2);
+const { runAbortableProcess } = await import(pathToFileURL(runnerPath).href);
+
+function processGroupId() {
+	const stat = readFileSync("/proc/self/stat", "utf8");
+	const fields = stat
+		.slice(stat.lastIndexOf(")") + 1)
+		.trim()
+		.split(/\s+/);
+	return Number(fields[2]);
+}
+
+writeFileSync(process.env.LOBSTER_TERMINAL_DIRECT_GROUP_FILE, String(processGroupId()), "utf8");
+
+await runAbortableProcess({
+	command: process.execPath,
+	argv: [
+		"-e",
+		`const { writeFileSync } = require("node:fs");
+writeFileSync(process.env.LOBSTER_TERMINAL_DIRECT_STARTED_FILE, String(process.pid));
+setTimeout(() => writeFileSync(process.env.LOBSTER_TERMINAL_DIRECT_COMPLETED_FILE, "completed"), 700);`,
+	],
+	env: process.env,
+	notFoundMessage: "node missing",
+});

--- a/test/fixtures/mock-gh-cancellation.mjs
+++ b/test/fixtures/mock-gh-cancellation.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+
+function mark(path, value) {
+	if (path) writeFileSync(path, value, "utf8");
+}
+
+process.once("SIGTERM", () => {
+	mark(process.env.MOCK_GH_TERMINATED_FILE, "SIGTERM");
+	process.exit(143);
+});
+mark(process.env.MOCK_GH_STARTED_FILE, String(process.pid));
+setTimeout(() => {
+	mark(process.env.MOCK_GH_COMPLETED_FILE, "completed");
+	process.stdout.write(
+		JSON.stringify({
+			number: 1,
+			title: "Fixture PR",
+			url: "https://example.invalid/pr/1",
+			state: "OPEN",
+			isDraft: false,
+			mergeable: "MERGEABLE",
+			reviewDecision: "",
+			updatedAt: "2026-07-11T00:00:00Z",
+			baseRefName: "main",
+			headRefName: "fixture",
+		}),
+	);
+}, 1200);

--- a/test/fixtures/mock-gh-cancellation.mjs
+++ b/test/fixtures/mock-gh-cancellation.mjs
@@ -7,23 +7,27 @@ function mark(path, value) {
 
 process.once("SIGTERM", () => {
 	mark(process.env.MOCK_GH_TERMINATED_FILE, "SIGTERM");
-	process.exit(143);
+	const terminationDelayMs = Number(process.env.MOCK_GH_TERMINATION_DELAY_MS ?? 0);
+	setTimeout(() => process.exit(143), terminationDelayMs);
 });
 mark(process.env.MOCK_GH_STARTED_FILE, String(process.pid));
-setTimeout(() => {
-	mark(process.env.MOCK_GH_COMPLETED_FILE, "completed");
-	process.stdout.write(
-		JSON.stringify({
-			number: 1,
-			title: "Fixture PR",
-			url: "https://example.invalid/pr/1",
-			state: "OPEN",
-			isDraft: false,
-			mergeable: "MERGEABLE",
-			reviewDecision: "",
-			updatedAt: "2026-07-11T00:00:00Z",
-			baseRefName: "main",
-			headRefName: "fixture",
-		}),
-	);
-}, 1200);
+setTimeout(
+	() => {
+		mark(process.env.MOCK_GH_COMPLETED_FILE, "completed");
+		process.stdout.write(
+			JSON.stringify({
+				number: 1,
+				title: "Fixture PR",
+				url: "https://example.invalid/pr/1",
+				state: "OPEN",
+				isDraft: false,
+				mergeable: "MERGEABLE",
+				reviewDecision: "",
+				updatedAt: "2026-07-11T00:00:00Z",
+				baseRefName: "main",
+				headRefName: "fixture",
+			}),
+		);
+	},
+	Number(process.env.MOCK_GH_COMPLETION_DELAY_MS ?? 1200),
+);

--- a/test/fixtures/mock-gog-cancellation.mjs
+++ b/test/fixtures/mock-gog-cancellation.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+
+const argv = process.argv.slice(2);
+
+function mark(path, value) {
+	if (path) writeFileSync(path, value, "utf8");
+}
+
+function waitForCompletion({ startedFile, terminatedFile, completedFile, output }) {
+	process.once("SIGTERM", () => {
+		mark(terminatedFile, "SIGTERM");
+		process.exit(143);
+	});
+	mark(startedFile, String(process.pid));
+	setTimeout(() => {
+		mark(completedFile, "completed");
+		process.stdout.write(JSON.stringify(output));
+	}, 1200);
+}
+
+if (argv[0] === "gmail" && argv[1] === "search") {
+	waitForCompletion({
+		startedFile: process.env.MOCK_GOG_SEARCH_STARTED_FILE,
+		terminatedFile: process.env.MOCK_GOG_SEARCH_TERMINATED_FILE,
+		completedFile: process.env.MOCK_GOG_SEARCH_COMPLETED_FILE,
+		output: [{ to: "user@example.com", subject: "Reply", body: "Hello" }],
+	});
+} else if (argv[0] === "gmail" && argv[1] === "send") {
+	waitForCompletion({
+		startedFile: process.env.MOCK_GOG_SEND_STARTED_FILE,
+		terminatedFile: process.env.MOCK_GOG_SEND_TERMINATED_FILE,
+		completedFile: process.env.MOCK_GOG_SEND_COMPLETED_FILE,
+		output: { ok: true },
+	});
+} else {
+	process.stderr.write(`mock-gog-cancellation: unsupported args: ${argv.join(" ")}\n`);
+	process.exit(2);
+}

--- a/test/fixtures/mock-gog-cancellation.mjs
+++ b/test/fixtures/mock-gog-cancellation.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { writeFileSync } from "node:fs";
+import { appendFileSync, writeFileSync } from "node:fs";
 
 const argv = process.argv.slice(2);
 
@@ -8,15 +8,17 @@ function mark(path, value) {
 }
 
 function waitForCompletion({ startedFile, terminatedFile, completedFile, output }) {
+	const terminationDelayMs = Number(process.env.MOCK_GOG_TERMINATION_DELAY_MS ?? 0);
+	const completionDelayMs = Number(process.env.MOCK_GOG_COMPLETION_DELAY_MS ?? 1200);
 	process.once("SIGTERM", () => {
 		mark(terminatedFile, "SIGTERM");
-		process.exit(143);
+		setTimeout(() => process.exit(143), terminationDelayMs);
 	});
 	mark(startedFile, String(process.pid));
 	setTimeout(() => {
 		mark(completedFile, "completed");
 		process.stdout.write(JSON.stringify(output));
-	}, 1200);
+	}, completionDelayMs);
 }
 
 if (argv[0] === "gmail" && argv[1] === "search") {
@@ -27,6 +29,9 @@ if (argv[0] === "gmail" && argv[1] === "search") {
 		output: [{ to: "user@example.com", subject: "Reply", body: "Hello" }],
 	});
 } else if (argv[0] === "gmail" && argv[1] === "send") {
+	if (process.env.MOCK_GOG_SEND_INVOCATIONS_FILE) {
+		appendFileSync(process.env.MOCK_GOG_SEND_INVOCATIONS_FILE, `${process.pid}\n`, "utf8");
+	}
 	waitForCompletion({
 		startedFile: process.env.MOCK_GOG_SEND_STARTED_FILE,
 		terminatedFile: process.env.MOCK_GOG_SEND_TERMINATED_FILE,

--- a/test/fixtures/mock-gog-cancellation.mjs
+++ b/test/fixtures/mock-gog-cancellation.mjs
@@ -1,10 +1,27 @@
 #!/usr/bin/env node
 import { appendFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 const argv = process.argv.slice(2);
 
 function mark(path, value) {
 	if (path) writeFileSync(path, value, "utf8");
+}
+
+function startDescendant() {
+	if (!process.env.MOCK_GOG_DESCENDANT_STARTED_FILE) return;
+	const helper = spawn(
+		process.execPath,
+		[
+			"-e",
+			`const { writeFileSync } = require("node:fs");
+process.once("SIGTERM", () => {});
+writeFileSync(process.env.MOCK_GOG_DESCENDANT_STARTED_FILE, String(process.pid));
+setTimeout(() => writeFileSync(process.env.MOCK_GOG_DESCENDANT_COMPLETED_FILE, "completed"), 650);`,
+		],
+		{ env: process.env, stdio: "ignore" },
+	);
+	helper.unref();
 }
 
 function waitForCompletion({ startedFile, terminatedFile, completedFile, output }) {
@@ -15,6 +32,7 @@ function waitForCompletion({ startedFile, terminatedFile, completedFile, output 
 		setTimeout(() => process.exit(143), terminationDelayMs);
 	});
 	mark(startedFile, String(process.pid));
+	startDescendant();
 	setTimeout(() => {
 		mark(completedFile, "completed");
 		process.stdout.write(JSON.stringify(output));

--- a/test/fixtures/mock-openclaw-agent.mjs
+++ b/test/fixtures/mock-openclaw-agent.mjs
@@ -1,3 +1,6 @@
+import { writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+
 const writeResponse = () => {
 	process.stdout.write(
 		JSON.stringify({
@@ -7,6 +10,21 @@ const writeResponse = () => {
 		}),
 	);
 };
+
+if (process.argv.includes("--spawn-descendant")) {
+	const helper = spawn(
+		process.execPath,
+		[
+			"-e",
+			`const { writeFileSync } = require("node:fs");
+process.once("SIGTERM", () => {});
+writeFileSync(process.env.MOCK_OPENCLAW_AGENT_DESCENDANT_STARTED_FILE, String(process.pid));
+setTimeout(() => writeFileSync(process.env.MOCK_OPENCLAW_AGENT_DESCENDANT_COMPLETED_FILE, "completed"), 650);`,
+		],
+		{ env: process.env, stdio: "ignore" },
+	);
+	helper.unref();
+}
 
 if (process.argv.includes("--sleep")) {
 	setTimeout(writeResponse, 10_000);

--- a/test/fixtures/mock-openclaw-agent.mjs
+++ b/test/fixtures/mock-openclaw-agent.mjs
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 
 const writeResponse = () => {

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -285,6 +285,96 @@ test("llm.invoke does not publish a reusable cache entry when cancellation races
 	await rm(cacheDir, { recursive: true, force: true });
 });
 
+test("llm.invoke restores the previous cache entry when a refresh is cancelled after commit", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-refresh-cancel-"));
+	const stateDir = path.join(cacheDir, "state");
+	let calls = 0;
+	const adapter = {
+		source: "cache-refresh-cancel-test",
+		async invoke() {
+			calls += 1;
+			return {
+				ok: true,
+				result: {
+					runId: `call-${calls}`,
+					output: { data: { call: calls } },
+				},
+			};
+		},
+	};
+	const args = { _: [], provider: "cache-refresh-cancel-test", prompt: "Decide" };
+
+	try {
+		const first = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: {
+				...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+				llmAdapters: { "cache-refresh-cancel-test": adapter },
+			},
+		} as any);
+		assert.deepEqual((await collect(first.output!))[0]?.output.data, { call: 1 });
+
+		const controller = new AbortController();
+		const originalRename = fsp.rename;
+		let cacheCommitAborted = false;
+		try {
+			Object.defineProperty(fsp, "rename", {
+				configurable: true,
+				writable: true,
+				async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+					const result = await originalRename(from, to);
+					if (
+						!cacheCommitAborted &&
+						String(to).startsWith(`${path.join(cacheDir, "llm.invoke")}${path.sep}`)
+					) {
+						cacheCommitAborted = true;
+						controller.abort(new Error("cancelled during cache refresh publication"));
+					}
+					return result;
+				},
+			});
+
+			await assert.rejects(
+				cmd.run({
+					input: streamOf([]),
+					args: { ...args, refresh: true },
+					ctx: {
+						...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+						signal: controller.signal,
+						llmAdapters: { "cache-refresh-cancel-test": adapter },
+					},
+				} as any),
+				/cancelled during cache refresh publication/,
+			);
+		} finally {
+			Object.defineProperty(fsp, "rename", {
+				configurable: true,
+				writable: true,
+				value: originalRename,
+			});
+		}
+
+		const recovered = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: {
+				...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+				llmAdapters: { "cache-refresh-cancel-test": adapter },
+			},
+		} as any);
+		const recoveredItems = await collect(recovered.output!);
+		assert.equal(calls, 2, "the cancelled refresh must restore the existing cache entry");
+		assert.equal(recoveredItems[0]?.source, "cache");
+		assert.deepEqual(recoveredItems[0]?.output.data, { call: 1 });
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+	}
+});
+
 function baseCtx(envOverrides: Record<string, string>, registry?: any) {
 	return {
 		stdin: process.stdin,

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
+import { promises as fsp } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -208,6 +209,80 @@ test("llm.invoke does not retry schema validation after adapter cancellation", a
 		/adapter cancelled during validation/,
 	);
 	assert.equal(calls, 1, "cancellation after an invalid response must suppress retries");
+});
+
+test("llm.invoke does not publish a reusable cache entry when cancellation races cache commit", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-cancel-publication-"));
+	const stateDir = path.join(cacheDir, "state");
+	const controller = new AbortController();
+	const originalRename = fsp.rename;
+	let cacheCommitAborted = false;
+	let calls = 0;
+	const adapter = {
+		source: "cache-cancel-test",
+		async invoke() {
+			calls += 1;
+			return {
+				ok: true,
+				result: {
+					runId: `call-${calls}`,
+					output: { data: { call: calls } },
+				},
+			};
+		},
+	};
+	const args = { _: [], provider: "cache-cancel-test", prompt: "Decide" };
+
+	try {
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
+				const result = await originalRename(from, to);
+				if (!cacheCommitAborted && String(to).startsWith(`${cacheDir}${path.sep}`)) {
+					cacheCommitAborted = true;
+					controller.abort(new Error("cancelled during cache publication"));
+				}
+				return result;
+			},
+		});
+
+		await assert.rejects(
+			cmd.run({
+				input: streamOf([]),
+				args,
+				ctx: {
+					...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+					signal: controller.signal,
+					llmAdapters: { "cache-cancel-test": adapter },
+				},
+			} as any),
+			/cancelled during cache publication/,
+		);
+	} finally {
+		Object.defineProperty(fsp, "rename", {
+			configurable: true,
+			writable: true,
+			value: originalRename,
+		});
+	}
+
+	const retried = await cmd.run({
+		input: streamOf([]),
+		args,
+		ctx: {
+			...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+			llmAdapters: { "cache-cancel-test": adapter },
+		},
+	} as any);
+	const retriedItems = await collect(retried.output!);
+	assert.equal(calls, 2, "a cancelled invocation must not satisfy a later request from cache");
+	assert.equal(retriedItems[0]?.source, "cache-cancel-test");
+
+	await rm(cacheDir, { recursive: true, force: true });
 });
 
 function baseCtx(envOverrides: Record<string, string>, registry?: any) {

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
+import { keyToPath } from "../src/state/store.js";
 
 function streamOf(items: any[]) {
 	return (async function* () {
@@ -209,6 +210,68 @@ test("llm.invoke does not retry schema validation after adapter cancellation", a
 		/adapter cancelled during validation/,
 	);
 	assert.equal(calls, 1, "cancellation after an invalid response must suppress retries");
+});
+
+test("llm.invoke aborts while waiting for its reusable run-state lock", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-llm-state-lock-abort-"));
+	const stateDir = path.join(cacheDir, "state");
+	const stateKey = "blocked-run-state";
+	const lockPath = `${keyToPath(stateDir, stateKey)}.lock`;
+	await fsp.mkdir(lockPath, { recursive: true });
+	await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+	try {
+		const controller = new AbortController();
+		const pending = cmd.run({
+			input: streamOf([]),
+			args: {
+				_: [],
+				provider: "state-lock-abort-test",
+				prompt: "Decide",
+				"state-key": stateKey,
+			},
+			ctx: {
+				...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+				signal: controller.signal,
+				llmAdapters: {
+					"state-lock-abort-test": {
+						source: "state-lock-abort-test",
+						async invoke() {
+							throw new Error("adapter must not run while the state read is locked");
+						},
+					},
+				},
+			},
+		} as any);
+		const completion = pending.then(
+			() => ({ kind: "success" as const }),
+			(error) => ({ kind: "error" as const, error }),
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+		controller.abort(new Error("LLM state read cancelled"));
+		const early = await Promise.race([
+			completion,
+			new Promise<{ kind: "timeout" }>((resolve) =>
+				setTimeout(() => resolve({ kind: "timeout" }), 75),
+			),
+		]);
+		if (early.kind === "timeout") await fsp.rm(lockPath, { recursive: true, force: true });
+		const settled = early.kind === "timeout" ? await completion : early;
+		assert.notEqual(
+			early.kind,
+			"timeout",
+			"state-key reads must observe cancellation while locked",
+		);
+		assert.equal(settled.kind, "error");
+		if (settled.kind === "error") {
+			assert.match(settled.error?.message ?? "", /LLM state read cancelled/);
+		}
+	} finally {
+		await fsp.rm(cacheDir, { recursive: true, force: true });
+	}
 });
 
 test("llm.invoke does not publish a reusable cache entry when cancellation races cache commit", async () => {

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -312,7 +312,8 @@ test("llm.invoke does not publish a reusable cache entry when cancellation races
 				const result = await originalRename(from, to);
 				if (
 					!cacheCommitAborted &&
-					String(to).startsWith(`${path.join(cacheDir, "llm.invoke")}${path.sep}`)
+					String(to).startsWith(`${path.join(cacheDir, "llm.invoke")}${path.sep}`) &&
+					String(to).endsWith(".json")
 				) {
 					cacheCommitAborted = true;
 					controller.abort(new Error("cancelled during cache publication"));

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -167,6 +167,49 @@ test("llm.invoke uses Pi adapter over local HTTP bridge", async () => {
 	}
 });
 
+test("llm.invoke does not retry schema validation after adapter cancellation", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const controller = new AbortController();
+	let calls = 0;
+
+	await assert.rejects(
+		cmd.run({
+			input: streamOf([]),
+			args: {
+				_: [],
+				provider: "cancel-test",
+				prompt: "Decide",
+				"output-schema": '{"type":"object","required":["decision"]}',
+				"max-validation-retries": 2,
+			},
+			ctx: {
+				...baseCtx({}, registry),
+				signal: controller.signal,
+				llmAdapters: {
+					"cancel-test": {
+						source: "cancel-test",
+						async invoke() {
+							calls += 1;
+							controller.abort(new Error("adapter cancelled during validation"));
+							return {
+								ok: true,
+								result: {
+									runId: "cancelled-attempt",
+									output: { data: { unexpected: true } },
+								},
+							};
+						},
+					},
+				},
+			},
+		} as any),
+		/adapter cancelled during validation/,
+	);
+	assert.equal(calls, 1, "cancellation after an invalid response must suppress retries");
+});
+
 function baseCtx(envOverrides: Record<string, string>, registry?: any) {
 	return {
 		stdin: process.stdin,

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -234,7 +234,12 @@ test("llm.invoke does not publish a reusable cache entry when cancellation races
 			};
 		},
 	};
-	const args = { _: [], provider: "cache-cancel-test", prompt: "Decide" };
+	const args = {
+		_: [],
+		provider: "cache-cancel-test",
+		prompt: "Decide",
+		"state-key": "cancelled-cache-publication",
+	};
 
 	try {
 		Object.defineProperty(fsp, "rename", {
@@ -242,7 +247,10 @@ test("llm.invoke does not publish a reusable cache entry when cancellation races
 			writable: true,
 			async value(from: Parameters<typeof fsp.rename>[0], to: Parameters<typeof fsp.rename>[1]) {
 				const result = await originalRename(from, to);
-				if (!cacheCommitAborted && String(to).startsWith(`${cacheDir}${path.sep}`)) {
+				if (
+					!cacheCommitAborted &&
+					String(to).startsWith(`${path.join(cacheDir, "llm.invoke")}${path.sep}`)
+				) {
 					cacheCommitAborted = true;
 					controller.abort(new Error("cancelled during cache publication"));
 				}
@@ -279,7 +287,11 @@ test("llm.invoke does not publish a reusable cache entry when cancellation races
 		},
 	} as any);
 	const retriedItems = await collect(retried.output!);
-	assert.equal(calls, 2, "a cancelled invocation must not satisfy a later request from cache");
+	assert.equal(
+		calls,
+		2,
+		"a cancelled invocation must not satisfy a later request from cache or run state",
+	);
 	assert.equal(retriedItems[0]?.source, "cache-cancel-test");
 
 	await rm(cacheDir, { recursive: true, force: true });
@@ -305,7 +317,12 @@ test("llm.invoke restores the previous cache entry when a refresh is cancelled a
 			};
 		},
 	};
-	const args = { _: [], provider: "cache-refresh-cancel-test", prompt: "Decide" };
+	const args = {
+		_: [],
+		provider: "cache-refresh-cancel-test",
+		prompt: "Decide",
+		"state-key": "refresh-cache-publication",
+	};
 
 	try {
 		const first = await cmd.run({
@@ -367,9 +384,21 @@ test("llm.invoke restores the previous cache entry when a refresh is cancelled a
 			},
 		} as any);
 		const recoveredItems = await collect(recovered.output!);
-		assert.equal(calls, 2, "the cancelled refresh must restore the existing cache entry");
-		assert.equal(recoveredItems[0]?.source, "cache");
+		assert.equal(calls, 2, "the cancelled refresh must restore the existing run state");
+		assert.equal(recoveredItems[0]?.source, "run_state");
 		assert.deepEqual(recoveredItems[0]?.output.data, { call: 1 });
+
+		const recoveredCache = await cmd.run({
+			input: streamOf([]),
+			args: { _: [], provider: "cache-refresh-cancel-test", prompt: "Decide" },
+			ctx: {
+				...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+				llmAdapters: { "cache-refresh-cancel-test": adapter },
+			},
+		} as any);
+		const recoveredCacheItems = await collect(recoveredCache.output!);
+		assert.equal(recoveredCacheItems[0]?.source, "cache");
+		assert.deepEqual(recoveredCacheItems[0]?.output.data, { call: 1 });
 	} finally {
 		await rm(cacheDir, { recursive: true, force: true });
 	}

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -468,6 +468,151 @@ test("llm.invoke restores the previous cache entry when a refresh is cancelled a
 	}
 });
 
+test("llm.invoke rolls back cache and run-state publications after a cache directory sync failure", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-dir-sync-failure-"));
+	const stateDir = path.join(cacheDir, "state");
+	const cacheNamespaceDir = path.join(cacheDir, "llm.invoke");
+	const originalOpen = fsp.open;
+	const fault = Object.assign(new Error("cache directory sync failed"), { code: "EIO" });
+	let failNextCacheDirectorySync = true;
+	let calls = 0;
+	const adapter = {
+		source: "cache-dir-sync-test",
+		async invoke() {
+			calls += 1;
+			return { ok: true, result: { runId: `call-${calls}`, output: { data: { call: calls } } } };
+		},
+	};
+	const args = {
+		_: [],
+		provider: "cache-dir-sync-test",
+		prompt: "Decide",
+		"state-key": "cache-directory-sync-failure",
+	};
+
+	try {
+		await fsp.mkdir(cacheNamespaceDir, { recursive: true });
+		Object.defineProperty(fsp, "open", {
+			configurable: true,
+			writable: true,
+			async value(...openArgs: any[]) {
+				const handle = await (originalOpen as any)(...openArgs);
+				if (
+					failNextCacheDirectorySync &&
+					String(openArgs[0]) === cacheNamespaceDir &&
+					openArgs[1] === "r"
+				) {
+					failNextCacheDirectorySync = false;
+					return new Proxy(handle, {
+						get(target, property, receiver) {
+							if (property === "sync") return async () => Promise.reject(fault);
+							const value = Reflect.get(target, property, receiver);
+							return typeof value === "function" ? value.bind(target) : value;
+						},
+					});
+				}
+				return handle;
+			},
+		});
+
+		await assert.rejects(
+			cmd.run({
+				input: streamOf([]),
+				args,
+				ctx: {
+					...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+					llmAdapters: { "cache-dir-sync-test": adapter },
+				},
+			} as any),
+			/cache directory sync failed/,
+		);
+	} finally {
+		Object.defineProperty(fsp, "open", {
+			configurable: true,
+			writable: true,
+			value: originalOpen,
+		});
+	}
+
+	const retried = await cmd.run({
+		input: streamOf([]),
+		args,
+		ctx: {
+			...baseCtx({ LOBSTER_CACHE_DIR: cacheDir, LOBSTER_STATE_DIR: stateDir }, registry),
+			llmAdapters: { "cache-dir-sync-test": adapter },
+		},
+	} as any);
+	const items = await collect(retried.output!);
+	assert.equal(calls, 2, "a failed publication must not be reused from cache or run state");
+	assert.equal(items[0]?.source, "cache-dir-sync-test");
+	await rm(cacheDir, { recursive: true, force: true });
+});
+
+test("llm.invoke reads a populated cache when lock creation is forbidden", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-readonly-cache-"));
+	const originalMkdir = fsp.mkdir;
+	let calls = 0;
+	const adapter = {
+		source: "readonly-cache-test",
+		async invoke() {
+			calls += 1;
+			return { ok: true, result: { runId: `call-${calls}`, output: { data: { call: calls } } } };
+		},
+	};
+	const args = { _: [], provider: "readonly-cache-test", prompt: "Decide" };
+
+	try {
+		const first = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: {
+				...baseCtx({ LOBSTER_CACHE_DIR: cacheDir }, registry),
+				llmAdapters: { "readonly-cache-test": adapter },
+			},
+		} as any);
+		await collect(first.output!);
+
+		Object.defineProperty(fsp, "mkdir", {
+			configurable: true,
+			writable: true,
+			async value(
+				filePath: Parameters<typeof fsp.mkdir>[0],
+				options?: Parameters<typeof fsp.mkdir>[1],
+			) {
+				if (String(filePath).endsWith(".lock")) {
+					throw Object.assign(new Error("read-only cache directory"), { code: "EACCES" });
+				}
+				return originalMkdir(filePath, options);
+			},
+		});
+
+		const cached = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: {
+				...baseCtx({ LOBSTER_CACHE_DIR: cacheDir }, registry),
+				llmAdapters: { "readonly-cache-test": adapter },
+			},
+		} as any);
+		const items = await collect(cached.output!);
+		assert.equal(calls, 1);
+		assert.equal(items[0]?.source, "cache");
+	} finally {
+		Object.defineProperty(fsp, "mkdir", {
+			configurable: true,
+			writable: true,
+			value: originalMkdir,
+		});
+		await rm(cacheDir, { recursive: true, force: true });
+	}
+});
+
 function baseCtx(envOverrides: Record<string, string>, registry?: any) {
 	return {
 		stdin: process.stdin,

--- a/test/openclaw_agent.test.ts
+++ b/test/openclaw_agent.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
 	createOpenClawAgentCommand,
@@ -10,6 +13,34 @@ function streamOf(items: unknown[]) {
 	return (async function* () {
 		for (const item of items) yield item;
 	})();
+}
+
+async function fileExists(filePath: string) {
+	try {
+		await access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForFile(filePath: string, timeoutMs = 2000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await fileExists(filePath)) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+function processIsRunning(pid: number) {
+	try {
+		const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+		const state = stat.slice(stat.lastIndexOf(")") + 2, stat.lastIndexOf(")") + 3);
+		return state !== "Z";
+	} catch {
+		return false;
+	}
 }
 
 test("openclaw.agent delegates agent, session, and model selection to OpenClaw", async () => {
@@ -117,3 +148,42 @@ test("OpenClaw CLI runner preserves workflow cancellation", async () => {
 
 	await assert.rejects(pending, (error: Error) => error.name === "AbortError");
 });
+
+test(
+	"OpenClaw CLI runner terminates descendant processes on cancellation",
+	{ skip: process.platform === "win32" },
+	async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "lobster-openclaw-agent-cancel-"));
+		try {
+			const fixturePath = path.join(process.cwd(), "test", "fixtures", "mock-openclaw-agent.mjs");
+			const descendantStarted = path.join(dir, "descendant-started");
+			const descendantCompleted = path.join(dir, "descendant-completed");
+			const controller = new AbortController();
+			const pending = runOpenClawAgentCli({
+				executable: process.execPath,
+				argv: [fixturePath, "--spawn-descendant", "--sleep"],
+				cwd: process.cwd(),
+				env: {
+					...process.env,
+					MOCK_OPENCLAW_AGENT_DESCENDANT_STARTED_FILE: descendantStarted,
+					MOCK_OPENCLAW_AGENT_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+				},
+				signal: controller.signal,
+			});
+
+			await waitForFile(descendantStarted);
+			const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+			controller.abort();
+			await assert.rejects(pending, (error: Error) => error.name === "AbortError");
+			await new Promise((resolve) => setTimeout(resolve, 700));
+			assert.equal(processIsRunning(descendantPid), false);
+			assert.equal(
+				await fileExists(descendantCompleted),
+				false,
+				"the OpenClaw child process must not outlive cancellation",
+			);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	},
+);

--- a/test/openclaw_agent.test.ts
+++ b/test/openclaw_agent.test.ts
@@ -134,6 +134,18 @@ test("OpenClaw CLI runner parses structured JSON output", async () => {
 	});
 });
 
+test("OpenClaw CLI runner preserves the 10 MiB output limit", async () => {
+	await assert.rejects(
+		runOpenClawAgentCli({
+			executable: process.execPath,
+			argv: ["-e", "process.stdout.write('x'.repeat(10 * 1024 * 1024 + 1))"],
+			cwd: process.cwd(),
+			env: process.env,
+		}),
+		/openclaw\.agent output exceeded 10485760 bytes/,
+	);
+});
+
 test("OpenClaw CLI runner preserves workflow cancellation", async () => {
 	const fixturePath = path.join(process.cwd(), "test", "fixtures", "mock-openclaw-agent.mjs");
 	const controller = new AbortController();

--- a/test/read_line.test.ts
+++ b/test/read_line.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
+import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 
 import { readLineFromStream } from "../src/read_line.js";
@@ -46,6 +47,23 @@ test("readLineFromStream returns buffered input after a child pipe reaches EOF",
 	assert.equal(await first, "yes");
 	await once(child, "close");
 	assert.equal(await readLineFromStream(child.stdout, { timeoutMs: 50 }), "partial");
+});
+
+test("readLineFromStream drains a buffer that remains readable after EOF", async () => {
+	let buffered: Buffer | null = Buffer.from("partial");
+	const input = Object.assign(new EventEmitter(), {
+		readableEnded: true,
+		closed: true,
+		read() {
+			const value = buffered;
+			buffered = null;
+			return value;
+		},
+		pause() {},
+		resume() {},
+	}) as unknown as NodeJS.ReadableStream;
+
+	assert.equal(await readLineFromStream(input), "partial");
 });
 
 test("readLineFromStream resolves on end without newline", async () => {

--- a/test/read_line.test.ts
+++ b/test/read_line.test.ts
@@ -31,3 +31,13 @@ test("readLineFromStream times out when no input arrives", async () => {
 		/Timed out waiting for input/,
 	);
 });
+
+test("readLineFromStream rejects when its signal is aborted", async () => {
+	const input = new PassThrough();
+	const controller = new AbortController();
+	const promise = readLineFromStream(input, { signal: controller.signal });
+	controller.abort(new Error("input cancelled"));
+
+	await assert.rejects(() => promise, /input cancelled/);
+	input.end();
+});

--- a/test/read_line.test.ts
+++ b/test/read_line.test.ts
@@ -14,6 +14,18 @@ test("readLineFromStream resolves on newline", async () => {
 	assert.equal(value, "yes");
 });
 
+test("readLineFromStream accepts sequential reads from one stream", async () => {
+	const input = new PassThrough();
+	const first = readLineFromStream(input);
+	input.write("yes\n");
+	assert.equal(await first, "yes");
+
+	const second = readLineFromStream(input, { timeoutMs: 50 });
+	input.write("no\n");
+	assert.equal(await second, "no");
+	input.end();
+});
+
 test("readLineFromStream resolves on end without newline", async () => {
 	const input = new PassThrough();
 	const promise = readLineFromStream(input);

--- a/test/read_line.test.ts
+++ b/test/read_line.test.ts
@@ -39,5 +39,6 @@ test("readLineFromStream rejects when its signal is aborted", async () => {
 	controller.abort(new Error("input cancelled"));
 
 	await assert.rejects(() => promise, /input cancelled/);
+	assert.equal(input.readableFlowing, false);
 	input.end();
 });

--- a/test/read_line.test.ts
+++ b/test/read_line.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { PassThrough } from "node:stream";
 
 import { readLineFromStream } from "../src/read_line.js";
@@ -32,6 +34,18 @@ test("readLineFromStream preserves the next line from a combined input chunk", a
 	input.end("yes\nno\n");
 	assert.equal(await first, "yes");
 	assert.equal(await readLineFromStream(input), "no");
+});
+
+test("readLineFromStream returns buffered input after a child pipe reaches EOF", async () => {
+	const child = spawn(process.execPath, ["-e", "process.stdout.write('yes\\npartial')"], {
+		stdio: ["ignore", "pipe", "inherit"],
+	});
+	assert.ok(child.stdout);
+
+	const first = readLineFromStream(child.stdout);
+	assert.equal(await first, "yes");
+	await once(child, "close");
+	assert.equal(await readLineFromStream(child.stdout, { timeoutMs: 50 }), "partial");
 });
 
 test("readLineFromStream resolves on end without newline", async () => {

--- a/test/read_line.test.ts
+++ b/test/read_line.test.ts
@@ -26,6 +26,14 @@ test("readLineFromStream accepts sequential reads from one stream", async () => 
 	input.end();
 });
 
+test("readLineFromStream preserves the next line from a combined input chunk", async () => {
+	const input = new PassThrough();
+	const first = readLineFromStream(input);
+	input.end("yes\nno\n");
+	assert.equal(await first, "yes");
+	assert.equal(await readLineFromStream(input), "no");
+});
+
 test("readLineFromStream resolves on end without newline", async () => {
 	const input = new PassThrough();
 	const promise = readLineFromStream(input);

--- a/test/request_input.test.ts
+++ b/test/request_input.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { resumeToolRequest, runToolRequest } from "../src/core/tool_runtime.js";
 import { runPipeline } from "../src/runtime.js";
 import { decodeResumeToken } from "../src/resume.js";
-import { readStateJson, writeStateJson } from "../src/state/store.js";
+import { readStateJsonWithLock as readStateJson, writeStateJson } from "../src/state/store.js";
 
 const responseSchema = {
 	type: "object",

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -333,6 +333,33 @@ test("diffAndStore treats corrupt previous state as a miss and rewrites atomical
 	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { ok: true });
 });
 
+test("diffAndStore does not publish a snapshot after cancellation before atomic replace", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-publish-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	await writeStateJson({ env, key: "snapshot", value: { version: "before" } });
+
+	const controller = new AbortController();
+	const signal = controller.signal;
+	const throwIfAborted = signal.throwIfAborted.bind(signal);
+	let signalChecks = 0;
+	Object.defineProperty(signal, "throwIfAborted", {
+		value() {
+			signalChecks += 1;
+			if (signalChecks === 2) controller.abort(new Error("abort before state publish"));
+			throwIfAborted();
+		},
+	});
+
+	await assert.rejects(
+		() => diffAndStore({ env, key: "snapshot", value: { version: "after" }, signal }),
+		/abort before state publish/,
+	);
+	assert.equal(signalChecks, 2);
+	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "before" });
+	const leftovers = (await fsp.readdir(tmp)).filter((file) => file.includes(".tmp"));
+	assert.deepEqual(leftovers, []);
+});
+
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-sdk-diff-corrupt-"));
 	const ctx = { env: { LOBSTER_STATE_DIR: tmp } };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -444,16 +444,8 @@ test("diffAndStore serializes cancellation rollback before a concurrent snapshot
 	await cancelledSnapshotPublished;
 
 	let successfulSnapshotPublished = false;
-	const successful = writeStateJson({
-		env,
-		key: "snapshot",
-		value: { version: "successful-B" },
-		atomicWriteOptions: {
-			async renameFile(from, to) {
-				await fsp.rename(from, to);
-				successfulSnapshotPublished = true;
-			},
-		},
+	const successful = writeState("snapshot", { version: "successful-B" }, { env }).then(() => {
+		successfulSnapshotPublished = true;
 	});
 	await new Promise((resolve) => setTimeout(resolve, 20));
 	assert.equal(successfulSnapshotPublished, false, "the next writer must wait for rollback");

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -484,6 +484,35 @@ test("diffAndStore reclaims an old lock with a malformed owner", async () => {
 	await assert.rejects(fsp.access(lockPath));
 });
 
+test("diffAndStore reclaims an old lock after its owner PID is reused", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-reused-pid-lock-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const lockPath = `${keyToPath(tmp, "snapshot")}.lock`;
+	await fsp.mkdir(lockPath);
+	await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}:stale-owner\n`, "utf8");
+	const staleAt = new Date(Date.now() - 10_000);
+	await fsp.utimes(lockPath, staleAt, staleAt);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(new Error("reused lock was not reclaimed")),
+		250,
+	);
+	try {
+		await diffAndStore({
+			env,
+			key: "snapshot",
+			value: { version: "recovered" },
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+	assert.equal(controller.signal.aborted, false);
+	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "recovered" });
+	await assert.rejects(fsp.access(lockPath));
+});
+
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-sdk-diff-corrupt-"));
 	const ctx = { env: { LOBSTER_STATE_DIR: tmp } };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -88,6 +88,52 @@ test("state.get returns null for missing key", async () => {
 	assert.deepEqual(output.items, [null]);
 });
 
+test("ordinary state reads work when creating a coordination lock is forbidden", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-readonly-state-"));
+	const env = { ...process.env, LOBSTER_STATE_DIR: tmp };
+	const key = "demo";
+	const value = { readable: true };
+	const statePath = keyToPath(tmp, key);
+	const lockPath = `${statePath}.lock`;
+	const originalMkdir = fsp.mkdir;
+	await fsp.writeFile(statePath, JSON.stringify(value), "utf8");
+	Object.defineProperty(fsp, "mkdir", {
+		configurable: true,
+		writable: true,
+		async value(
+			filePath: Parameters<typeof fsp.mkdir>[0],
+			options?: Parameters<typeof fsp.mkdir>[1],
+		) {
+			if (String(filePath) === lockPath) {
+				throw Object.assign(new Error("read-only state directory"), { code: "EACCES" });
+			}
+			return originalMkdir(filePath, options);
+		},
+	});
+	try {
+		assert.deepEqual(await readState(key, { env }), value);
+		const registry = createDefaultRegistry();
+		const output = await runPipeline({
+			pipeline: [{ name: "state.get", args: { _: [key] }, raw: `state.get ${key}` }],
+			registry,
+			input: [],
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		});
+		assert.deepEqual(output.items, [value]);
+	} finally {
+		Object.defineProperty(fsp, "mkdir", {
+			configurable: true,
+			writable: true,
+			value: originalMkdir,
+		});
+		await fsp.rm(tmp, { recursive: true, force: true });
+	}
+});
+
 // --- Atomic-write behavior proofs (issues #108, #109) ---
 //
 // Plain fsp.writeFile truncates the target before writing, so a concurrent
@@ -816,6 +862,46 @@ test("withFileLock does not reclaim a replacement lock after observing a stale o
 
 	assert.equal(replaced, true);
 	assert.equal(overlap, false);
+});
+
+test("withFileLock releases its key when best-effort cleanup cannot remove the detached lock", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-release-failure-"));
+	const filePath = path.join(tmp, "snapshot.json");
+	const lockPath = `${filePath}.lock`;
+	const originalRm = fsp.rm;
+	let failReleaseOnce = true;
+
+	Object.defineProperty(fsp, "rm", {
+		configurable: true,
+		writable: true,
+		async value(filePathArg: Parameters<typeof fsp.rm>[0], options?: Parameters<typeof fsp.rm>[1]) {
+			if (failReleaseOnce && String(filePathArg).startsWith(lockPath)) {
+				failReleaseOnce = false;
+				throw Object.assign(new Error("simulated lock cleanup failure"), { code: "EIO" });
+			}
+			return originalRm(filePathArg, options);
+		},
+	});
+
+	let second: Promise<string> | undefined;
+	try {
+		await withFileLock({ filePath, task: async () => {} });
+		second = withFileLock({ filePath, task: async () => "reacquired" });
+		const settled = await Promise.race([
+			second,
+			new Promise<"timed out">((resolve) => setTimeout(() => resolve("timed out"), 75)),
+		]);
+		if (settled === "timed out") await originalRm(lockPath, { recursive: true, force: true });
+		assert.equal(settled, "reacquired", "a failed cleanup must not poison the live state lock");
+		await second;
+	} finally {
+		Object.defineProperty(fsp, "rm", {
+			configurable: true,
+			writable: true,
+			value: originalRm,
+		});
+		await originalRm(tmp, { recursive: true, force: true });
+	}
 });
 
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -10,6 +10,7 @@ import { stateSet, readState, writeState } from "../src/sdk/primitives/state.js"
 import {
 	createApprovalIndex,
 	diffAndStore,
+	keyToPath,
 	writeStateJson,
 	readStateJson,
 	writeFileAtomic,
@@ -443,7 +444,7 @@ test("diffAndStore serializes cancellation rollback before a concurrent snapshot
 	await cancelledSnapshotPublished;
 
 	let successfulSnapshotPublished = false;
-	const successful = diffAndStore({
+	const successful = writeStateJson({
 		env,
 		key: "snapshot",
 		value: { version: "successful-B" },
@@ -467,6 +468,20 @@ test("diffAndStore serializes cancellation rollback before a concurrent snapshot
 		(file) => file.includes(".tmp") || file.endsWith(".lock"),
 	);
 	assert.deepEqual(leftovers, []);
+});
+
+test("diffAndStore reclaims an old lock with a malformed owner", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-malformed-lock-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const lockPath = `${keyToPath(tmp, "snapshot")}.lock`;
+	await fsp.mkdir(lockPath);
+	await fsp.writeFile(path.join(lockPath, "owner"), "\n", "utf8");
+	const staleAt = new Date(Date.now() - 10_000);
+	await fsp.utimes(lockPath, staleAt, staleAt);
+
+	await diffAndStore({ env, key: "snapshot", value: { version: "recovered" } });
+	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "recovered" });
+	await assert.rejects(fsp.access(lockPath));
 });
 
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -462,6 +462,78 @@ test("diffAndStore serializes cancellation rollback before a concurrent snapshot
 	assert.deepEqual(leftovers, []);
 });
 
+test("state.set stops waiting for a live state lock when its signal is aborted", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-abort-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const key = "blocked";
+	const lockPath = `${keyToPath(tmp, key)}.lock`;
+	await fsp.mkdir(lockPath);
+	await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+
+	const controller = new AbortController();
+	const stateSet = createDefaultRegistry().get("state.set");
+	const pending = stateSet.run({
+		input: streamOf([{ value: true }]),
+		args: { _: [key] },
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			signal: controller.signal,
+		},
+	});
+	const completion = pending.then(
+		() => ({ kind: "success" as const }),
+		(error) => ({ kind: "error" as const, error }),
+	);
+
+	await new Promise((resolve) => setImmediate(resolve));
+	controller.abort(new Error("state lock cancelled"));
+	const early = await Promise.race([
+		completion,
+		new Promise<{ kind: "timeout" }>((resolve) =>
+			setTimeout(() => resolve({ kind: "timeout" }), 75),
+		),
+	]);
+	if (early.kind === "timeout") await fsp.rm(lockPath, { recursive: true, force: true });
+	const settled = early.kind === "timeout" ? await completion : early;
+
+	assert.notEqual(early.kind, "timeout", "state.set must not remain blocked after cancellation");
+	assert.equal(settled.kind, "error");
+	if (settled.kind === "error") assert.match(settled.error?.message ?? "", /state lock cancelled/);
+	await fsp.rm(lockPath, { recursive: true, force: true });
+});
+
+test("diffAndStore does not reclaim a live fallback lock after a short heartbeat gap", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-lease-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const key = "snapshot";
+	const lockPath = `${keyToPath(tmp, key)}.lock`;
+	const ownerPath = path.join(lockPath, "owner");
+	await fsp.mkdir(lockPath);
+	await fsp.writeFile(ownerPath, `${process.pid}::live-writer\n`, "utf8");
+	const briefGap = new Date(Date.now() - 2_000);
+	await fsp.utimes(lockPath, briefGap, briefGap);
+	await fsp.utimes(ownerPath, briefGap, briefGap);
+
+	const controller = new AbortController();
+	const abort = setTimeout(
+		() => controller.abort(new Error("live fallback lock remained held")),
+		100,
+	);
+	try {
+		await assert.rejects(
+			() => diffAndStore({ env, key, value: { version: "new" }, signal: controller.signal }),
+			/live fallback lock remained held/,
+		);
+	} finally {
+		clearTimeout(abort);
+		await fsp.rm(lockPath, { recursive: true, force: true });
+	}
+	assert.equal(await readStateJson({ env, key }), null);
+});
+
 test("diffAndStore reclaims an old lock with a malformed owner", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-malformed-lock-"));
 	const env = { LOBSTER_STATE_DIR: tmp };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -9,6 +9,8 @@ import { diffLast, diffAndStoreValue } from "../src/sdk/primitives/diff.js";
 import { stateSet, readState, writeState } from "../src/sdk/primitives/state.js";
 import {
 	createApprovalIndex,
+	consumeResumeState,
+	deleteResumeStateWithRollback,
 	diffAndStore,
 	keyToPath,
 	withFileLock,
@@ -191,6 +193,94 @@ test("writeFileAtomic propagates parent directory sync failures", async () => {
 	assert.equal(await fsp.readFile(target, "utf8"), '{"ok":true}\n');
 	const leftovers = (await fsp.readdir(tmp)).filter((f) => f.includes(".tmp"));
 	assert.deepEqual(leftovers, []);
+});
+
+test("consumeResumeState restores a published marker when parent sync fails", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-consume-dir-sync-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const expectedState = { haltType: "approval_request", pipeline: [] };
+	const fault = Object.assign(new Error("dir sync failed after resume claim"), { code: "EIO" });
+	const originalOpen = fsp.open;
+	let failNextDirectorySync = true;
+
+	await writeStateJson({ env, key: "resume", value: expectedState });
+	Object.defineProperty(fsp, "open", {
+		configurable: true,
+		writable: true,
+		async value(...args: any[]) {
+			const handle = await (originalOpen as any)(...args);
+			if (failNextDirectorySync && String(args[0]) === tmp && args[1] === "r") {
+				failNextDirectorySync = false;
+				return new Proxy(handle, {
+					get(target, property) {
+						if (property === "sync") return async () => Promise.reject(fault);
+						const value = Reflect.get(target, property);
+						return typeof value === "function" ? value.bind(target) : value;
+					},
+				});
+			}
+			return handle;
+		},
+	});
+
+	try {
+		await assert.rejects(
+			() => consumeResumeState({ env, key: "resume", expectedState }),
+			(err: NodeJS.ErrnoException) => err?.code === "EIO",
+		);
+		assert.deepEqual(await readStateJson({ env, key: "resume" }), expectedState);
+	} finally {
+		Object.defineProperty(fsp, "open", {
+			configurable: true,
+			writable: true,
+			value: originalOpen,
+		});
+	}
+});
+
+test("deleteResumeStateWithRollback restores a published marker when parent sync fails", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-delete-resume-dir-sync-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const expectedState = { haltType: "input_request", pipeline: [] };
+	const fault = Object.assign(new Error("dir sync failed after terminal resume claim"), {
+		code: "EIO",
+	});
+	const originalOpen = fsp.open;
+	let failNextDirectorySync = true;
+
+	await writeStateJson({ env, key: "resume", value: expectedState });
+	Object.defineProperty(fsp, "open", {
+		configurable: true,
+		writable: true,
+		async value(...args: any[]) {
+			const handle = await (originalOpen as any)(...args);
+			if (failNextDirectorySync && String(args[0]) === tmp && args[1] === "r") {
+				failNextDirectorySync = false;
+				return new Proxy(handle, {
+					get(target, property) {
+						if (property === "sync") return async () => Promise.reject(fault);
+						const value = Reflect.get(target, property);
+						return typeof value === "function" ? value.bind(target) : value;
+					},
+				});
+			}
+			return handle;
+		},
+	});
+
+	try {
+		await assert.rejects(
+			() => deleteResumeStateWithRollback({ env, key: "resume", expectedState }),
+			(err: NodeJS.ErrnoException) => err?.code === "EIO",
+		);
+		assert.deepEqual(await readStateJson({ env, key: "resume" }), expectedState);
+	} finally {
+		Object.defineProperty(fsp, "open", {
+			configurable: true,
+			writable: true,
+			value: originalOpen,
+		});
+	}
 });
 
 test("readStateJson surfaces malformed authoritative state", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -413,6 +413,62 @@ test("diffAndStore removes a newly published snapshot when cancellation arrives 
 	assert.deepEqual(leftovers, []);
 });
 
+test("diffAndStore serializes cancellation rollback before a concurrent snapshot update", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-concurrent-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	await writeStateJson({ env, key: "snapshot", value: { version: "before" } });
+
+	const controller = new AbortController();
+	let publishCancelledSnapshot!: () => void;
+	const cancelledSnapshotPublished = new Promise<void>((resolve) => {
+		publishCancelledSnapshot = resolve;
+	});
+	let allowCancellation!: () => void;
+	const waitForCancellation = new Promise<void>((resolve) => {
+		allowCancellation = resolve;
+	});
+	const cancelled = diffAndStore({
+		env,
+		key: "snapshot",
+		value: { version: "cancelled-A" },
+		signal: controller.signal,
+		atomicWriteOptions: {
+			async renameFile(from, to) {
+				await fsp.rename(from, to);
+				publishCancelledSnapshot();
+				await waitForCancellation;
+			},
+		},
+	});
+	await cancelledSnapshotPublished;
+
+	let successfulSnapshotPublished = false;
+	const successful = diffAndStore({
+		env,
+		key: "snapshot",
+		value: { version: "successful-B" },
+		atomicWriteOptions: {
+			async renameFile(from, to) {
+				await fsp.rename(from, to);
+				successfulSnapshotPublished = true;
+			},
+		},
+	});
+	await new Promise((resolve) => setTimeout(resolve, 20));
+	assert.equal(successfulSnapshotPublished, false, "the next writer must wait for rollback");
+
+	controller.abort(new Error("abort during concurrent atomic rename"));
+	allowCancellation();
+	await assert.rejects(cancelled, /abort during concurrent atomic rename/);
+	await successful;
+	assert.equal(successfulSnapshotPublished, true);
+	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "successful-B" });
+	const leftovers = (await fsp.readdir(tmp)).filter(
+		(file) => file.includes(".tmp") || file.endsWith(".lock"),
+	);
+	assert.deepEqual(leftovers, []);
+});
+
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-sdk-diff-corrupt-"));
 	const ctx = { env: { LOBSTER_STATE_DIR: tmp } };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -360,6 +360,59 @@ test("diffAndStore does not publish a snapshot after cancellation before atomic 
 	assert.deepEqual(leftovers, []);
 });
 
+test("diffAndStore restores the previous snapshot when cancellation arrives during atomic rename", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-rename-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	await writeStateJson({ env, key: "snapshot", value: { version: "before" } });
+
+	const controller = new AbortController();
+	await assert.rejects(
+		() =>
+			diffAndStore({
+				env,
+				key: "snapshot",
+				value: { version: "after" },
+				signal: controller.signal,
+				atomicWriteOptions: {
+					async renameFile(from, to) {
+						await fsp.rename(from, to);
+						controller.abort(new Error("abort during atomic rename"));
+					},
+				},
+			}),
+		/abort during atomic rename/,
+	);
+	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "before" });
+	const leftovers = (await fsp.readdir(tmp)).filter((file) => file.includes(".tmp"));
+	assert.deepEqual(leftovers, []);
+});
+
+test("diffAndStore removes a newly published snapshot when cancellation arrives during atomic rename", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-new-rename-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const controller = new AbortController();
+
+	await assert.rejects(
+		() =>
+			diffAndStore({
+				env,
+				key: "snapshot",
+				value: { version: "after" },
+				signal: controller.signal,
+				atomicWriteOptions: {
+					async renameFile(from, to) {
+						await fsp.rename(from, to);
+						controller.abort(new Error("abort during initial atomic rename"));
+					},
+				},
+			}),
+		/abort during initial atomic rename/,
+	);
+	assert.equal(await readStateJson({ env, key: "snapshot" }), null);
+	const leftovers = (await fsp.readdir(tmp)).filter((file) => file.includes(".tmp"));
+	assert.deepEqual(leftovers, []);
+});
+
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-sdk-diff-corrupt-"));
 	const ctx = { env: { LOBSTER_STATE_DIR: tmp } };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -488,10 +488,12 @@ test("diffAndStore reclaims an old lock after its owner PID is reused", async ()
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-reused-pid-lock-"));
 	const env = { LOBSTER_STATE_DIR: tmp };
 	const lockPath = `${keyToPath(tmp, "snapshot")}.lock`;
+	const ownerPath = path.join(lockPath, "owner");
 	await fsp.mkdir(lockPath);
-	await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}:stale-owner\n`, "utf8");
+	await fsp.writeFile(ownerPath, `${process.pid}:0:stale-owner\n`, "utf8");
 	const staleAt = new Date(Date.now() - 10_000);
 	await fsp.utimes(lockPath, staleAt, staleAt);
+	await fsp.utimes(ownerPath, staleAt, staleAt);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -414,6 +414,33 @@ test("diffAndStore removes a newly published snapshot when cancellation arrives 
 	assert.deepEqual(leftovers, []);
 });
 
+test("diffAndStore restores an existing null snapshot when cancellation arrives during atomic rename", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-null-rename-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	await writeStateJson({ env, key: "snapshot", value: null });
+	const snapshotPath = keyToPath(tmp, "snapshot");
+
+	const controller = new AbortController();
+	await assert.rejects(
+		() =>
+			diffAndStore({
+				env,
+				key: "snapshot",
+				value: { version: "after" },
+				signal: controller.signal,
+				atomicWriteOptions: {
+					async renameFile(from, to) {
+						await fsp.rename(from, to);
+						controller.abort(new Error("abort during null snapshot rename"));
+					},
+				},
+			}),
+		/abort during null snapshot rename/,
+	);
+	assert.equal(await readStateJson({ env, key: "snapshot" }), null);
+	assert.equal(await fsp.readFile(snapshotPath, "utf8"), "null\n");
+});
+
 test("diffAndStore serializes cancellation rollback before a concurrent snapshot update", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-concurrent-"));
 	const env = { LOBSTER_STATE_DIR: tmp };
@@ -532,37 +559,6 @@ test("diffAndStore does not reclaim a live fallback lock after a short heartbeat
 		await fsp.rm(lockPath, { recursive: true, force: true });
 	}
 	assert.equal(await readStateJson({ env, key }), null);
-});
-
-test("diffAndStore reclaims a live lock after its heartbeat lease expires", async () => {
-	if (process.platform !== "linux") return;
-
-	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-expired-heartbeat-"));
-	const env = { LOBSTER_STATE_DIR: tmp };
-	const key = "snapshot";
-	const lockPath = `${keyToPath(tmp, key)}.lock`;
-	const ownerPath = path.join(lockPath, "owner");
-	const processStat = await fsp.readFile(`/proc/${process.pid}/stat`, "utf8");
-	const closeParen = processStat.lastIndexOf(")");
-	const processStartIdentity = processStat
-		.slice(closeParen + 1)
-		.trim()
-		.split(/\s+/)[19];
-	assert.ok(processStartIdentity);
-
-	await fsp.mkdir(lockPath);
-	await fsp.writeFile(
-		ownerPath,
-		`${process.pid}:${processStartIdentity}:stopped-heartbeat\n`,
-		"utf8",
-	);
-	const staleAt = new Date(Date.now() - 31_000);
-	await fsp.utimes(lockPath, staleAt, staleAt);
-	await fsp.utimes(ownerPath, staleAt, staleAt);
-
-	await diffAndStore({ env, key, value: { version: "recovered" } });
-	assert.deepEqual(await readStateJson({ env, key }), { version: "recovered" });
-	await assert.rejects(fsp.access(lockPath));
 });
 
 test("diffAndStore reclaims an old lock with a malformed owner", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -784,36 +784,40 @@ test("diffAndStore reclaims an old lock with a malformed owner", async () => {
 	await assert.rejects(fsp.access(lockPath));
 });
 
-test("diffAndStore reclaims an old lock after its owner PID is reused", async () => {
-	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-reused-pid-lock-"));
-	const env = { LOBSTER_STATE_DIR: tmp };
-	const lockPath = `${keyToPath(tmp, "snapshot")}.lock`;
-	const ownerPath = path.join(lockPath, "owner");
-	await fsp.mkdir(lockPath);
-	await fsp.writeFile(ownerPath, `${process.pid}:0:stale-owner\n`, "utf8");
-	const staleAt = new Date(Date.now() - 10_000);
-	await fsp.utimes(lockPath, staleAt, staleAt);
-	await fsp.utimes(ownerPath, staleAt, staleAt);
+test(
+	"diffAndStore reclaims an old lock after its owner PID is reused",
+	{ skip: process.platform !== "linux" },
+	async () => {
+		const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-reused-pid-lock-"));
+		const env = { LOBSTER_STATE_DIR: tmp };
+		const lockPath = `${keyToPath(tmp, "snapshot")}.lock`;
+		const ownerPath = path.join(lockPath, "owner");
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(ownerPath, `${process.pid}:0:stale-owner\n`, "utf8");
+		const staleAt = new Date(Date.now() - 10_000);
+		await fsp.utimes(lockPath, staleAt, staleAt);
+		await fsp.utimes(ownerPath, staleAt, staleAt);
 
-	const controller = new AbortController();
-	const timeout = setTimeout(
-		() => controller.abort(new Error("reused lock was not reclaimed")),
-		250,
-	);
-	try {
-		await diffAndStore({
-			env,
-			key: "snapshot",
-			value: { version: "recovered" },
-			signal: controller.signal,
-		});
-	} finally {
-		clearTimeout(timeout);
-	}
-	assert.equal(controller.signal.aborted, false);
-	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "recovered" });
-	await assert.rejects(fsp.access(lockPath));
-});
+		const controller = new AbortController();
+		const timeout = setTimeout(
+			() => controller.abort(new Error("reused lock was not reclaimed")),
+			250,
+		);
+		try {
+			await diffAndStore({
+				env,
+				key: "snapshot",
+				value: { version: "recovered" },
+				signal: controller.signal,
+			});
+		} finally {
+			clearTimeout(timeout);
+		}
+		assert.equal(controller.signal.aborted, false);
+		assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "recovered" });
+		await assert.rejects(fsp.access(lockPath));
+	},
+);
 
 test("withFileLock does not reclaim a replacement lock after observing a stale one", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-replacement-"));
@@ -916,7 +920,7 @@ test("withFileLock releases its key when best-effort cleanup cannot remove the d
 		second = withFileLock({ filePath, task: async () => "reacquired" });
 		const settled = await Promise.race([
 			second,
-			new Promise<"timed out">((resolve) => setTimeout(() => resolve("timed out"), 75)),
+			new Promise<"timed out">((resolve) => setTimeout(() => resolve("timed out"), 500)),
 		]);
 		if (settled === "timed out") await originalRm(lockPath, { recursive: true, force: true });
 		assert.equal(settled, "reacquired", "a failed cleanup must not poison the live state lock");

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -534,6 +534,37 @@ test("diffAndStore does not reclaim a live fallback lock after a short heartbeat
 	assert.equal(await readStateJson({ env, key }), null);
 });
 
+test("diffAndStore reclaims a live lock after its heartbeat lease expires", async () => {
+	if (process.platform !== "linux") return;
+
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-expired-heartbeat-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	const key = "snapshot";
+	const lockPath = `${keyToPath(tmp, key)}.lock`;
+	const ownerPath = path.join(lockPath, "owner");
+	const processStat = await fsp.readFile(`/proc/${process.pid}/stat`, "utf8");
+	const closeParen = processStat.lastIndexOf(")");
+	const processStartIdentity = processStat
+		.slice(closeParen + 1)
+		.trim()
+		.split(/\s+/)[19];
+	assert.ok(processStartIdentity);
+
+	await fsp.mkdir(lockPath);
+	await fsp.writeFile(
+		ownerPath,
+		`${process.pid}:${processStartIdentity}:stopped-heartbeat\n`,
+		"utf8",
+	);
+	const staleAt = new Date(Date.now() - 31_000);
+	await fsp.utimes(lockPath, staleAt, staleAt);
+	await fsp.utimes(ownerPath, staleAt, staleAt);
+
+	await diffAndStore({ env, key, value: { version: "recovered" } });
+	assert.deepEqual(await readStateJson({ env, key }), { version: "recovered" });
+	await assert.rejects(fsp.access(lockPath));
+});
+
 test("diffAndStore reclaims an old lock with a malformed owner", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-malformed-lock-"));
 	const env = { LOBSTER_STATE_DIR: tmp };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -11,6 +11,7 @@ import {
 	createApprovalIndex,
 	diffAndStore,
 	keyToPath,
+	withFileLock,
 	writeStateJson,
 	readStateJson,
 	writeFileAtomic,
@@ -604,6 +605,82 @@ test("diffAndStore reclaims an old lock after its owner PID is reused", async ()
 	assert.equal(controller.signal.aborted, false);
 	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "recovered" });
 	await assert.rejects(fsp.access(lockPath));
+});
+
+test("withFileLock does not reclaim a replacement lock after observing a stale one", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-lock-replacement-"));
+	const filePath = path.join(tmp, "snapshot.json");
+	const lockPath = `${filePath}.lock`;
+	await fsp.mkdir(lockPath);
+	await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}:0:stale-owner\n`, "utf8");
+	const staleAt = new Date(Date.now() - 10_000);
+	await fsp.utimes(lockPath, staleAt, staleAt);
+	await fsp.utimes(path.join(lockPath, "owner"), staleAt, staleAt);
+
+	const originalReadFile = fsp.readFile;
+	let replaced = false;
+	let replacementActive = false;
+	let overlap = false;
+	let replacement: Promise<void> | undefined;
+	let releaseReplacement!: () => void;
+	const replacementReleased = new Promise<void>((resolve) => {
+		releaseReplacement = resolve;
+	});
+	let replacementStarted!: () => void;
+	const replacementEntered = new Promise<void>((resolve) => {
+		replacementStarted = resolve;
+	});
+
+	Object.defineProperty(fsp, "readFile", {
+		configurable: true,
+		writable: true,
+		async value(
+			filePathArg: Parameters<typeof fsp.readFile>[0],
+			options?: Parameters<typeof fsp.readFile>[1],
+		) {
+			const result = await originalReadFile(filePathArg, options);
+			if (!replaced && String(filePathArg) === path.join(lockPath, "owner")) {
+				replaced = true;
+				await fsp.rm(lockPath, { recursive: true, force: true });
+				replacement = withFileLock({
+					filePath,
+					task: async () => {
+						replacementActive = true;
+						replacementStarted();
+						await replacementReleased;
+						replacementActive = false;
+					},
+				});
+				await replacementEntered;
+			}
+			return result;
+		},
+	});
+
+	try {
+		const original = withFileLock({
+			filePath,
+			task: async () => {
+				if (replacementActive) overlap = true;
+			},
+		});
+		await replacementEntered;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		assert.equal(overlap, false, "the stale reclaimer must not enter beside the replacement");
+		releaseReplacement();
+		if (!replacement) throw new Error("replacement lock did not start");
+		await Promise.all([original, replacement]);
+	} finally {
+		Object.defineProperty(fsp, "readFile", {
+			configurable: true,
+			writable: true,
+			value: originalReadFile,
+		});
+		await fsp.rm(tmp, { recursive: true, force: true });
+	}
+
+	assert.equal(replaced, true);
+	assert.equal(overlap, false);
 });
 
 test("SDK diff primitives treat corrupt previous state as a miss (#112)", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -15,7 +15,7 @@ import {
 	keyToPath,
 	withFileLock,
 	writeStateJson,
-	readStateJson,
+	readStateJsonWithLock as readStateJson,
 	writeFileAtomic,
 	writeFileAtomicExclusive,
 } from "../src/state/store.js";
@@ -578,6 +578,51 @@ test("diffAndStore serializes cancellation rollback before a concurrent snapshot
 		(file) => file.includes(".tmp") || file.endsWith(".lock"),
 	);
 	assert.deepEqual(leftovers, []);
+});
+
+test("state.get waits for a diff publication to commit or roll back", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-state-read-transaction-"));
+	const env = { ...process.env, LOBSTER_STATE_DIR: tmp };
+	await writeStateJson({ env, key: "snapshot", value: { version: "before" } });
+	let markPublished!: () => void;
+	const published = new Promise<void>((resolve) => {
+		markPublished = resolve;
+	});
+	let release!: () => void;
+	const releasePublication = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const transaction = diffAndStore({
+		env,
+		key: "snapshot",
+		value: { version: "new" },
+		afterStore: async () => {
+			markPublished();
+			await releasePublication;
+			throw new Error("paired publication failed");
+		},
+	});
+	await published;
+
+	const getCmd = createDefaultRegistry().get("state.get");
+	const pendingRead = getCmd.run({
+		input: streamOf([]),
+		args: { _: ["snapshot"] },
+		ctx: { stdin: process.stdin, stdout: process.stdout, stderr: process.stderr, env },
+	});
+	const early = await Promise.race([
+		pendingRead.then(() => "settled" as const),
+		new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+	]);
+	assert.equal(early, "pending", "state.get must not expose a snapshot pending rollback");
+
+	release();
+	await assert.rejects(transaction, /paired publication failed/);
+	const result = await pendingRead;
+	const items = [];
+	for await (const item of result.output) items.push(item);
+	assert.deepEqual(items, [{ version: "before" }]);
+	await fsp.rm(tmp, { recursive: true, force: true });
 });
 
 test("state.set stops waiting for a live state lock when its signal is aborted", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -471,6 +471,33 @@ test("diffAndStore treats corrupt previous state as a miss and rewrites atomical
 	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { ok: true });
 });
 
+test("diffAndStore rolls back a state publication when its parent-directory sync fails", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-dir-sync-"));
+	const env = { LOBSTER_STATE_DIR: tmp };
+	await writeStateJson({ env, key: "snapshot", value: { version: "before" } });
+	const fault = Object.assign(new Error("dir sync failed after state publication"), {
+		code: "EIO",
+	});
+
+	await assert.rejects(
+		() =>
+			diffAndStore({
+				env,
+				key: "snapshot",
+				value: { version: "after" },
+				atomicWriteOptions: {
+					async syncParentDir() {
+						throw fault;
+					},
+				},
+			}),
+		(err: NodeJS.ErrnoException) => err?.code === "EIO",
+	);
+
+	assert.deepEqual(await readStateJson({ env, key: "snapshot" }), { version: "before" });
+	await fsp.rm(tmp, { recursive: true, force: true });
+});
+
 test("diffAndStore does not publish a snapshot after cancellation before atomic replace", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-diff-cancel-publish-"));
 	const env = { LOBSTER_STATE_DIR: tmp };

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -92,6 +92,61 @@ test("workflow file runs with approval and resume", async () => {
 	assert.deepEqual(resumeStateFiles, []);
 });
 
+test("sequential workflow approvals reclaim superseded resume markers", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-sequential-approval-"));
+	try {
+		const stateDir = path.join(tmpDir, "state");
+		const filePath = path.join(tmpDir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		await fsp.writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "first", approval: "First?" },
+					{ id: "second", approval: "Second?" },
+					{ id: "finish", command: "node -e \"process.stdout.write('{}')\"" },
+				],
+			}),
+			"utf8",
+		);
+
+		const ctx = {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool" as const,
+		};
+		const first = await runWorkflowFile({ filePath, ctx });
+		assert.equal(first.status, "needs_approval");
+		const firstPayload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+		assert.equal(firstPayload.kind, "workflow-file");
+		const second = await runWorkflowFile({
+			filePath,
+			ctx,
+			resume: firstPayload,
+			approved: true,
+		});
+		assert.equal(second.status, "needs_approval");
+		const secondPayload = decodeResumeToken(second.requiresApproval?.resumeToken ?? "");
+		assert.equal(secondPayload.kind, "workflow-file");
+		const completed = await runWorkflowFile({
+			filePath,
+			ctx,
+			resume: secondPayload,
+			approved: true,
+		});
+		assert.equal(completed.status, "ok");
+		const stateFiles = await fsp.readdir(stateDir);
+		assert.deepEqual(
+			stateFiles.filter((name) => name.startsWith("workflow_resume_")),
+			[],
+		);
+	} finally {
+		await fsp.rm(tmpDir, { recursive: true, force: true });
+	}
+});
+
 test("workflow resume cancellation cleans up resume state", async () => {
 	const workflow = {
 		steps: [

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import { createDefaultRegistry } from "../src/commands/registry.js";
 import { runWorkflowFile } from "../src/workflows/file.js";
 import { decodeResumeToken } from "../src/resume.js";
-import { readStateJson } from "../src/state/store.js";
+import { keyToPath, readStateJson } from "../src/state/store.js";
 
 function streamOf(items: unknown[]) {
 	return (async function* () {
@@ -577,6 +577,72 @@ test("workflow resume retries a timed-out effect before consuming its capability
 	assert.deepEqual(resumed.output, ["retried"]);
 	assert.equal(await fsp.readFile(attemptsPath, "utf8"), "2");
 	assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+});
+
+test("workflow resume retries a claim blocked by a state lock before dispatch", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-claim-retry-"));
+	try {
+		const stateDir = path.join(tmpDir, "state");
+		const filePath = path.join(tmpDir, "workflow.lobster");
+		await fsp.writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "approve", approval: "Proceed?" },
+					{
+						id: "effect",
+						run: "printf ran",
+						condition: "$approve.approved",
+						timeout_ms: 150,
+						retry: { max: 2, delay_ms: 220 },
+					},
+				],
+			}),
+			"utf8",
+		);
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const first = await runWorkflowFile({
+			filePath,
+			ctx: {
+				stdin: process.stdin,
+				stdout: process.stdout,
+				stderr: process.stderr,
+				env,
+				mode: "tool",
+			},
+		});
+		assert.equal(first.status, "needs_approval");
+		const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+		assert.equal(payload.kind, "workflow-file");
+		assert.ok(payload.stateKey);
+
+		const lockPath = `${keyToPath(stateDir, payload.stateKey!)}.lock`;
+		await fsp.mkdir(lockPath);
+		await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
+		const release = setTimeout(() => void fsp.rm(lockPath, { recursive: true, force: true }), 190);
+		try {
+			const resumed = await runWorkflowFile({
+				filePath,
+				ctx: {
+					stdin: process.stdin,
+					stdout: process.stdout,
+					stderr: process.stderr,
+					env,
+					mode: "tool",
+				},
+				resume: payload,
+				approved: true,
+			});
+			assert.equal(resumed.status, "ok");
+			assert.deepEqual(resumed.output, ["ran"]);
+			assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+		} finally {
+			clearTimeout(release);
+			await fsp.rm(lockPath, { recursive: true, force: true });
+		}
+	} finally {
+		await fsp.rm(tmpDir, { recursive: true, force: true });
+	}
 });
 
 test("workflow resume consumes its capability after a parallel timeout starts an effect", async () => {

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -617,18 +617,22 @@ test("workflow resume retries a claim blocked by a state lock before dispatch", 
 		assert.ok(payload.stateKey);
 
 		const lockPath = `${keyToPath(stateDir, payload.stateKey!)}.lock`;
+		const originalRename = fsp.rename;
 		const originalRm = fsp.rm;
 		let releasedInitialReadLocks = 0;
 		let lockReplaced!: () => void;
 		const replacedInitialReadLocks = new Promise<void>((resolve) => {
 			lockReplaced = resolve;
 		});
-		Object.defineProperty(fsp, "rm", {
+		Object.defineProperty(fsp, "rename", {
 			configurable: true,
 			writable: true,
-			async value(pathArg: Parameters<typeof fsp.rm>[0], options?: Parameters<typeof fsp.rm>[1]) {
-				const result = await originalRm(pathArg, options);
-				if (String(pathArg) === lockPath && ++releasedInitialReadLocks === 2) {
+			async value(
+				oldPath: Parameters<typeof fsp.rename>[0],
+				newPath: Parameters<typeof fsp.rename>[1],
+			) {
+				const result = await originalRename(oldPath, newPath);
+				if (String(oldPath) === lockPath && ++releasedInitialReadLocks === 2) {
 					await fsp.mkdir(lockPath);
 					await fsp.writeFile(
 						path.join(lockPath, "owner"),
@@ -664,10 +668,10 @@ test("workflow resume retries a claim blocked by a state lock before dispatch", 
 			assert.deepEqual(resumed.output, ["ran"]);
 			assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
 		} finally {
-			Object.defineProperty(fsp, "rm", {
+			Object.defineProperty(fsp, "rename", {
 				configurable: true,
 				writable: true,
-				value: originalRm,
+				value: originalRename,
 			});
 			await fsp.rm(lockPath, { recursive: true, force: true });
 		}

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -1858,6 +1858,76 @@ test("workflow conditions reject standalone bare identifiers", async () => {
 	);
 });
 
+test("parallel wait:any fails promptly when a registered loser ignores cancellation", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-parallel-unsettled-"));
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	const registry = {
+		get(name: string) {
+			if (name === "winner") {
+				return {
+					name,
+					help: () => "winner",
+					async run() {
+						return { output: [{ winner: true }] };
+					},
+				};
+			}
+			if (name === "never") {
+				return {
+					name,
+					help: () => "never",
+					async run() {
+						await new Promise<void>(() => {});
+					},
+				};
+			}
+			return undefined;
+		},
+	};
+
+	try {
+		await fsp.writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "parallel",
+						parallel: {
+							wait: "any",
+							branches: [
+								{ id: "winner", pipeline: "winner" },
+								{ id: "never", pipeline: "never" },
+							],
+						},
+					},
+				],
+			}),
+			"utf8",
+		);
+		await assert.rejects(
+			Promise.race([
+				runWorkflowFile({
+					filePath,
+					ctx: {
+						stdin: process.stdin,
+						stdout: process.stdout,
+						stderr: process.stderr,
+						env: { ...process.env },
+						mode: "tool",
+						registry,
+					},
+				}),
+				new Promise<never>((_resolve, reject) =>
+					setTimeout(() => reject(new Error("workflow did not finish")), 1_000),
+				),
+			]),
+			/Parallel branches did not settle after cancellation/,
+		);
+	} finally {
+		await fsp.rm(tmpDir, { recursive: true, force: true });
+	}
+});
+
 test("workflow conditions reject unknown step refs even under negation", async () => {
 	const workflow = {
 		steps: [

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -245,6 +245,86 @@ test("direct workflow resume consumes its capability after cancellation starts a
 	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
 });
 
+test("workflow template setup failure preserves an unstarted approval capability", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-template-resume-"));
+	try {
+		const stateDir = path.join(tmpDir, "state");
+		const filePath = path.join(tmpDir, "workflow.lobster");
+		const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+		const broken = {
+			steps: [
+				{ id: "approve", approval: "Continue?" },
+				{
+					id: "effect",
+					run: "node -e \"process.stdout.write('should not run')\"",
+					stdin: "$missing.stdout",
+				},
+			],
+		};
+		await fsp.writeFile(filePath, JSON.stringify(broken), "utf8");
+
+		const first = await runWorkflowFile({
+			filePath,
+			ctx: {
+				stdin: process.stdin,
+				stdout: process.stdout,
+				stderr: process.stderr,
+				env,
+				mode: "tool",
+			},
+		});
+		assert.equal(first.status, "needs_approval");
+		const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+		assert.equal(payload.kind, "workflow-file");
+		assert.ok(payload.stateKey);
+
+		await assert.rejects(
+			() =>
+				runWorkflowFile({
+					filePath,
+					ctx: {
+						stdin: process.stdin,
+						stdout: process.stdout,
+						stderr: process.stderr,
+						env,
+						mode: "tool",
+					},
+					resume: payload,
+					approved: true,
+				}),
+			/Unknown step reference: missing\.stdout/,
+		);
+		assert.notEqual(await readStateJson({ env, key: payload.stateKey! }), null);
+
+		await fsp.writeFile(
+			filePath,
+			JSON.stringify({
+				steps: [
+					{ id: "approve", approval: "Continue?" },
+					{ id: "effect", run: "node -e \"process.stdout.write('ok')\"" },
+				],
+			}),
+			"utf8",
+		);
+		const retried = await runWorkflowFile({
+			filePath,
+			ctx: {
+				stdin: process.stdin,
+				stdout: process.stdout,
+				stderr: process.stderr,
+				env,
+				mode: "tool",
+			},
+			resume: payload,
+			approved: true,
+		});
+		assert.equal(retried.status, "ok");
+		assert.deepEqual(retried.output, ["ok"]);
+	} finally {
+		await fsp.rm(tmpDir, { recursive: true, force: true });
+	}
+});
+
 test("workflow resume consumes its capability after a step timeout starts an effect", async () => {
 	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-step-timeout-"));
 	const stateDir = path.join(tmpDir, "state");

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -264,7 +264,7 @@ test("workflow resume consumes its capability after a step timeout starts an eff
 					id: "effect",
 					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
 					condition: "$approve.approved",
-					timeout_ms: 300,
+					timeout_ms: 1500,
 				},
 			],
 		}),
@@ -342,7 +342,7 @@ test("workflow resume applies on_error after a timed-out effect", async () => {
 					id: "effect",
 					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
 					condition: "$approve.approved",
-					timeout_ms: 300,
+					timeout_ms: 1500,
 					on_error: "continue",
 				},
 				{ id: "after", run: "echo continued" },
@@ -463,7 +463,7 @@ test("workflow resume consumes its capability after a parallel timeout starts an
 					id: "effect",
 					condition: "$approve.approved",
 					parallel: {
-						timeout_ms: 300,
+						timeout_ms: 1500,
 						branches: [
 							{
 								id: "side-effect",

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -154,6 +154,97 @@ test("workflow resume cancellation cleans up resume state", async () => {
 	assert.deepEqual(resumeStateFiles, []);
 });
 
+test("direct workflow resume consumes its capability after cancellation starts an effect", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-direct-cancel-"));
+	const stateDir = path.join(tmpDir, "state");
+	const effectPath = path.join(tmpDir, "effects.log");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(
+		filePath,
+		JSON.stringify({
+			steps: [
+				{
+					id: "approve",
+					command:
+						"node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?',items:[{id:1}]}}))\"",
+					approval: "required",
+				},
+				{
+					id: "effect",
+					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+					condition: "$approve.approved",
+				},
+			],
+		}),
+		"utf8",
+	);
+	const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+	const first = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+	});
+	assert.equal(first.status, "needs_approval");
+	const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+	assert.equal(payload.kind, "workflow-file");
+	assert.ok(payload.stateKey);
+
+	const controller = new AbortController();
+	const resumed = runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+			signal: controller.signal,
+		},
+		resume: payload,
+		approved: true,
+	});
+	for (let attempt = 0; attempt < 100; attempt++) {
+		try {
+			await fsp.access(effectPath);
+			break;
+		} catch {
+			if (attempt === 99) throw new Error("workflow effect did not start");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	}
+	controller.abort(new Error("cancel after dispatch"));
+	await assert.rejects(() => resumed, /cancel after dispatch/);
+	assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+	const stateFiles = await fsp.readdir(stateDir);
+	assert.equal(
+		stateFiles.some((file) => file.startsWith("approval_")),
+		false,
+	);
+
+	await assert.rejects(
+		() =>
+			runWorkflowFile({
+				filePath,
+				ctx: {
+					stdin: process.stdin,
+					stdout: process.stdout,
+					stderr: process.stderr,
+					env,
+					mode: "tool",
+				},
+				resume: payload,
+				approved: true,
+			}),
+		/Workflow resume state not found/,
+	);
+	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+});
+
 test("workflow resume accepts workflow-resume_ state key aliases and cleans up state", async () => {
 	const workflow = {
 		steps: [

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -245,6 +245,169 @@ test("direct workflow resume consumes its capability after cancellation starts a
 	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
 });
 
+test("workflow resume consumes its capability after a step timeout starts an effect", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-step-timeout-"));
+	const stateDir = path.join(tmpDir, "state");
+	const effectPath = path.join(tmpDir, "effects.log");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(
+		filePath,
+		JSON.stringify({
+			steps: [
+				{
+					id: "approve",
+					command:
+						"node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?',items:[{id:1}]}}))\"",
+					approval: "required",
+				},
+				{
+					id: "effect",
+					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+					condition: "$approve.approved",
+					timeout_ms: 300,
+				},
+			],
+		}),
+		"utf8",
+	);
+	const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+	const first = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+	});
+	assert.equal(first.status, "needs_approval");
+	const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+	assert.equal(payload.kind, "workflow-file");
+	assert.ok(payload.stateKey);
+
+	await assert.rejects(
+		() =>
+			runWorkflowFile({
+				filePath,
+				ctx: {
+					stdin: process.stdin,
+					stdout: process.stdout,
+					stderr: process.stderr,
+					env,
+					mode: "tool",
+				},
+				resume: payload,
+				approved: true,
+			}),
+		/timed out|timeout|abort|cancel/i,
+	);
+	assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+	await assert.rejects(
+		() =>
+			runWorkflowFile({
+				filePath,
+				ctx: {
+					stdin: process.stdin,
+					stdout: process.stdout,
+					stderr: process.stderr,
+					env,
+					mode: "tool",
+				},
+				resume: payload,
+				approved: true,
+			}),
+		/Workflow resume state not found/,
+	);
+	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+});
+
+test("workflow resume consumes its capability after a parallel timeout starts an effect", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-parallel-timeout-"));
+	const stateDir = path.join(tmpDir, "state");
+	const effectPath = path.join(tmpDir, "effects.log");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(
+		filePath,
+		JSON.stringify({
+			steps: [
+				{
+					id: "approve",
+					command:
+						"node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?',items:[{id:1}]}}))\"",
+					approval: "required",
+				},
+				{
+					id: "effect",
+					condition: "$approve.approved",
+					parallel: {
+						timeout_ms: 300,
+						branches: [
+							{
+								id: "side-effect",
+								run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+							},
+						],
+					},
+				},
+			],
+		}),
+		"utf8",
+	);
+	const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+	const first = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+	});
+	assert.equal(first.status, "needs_approval");
+	const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+	assert.equal(payload.kind, "workflow-file");
+	assert.ok(payload.stateKey);
+
+	await assert.rejects(
+		() =>
+			runWorkflowFile({
+				filePath,
+				ctx: {
+					stdin: process.stdin,
+					stdout: process.stdout,
+					stderr: process.stderr,
+					env,
+					mode: "tool",
+				},
+				resume: payload,
+				approved: true,
+			}),
+		/timed out|timeout|abort|cancel/i,
+	);
+	assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+	await assert.rejects(
+		() =>
+			runWorkflowFile({
+				filePath,
+				ctx: {
+					stdin: process.stdin,
+					stdout: process.stdout,
+					stderr: process.stderr,
+					env,
+					mode: "tool",
+				},
+				resume: payload,
+				approved: true,
+			}),
+		/Workflow resume state not found/,
+	);
+	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+});
+
 test("workflow resume accepts workflow-resume_ state key aliases and cleans up state", async () => {
 	const workflow = {
 		steps: [

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -758,6 +758,7 @@ test("workflow pipeline requestInput resume invariant bypasses on_error", async 
 	let sideEffects = 0;
 	const choose = {
 		name: "choose",
+		meta: { resumeSafeBeforeInput: true },
 		async run({ ctx }: any) {
 			calls += 1;
 			if (calls > 1) return { output: streamOf([{ skipped: true }]) };

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -323,6 +323,127 @@ test("workflow resume consumes its capability after a step timeout starts an eff
 	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
 });
 
+test("workflow resume applies on_error after a timed-out effect", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-timeout-on-error-"));
+	const stateDir = path.join(tmpDir, "state");
+	const effectPath = path.join(tmpDir, "effects.log");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(
+		filePath,
+		JSON.stringify({
+			steps: [
+				{
+					id: "approve",
+					command:
+						"node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?',items:[{id:1}]}}))\"",
+					approval: "required",
+				},
+				{
+					id: "effect",
+					run: `node -e "require('fs').appendFileSync(process.argv[1], 'run\\n'); setInterval(() => {}, 1000)" ${JSON.stringify(effectPath)}`,
+					condition: "$approve.approved",
+					timeout_ms: 300,
+					on_error: "continue",
+				},
+				{ id: "after", run: "echo continued" },
+			],
+		}),
+		"utf8",
+	);
+	const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+	const first = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+	});
+	assert.equal(first.status, "needs_approval");
+	const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+	assert.equal(payload.kind, "workflow-file");
+	assert.ok(payload.stateKey);
+
+	const resumed = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+		resume: payload,
+		approved: true,
+	});
+	assert.equal(resumed.status, "ok");
+	assert.deepEqual(resumed.output, ["continued\n"]);
+	assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+	assert.equal((await fsp.readFile(effectPath, "utf8")).trim().split(/\r?\n/).length, 1);
+});
+
+test("workflow resume retries a timed-out effect before consuming its capability", async () => {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-timeout-retry-"));
+	const stateDir = path.join(tmpDir, "state");
+	const attemptsPath = path.join(tmpDir, "attempts");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(
+		filePath,
+		JSON.stringify({
+			steps: [
+				{
+					id: "approve",
+					command:
+						"node -e \"process.stdout.write(JSON.stringify({requiresApproval:{prompt:'Proceed?',items:[{id:1}]}}))\"",
+					approval: "required",
+				},
+				{
+					id: "effect",
+					run: `node -e "const fs=require('fs'); const file=process.argv[1]; const attempt=fs.existsSync(file) ? Number(fs.readFileSync(file, 'utf8')) : 0; fs.writeFileSync(file, String(attempt + 1)); if (attempt === 0) setInterval(() => {}, 1000); else process.stdout.write('retried');" ${JSON.stringify(attemptsPath)}`,
+					condition: "$approve.approved",
+					timeout_ms: 300,
+					retry: { max: 2, delay_ms: 10 },
+				},
+			],
+		}),
+		"utf8",
+	);
+	const env = { ...process.env, LOBSTER_STATE_DIR: stateDir };
+	const first = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+	});
+	assert.equal(first.status, "needs_approval");
+	const payload = decodeResumeToken(first.requiresApproval?.resumeToken ?? "");
+	assert.equal(payload.kind, "workflow-file");
+	assert.ok(payload.stateKey);
+
+	const resumed = await runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env,
+			mode: "tool",
+		},
+		resume: payload,
+		approved: true,
+	});
+	assert.equal(resumed.status, "ok");
+	assert.deepEqual(resumed.output, ["retried"]);
+	assert.equal(await fsp.readFile(attemptsPath, "utf8"), "2");
+	assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
+});
+
 test("workflow resume consumes its capability after a parallel timeout starts an effect", async () => {
 	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-workflow-parallel-timeout-"));
 	const stateDir = path.join(tmpDir, "state");

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -403,7 +403,7 @@ test("workflow resume retries a timed-out effect before consuming its capability
 					id: "effect",
 					run: `node -e "const fs=require('fs'); const file=process.argv[1]; const attempt=fs.existsSync(file) ? Number(fs.readFileSync(file, 'utf8')) : 0; fs.writeFileSync(file, String(attempt + 1)); if (attempt === 0) setInterval(() => {}, 1000); else process.stdout.write('retried');" ${JSON.stringify(attemptsPath)}`,
 					condition: "$approve.approved",
-					timeout_ms: 300,
+					timeout_ms: 1500,
 					retry: { max: 2, delay_ms: 10 },
 				},
 			],

--- a/test/workflow_file.test.ts
+++ b/test/workflow_file.test.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import { createDefaultRegistry } from "../src/commands/registry.js";
 import { runWorkflowFile } from "../src/workflows/file.js";
 import { decodeResumeToken } from "../src/resume.js";
-import { keyToPath, readStateJson } from "../src/state/store.js";
+import { keyToPath, readStateJsonWithLock as readStateJson } from "../src/state/store.js";
 
 function streamOf(items: unknown[]) {
 	return (async function* () {
@@ -593,8 +593,8 @@ test("workflow resume retries a claim blocked by a state lock before dispatch", 
 						id: "effect",
 						run: "printf ran",
 						condition: "$approve.approved",
-						timeout_ms: 150,
-						retry: { max: 2, delay_ms: 220 },
+						timeout_ms: 1000,
+						retry: { max: 2, delay_ms: 250 },
 					},
 				],
 			}),
@@ -617,11 +617,31 @@ test("workflow resume retries a claim blocked by a state lock before dispatch", 
 		assert.ok(payload.stateKey);
 
 		const lockPath = `${keyToPath(stateDir, payload.stateKey!)}.lock`;
-		await fsp.mkdir(lockPath);
-		await fsp.writeFile(path.join(lockPath, "owner"), `${process.pid}::live-writer\n`, "utf8");
-		const release = setTimeout(() => void fsp.rm(lockPath, { recursive: true, force: true }), 190);
+		const originalRm = fsp.rm;
+		let releasedInitialReadLocks = 0;
+		let lockReplaced!: () => void;
+		const replacedInitialReadLocks = new Promise<void>((resolve) => {
+			lockReplaced = resolve;
+		});
+		Object.defineProperty(fsp, "rm", {
+			configurable: true,
+			writable: true,
+			async value(pathArg: Parameters<typeof fsp.rm>[0], options?: Parameters<typeof fsp.rm>[1]) {
+				const result = await originalRm(pathArg, options);
+				if (String(pathArg) === lockPath && ++releasedInitialReadLocks === 2) {
+					await fsp.mkdir(lockPath);
+					await fsp.writeFile(
+						path.join(lockPath, "owner"),
+						`${process.pid}::live-writer\n`,
+						"utf8",
+					);
+					lockReplaced();
+				}
+				return result;
+			},
+		});
 		try {
-			const resumed = await runWorkflowFile({
+			const resumedRun = runWorkflowFile({
 				filePath,
 				ctx: {
 					stdin: process.stdin,
@@ -633,11 +653,22 @@ test("workflow resume retries a claim blocked by a state lock before dispatch", 
 				resume: payload,
 				approved: true,
 			});
+			await replacedInitialReadLocks;
+			const release = setTimeout(
+				() => void originalRm(lockPath, { recursive: true, force: true }),
+				1200,
+			);
+			const resumed = await resumedRun;
+			clearTimeout(release);
 			assert.equal(resumed.status, "ok");
 			assert.deepEqual(resumed.output, ["ran"]);
 			assert.equal(await readStateJson({ env, key: payload.stateKey! }), null);
 		} finally {
-			clearTimeout(release);
+			Object.defineProperty(fsp, "rm", {
+				configurable: true,
+				writable: true,
+				value: originalRm,
+			});
 			await fsp.rm(lockPath, { recursive: true, force: true });
 		}
 	} finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes cancellation gaps in embedded tool pipelines and workflow resumes. A cancelled pipeline could start or continue later external work, remain blocked while waiting for more lazy input, report success after cancellation, persist a cancelled monitor snapshot, or leave an already-used resume capability replayable.

The remaining workflow gap occurred when an approved resume started a shell, pipeline, nested workflow, or parallel branch and a step or parallel timeout then cancelled it. The previous approval capability could remain available and replay the already-started effect. Native async generators with a permanently pending read could also make cancellation wait forever for `return()` cleanup that cannot begin.

## Why This Change Was Made

The runtime keeps cancellation prompt for sources without an explicit abort hook: it asks the iterator to close as best effort but does not wait indefinitely for an in-flight native-generator read. Sources that own pending timers, sockets, or processes still expose an abort hook so their cleanup is awaited.

Workflow execution now distinguishes an interrupted started effect from an external cancellation. Step and parallel timeouts retire the old resume capability when the invocation reaches a terminal outcome, but still honor the workflow's configured retry and `on_error` policy. A claim that times out only while waiting for a live state lock is not treated as an execution boundary: its failed memoized claim is cleared so the next retry can claim after the lock releases. Nested workflows report their own effect boundary to the parent instead of consuming the parent capability during child file setup. Pipeline terminal cleanup keeps the original approval ID until its final cancellation checkpoint, so a cleanup-only interruption can restore the exact capability.

At the first unsafe command or workflow boundary, a resumed capability is now durably replaced with a consumed marker before dispatch. That replacement compares the locked state with the snapshot loaded by the caller, so concurrent token or approval-ID resumes cannot both claim the same capability. The marker is rejected by both pipeline and workflow loaders, so an I/O failure while later deleting the state cannot make the raw token replay an already-started effect. If the directory sync after the marker rename fails before dispatch, the caller detects that publication, restores only its own marker claim under the state lock, and returns the I/O error so the original capability remains retryable. Terminal cleanup now claims and deletes under the same state lock, so a stale cancelled resume cannot write its obsolete snapshot back after another resume has settled the capability. The original short approval ID remains until the started invocation reaches a terminal result, so a restored pre-dispatch claim remains retryable by either form. Resume-safe input validation still leaves its original capability available until an unsafe boundary is reached. Explicit workflow cancellation resolves canonical and alternate state spellings before deletion, removes the non-authoritative spelling first, and only retires its approval index after all deletion succeeds. This also preserves a corrupt-but-present state file long enough for retry if cancellation interrupts the alternate lock wait.

When an approved resume stops at another safe approval or input gate, the runtime now saves the successor and atomically claims the exact predecessor snapshot before returning that successor token. A competing resume therefore discards its private successor and receives a resume-state rejection instead of creating a second executable branch. If cancellation interrupts that handoff after the predecessor marker is published, cleanup now removes the unpublished successor and its approval index even though the cancelled lock read exits immediately; only the restored predecessor remains retryable. Completed successors reclaim only their retained consumed ancestors, so sequential gates do not leak tombstones while a restored live state remains retryable.

LLM schema-validation retries now re-check cancellation before and after every adapter call and before state or cache publication, preventing an aborted invalid response from starting another request. Run-state and cache publication now form one state-locked reversible transition: if cache publication is cancelled, both a newly written run-state and a replaced prior run-state are restored along with the cache entry, and run-state readers wait for that transition to settle. `openclaw.agent` now uses the same process-group-aware runner as other local commands, so cancellation reaches descendants spawned by the OpenClaw CLI.

Explicit cancellation now stops waiting for a contested resume-state lock without first dropping the approval ID. Rejected approvals use the same delete-before-index order and pass their cancellation signal into state deletion. After a started effect is cancelled, pipeline and workflow cleanup use a bounded state-lock attempt: an uncontended tombstone is still removed, while a live writer cannot make the cancelled invocation wait indefinitely and the tombstone remains non-replayable. Even when that bounded tombstone deletion times out, the short approval-ID index is independently cleaned up on a best-effort basis. Stale-lock reclamation binds removal to the observed lock directory and claims reclamation inside that directory, so it cannot recursively remove a replacement writer's live lock. Parallel timeout and `wait: any` cleanup wait for already-started branches to settle before retry or later workflow policy continues. Lazy-output tracking forwards an abort hook that belongs to the iterator returned by an async iterable; terminal lazy output uses the same abort-aware path and never pulls a later item after cancellation. Iterator acquisition is inside the stage's guarded cleanup path. `diffAndStore` records whether a prior state file existed, so cancellation restores a stored JSON `null` rather than deleting it. A live owner with a matching process identity is no longer reclaimed only because its heartbeat timestamp was delayed.

Same-stage input now retains its original state through safe response delivery; the first non-resume-safe command claims it atomically immediately before dispatch. Workflow shell, loop, pipeline, and parallel branches likewise resolve templates, stdin, and pipeline setup before crossing that boundary. This keeps malformed setup retryable rather than consuming an approval before a process or command starts. Lazy-output tracking falls back from an iterator-owned abort hook to an iterable-owned hook with the correct receiver. CLI resume cleanup catches signal-interrupted state-lock errors as a tool envelope, and the outer signal handler preserves the conventional exit code for SIGINT, SIGTERM, SIGHUP, or SIGQUIT.

State-lock release now atomically detaches an owned lock before best-effort deletion, so a cleanup error cannot leave the canonical lock path blocked by the still-live owner PID. Normal readers continue to wait for a writer's publish-or-rollback transition; only an inability to create the lock in a readable read-only state directory falls back to a direct JSON read. A pre-aborted pipeline resume now returns its cancellation envelope before reading a contested state lock, preserving its untouched capability for retry. Configured workflow timeouts now request immediate process-tree termination only when their own timeout fires; external cancellation and `parallel.wait: any` retain graceful SIGTERM cleanup. The CLI bridges SIGHUP and SIGQUIT as well as SIGINT and SIGTERM, and a second terminating signal immediately force-kills managed process groups.

When a parent-directory sync fails after an atomic cache or state rename, the paired cache entry and run-state snapshot are restored while their locks are still held, so an error cannot publish a reusable result. Cache reads use the same read-only fallback as state records when lock creation is forbidden. `parallel.wait: any` now bounds cancellation cleanup and returns a cleanup error rather than waiting forever for a registered command that ignores abort. Managed processes running under a derived step or branch signal also register with the CLI root termination channel, so a second terminating signal immediately reaches their process groups.

This keeps the behavior in Lobster's canonical workflow and runtime cancellation boundaries. Token formats, workflow schemas, CLI syntax, configuration, and dependencies are unchanged.

## User Impact

An approved workflow or pipeline can start an effect at most once, even if the same token or approval ID is resumed concurrently. An approved workflow that starts an effect and then times out, is interrupted, or returns a non-abort error cannot be resumed again to run that effect twice. If the workflow explicitly asks to retry or continue after that timeout, the configured policy runs inside the same approved invocation before the capability is retired. Parallel timeout and `wait: any` paths do not begin retry or later workflow policy while their already-started branches are still settling. Setup-only cancellation, malformed workflow setup, resume-safe input validation, same-stage resume-safe input cancellation, and terminal pipeline cleanup cancellation remain retryable without losing the capability, including the original short approval ID. Explicit cancellation or rejection of a locked state exits promptly while preserving the approval capability for retry. Signal-interrupted CLI cleanup returns a machine-readable error and the conventional signal exit status. Cancellation also returns promptly when a legacy native async generator cannot interrupt its pending read, while resource-owning sources retain awaited cleanup through an abort hook on either the iterable or its iterator.

Concurrent resumes that pause at a second approval or input gate now yield one successor capability, not two. Cancelling an LLM invocation during schema validation stops bounded retries; cancelling a cache refresh preserves the prior usable cache entry; and cancelling an `openclaw.agent` turn also stops its child process tree. A failed state-lock cleanup cannot strand future work behind a live PID, while read-only state directories remain usable for state reads. A pre-aborted resume remains retryable without waiting for a held lock, and user cancellation or a `wait: any` loser gets SIGTERM instead of an unintended immediate SIGKILL. If a non-cooperative parallel loser cannot settle, the workflow reports cleanup failure instead of hanging; a cache/state durability failure leaves neither result reusable; and a repeated CLI signal also immediately terminates timed or parallel process groups.

## Evidence

Validation passed on the current candidate:

- formatting check passed;
- TypeScript typecheck passed;
- full repository suite passed: 446 tests;
- a tool-mode Lobster CLI workflow paused for approval, resumed into a started shell effect, timed out, removed its resume capability, and rejected a replay without a second effect;
- two independent real CLI resume processes using the same approval produced one effect, one successful result, and one `Workflow resume state not found` rejection; a cancelled stale resume cannot restore a capability that a different resume has already settled;
- concurrent real CLI resumes that paused at the next safe input gate produced exactly one successor in both pipeline and workflow paths; resuming that winner executed one external effect;
- cancellation immediately after a pipeline gate handoff leaves only the restored predecessor capability and its approval index, never an executable orphan successor;
- a second real CLI resume held behind a live state lock emitted a structured `runtime_error` envelope and exited 130 after SIGINT while its original state remained available.

Additional regression coverage verifies atomic lock detachment after best-effort cleanup failure, read-only state reads and cache reads, pre-aborted resume behavior under a live lock, cache/state rollback after post-rename directory-sync failure, SIGHUP and repeated-SIGINT process-tree termination through a derived timeout signal, bounded `wait: any` cleanup for a non-cooperative registered command, and graceful external-cancellation behavior when a workflow timeout is merely configured.

The latest regression coverage also verifies that LLM cache-publication cancellation rolls back its paired run-state, public state readers wait for that rollback to settle, and cancellation while waiting for the LLM state lock is interruptible. A pre-aborted pipeline still leaves its resume capability retryable because it has not crossed an effect boundary.

Raw CLI runtime transcript:

```text
trigger: approved Lobster CLI workflow resume started its shell effect
transition: {
  "protocolVersion": 1,
  "ok": false,
  "error": {
    "type": "runtime_error",
    "message": "Step 'effect' timed out after 1500ms"
  }
}
after-fix replay: {
  "protocolVersion": 1,
  "ok": false,
  "error": {
    "type": "runtime_error",
    "message": "Workflow resume state not found"
  }
}
after-fix concurrent resume exit codes: 0, 1
after-fix SIGINT under live state lock: exit=130 {
  "protocolVersion": 1,
  "ok": false,
  "error": {
    "type": "runtime_error",
    "message": "Received SIGINT"
  }
}
```

The regression suite covers atomic one-time consumption for token and approval-ID resumes in both pipeline and workflow paths, cancellation immediately after the consumed-marker rename, post-rename directory-sync rollback before dispatch, approval-ID retention through a started invocation's terminal result, malformed workflow template setup before dispatch, a state-lock-blocked claim that retries before dispatch, consumed-state replay rejection after cleanup I/O failure, canonical/alternate workflow state-lock ordering, bounded started-effect cleanup under lock contention, replacement-lock reclamation without overlapping critical sections, resumed step and parallel timeouts, timeout `on_error` and retry handling, terminal and replacement cleanup under lock contention, same-stage pipeline and workflow input recovery, parallel timeout settlement before retry, nested workflow setup cancellation, terminal approval-ID cleanup, approval rejection under lock contention, cache and run-state rollback after cancelled cache publication or refresh, iterable- and iterator-owned abort hooks, terminal stalled lazy output, no post-cancellation iterator pull, iterator acquisition cleanup, CLI SIGINT cleanup envelopes, `null` state rollback, conservative live-lock recovery, and a permanently stalled native async generator. The CLI proof exercises Lobster's standalone workflow/resume path; it does not traverse OpenClaw Gateway.
