### PR TITLE
test(commands): cover the where filter command

### DIFF
--- a/test/where.test.ts
+++ b/test/where.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runPipeline } from "../src/runtime.js";
+import { createDefaultRegistry } from "../src/commands/registry.js";
+import { parsePipeline } from "../src/parser.js";
+
+async function run(pipelineText: string, input: any[]) {
+	const pipeline = parsePipeline(pipelineText);
+	const registry = createDefaultRegistry();
+	const res = await runPipeline({
+		pipeline,
+		registry,
+		stdin: process.stdin,
+		stdout: process.stdout,
+		stderr: process.stderr,
+		env: process.env,
+		mode: "tool",
+		input: (async function* () {
+			for (const x of input) yield x;
+		})(),
+	});
+	return res.items;
+}
+
+test("where coerces a numeric literal and filters with >=", async () => {
+	const input = [{ n: 10 }, { n: 30 }, { n: 50 }];
+	const out = await run("where n>=30", input);
+	assert.deepEqual(out, [{ n: 30 }, { n: 50 }]);
+});
+
+test("where normalizes a single = to == and coerces true", async () => {
+	const input = [
+		{ unread: true, id: 1 },
+		{ unread: false, id: 2 },
+	];
+	const out = await run("where unread=true", input);
+	assert.deepEqual(out, [{ unread: true, id: 1 }]);
+});
+
+test("where coerces the false literal to a boolean", async () => {
+	const input = [
+		{ unread: true, id: 1 },
+		{ unread: false, id: 2 },
+	];
+	const out = await run("where unread=false", input);
+	assert.deepEqual(out, [{ unread: false, id: 2 }]);
+});
+
+test("where resolves a dotted path with ==", async () => {
+	const input = [{ user: { id: "u1" } }, { user: { id: "u2" } }];
+	const out = await run("where user.id==u1", input);
+	assert.deepEqual(out, [{ user: { id: "u1" } }]);
+});
+
+test("where keeps a non-coercible right-hand side as a string", async () => {
+	const input = [
+		{ status: "active", id: 1 },
+		{ status: "closed", id: 2 },
+	];
+	const out = await run("where status==active", input);
+	assert.deepEqual(out, [{ status: "active", id: 1 }]);
+});
+
+test("where supports the != operator", async () => {
+	const input = [
+		{ kind: "spam", id: 1 },
+		{ kind: "ham", id: 2 },
+	];
+	const out = await run("where kind!=spam", input);
+	assert.deepEqual(out, [{ kind: "ham", id: 2 }]);
+});
+
+test("where supports the strict ordering operators < and >", async () => {
+	const input = [{ n: 1 }, { n: 5 }, { n: 9 }];
+	assert.deepEqual(await run("where n<5", input), [{ n: 1 }]);
+	assert.deepEqual(await run("where n>5", input), [{ n: 9 }]);
+});
+
+test("where supports the inclusive ordering operator <=", async () => {
+	const input = [{ n: 1 }, { n: 5 }, { n: 9 }];
+	const out = await run("where n<=5", input);
+	assert.deepEqual(out, [{ n: 1 }, { n: 5 }]);
+});
+
+test("where coerces the null literal and matches missing paths via loose equality", async () => {
+	// getPath returns undefined for the missing key, and undefined == null is true,
+	// so both the explicit-null and the missing-key rows pass; the numeric 0 does not.
+	const input = [{ x: null, id: 1 }, { x: 0, id: 3 }, { id: 2 }];
+	const out = await run("where x=null", input);
+	assert.deepEqual(out, [{ x: null, id: 1 }, { id: 2 }]);
+});
+
+test("where returns undefined (excluding the row) when a dotted path hits a non-object", async () => {
+	const input = [{ a: { b: 1 } }, { a: 5 }];
+	const out = await run("where a.b==1", input);
+	assert.deepEqual(out, [{ a: { b: 1 } }]);
+});
+
+test("where throws when the expression is missing", async () => {
+	await assert.rejects(run("where", [{ n: 1 }]), /where requires an expression/);
+});
+
+test("where throws on an expression with no operator", async () => {
+	await assert.rejects(run("where garbage", [{ n: 1 }]), /Invalid where expression/);
+});


### PR DESCRIPTION
## What Problem This Solves

`where` is a core stdlib pipeline command (`... | where minutes>=30`) that filters streamed objects by a small predicate, yet `src/commands/stdlib/where.ts` shipped with **no direct test coverage**. The only existing reference to it in the test tree is `parser.test.ts`, which asserts the parsed stage *name* is `"where"` — it never executes the command, so none of the command's actual behavior is pinned:

- literal coercion in `parsePredicate` (`"true"`/`"false"`/`"null"`/numeric strings),
- the `=` → `==` operator normalization,
- dotted-path resolution in `getPath` (and its non-object safety),
- the six comparison operators in `compare` (with intentional loose equality),
- the two throw paths (missing expression / operator-less expression).

A regression in any of these — e.g. dropping the numeric coercion, or breaking the `=`→`==` normalization so `where unread=true` silently throws — would not be caught before merge.

## Why This Change Was Made

Coverage-only. This adds one new file, `test/where.test.ts` (+106, no production code touched), pinning the command's current `main` behavior. Tests drive the **real** command end-to-end through `parsePipeline` + `runPipeline` (the same harness `sort.test.ts` / `group_by.test.ts` use), not a unit stub of the internal helpers, so they exercise the production path a user actually hits. No new config, defaults, dependencies, or behavior — the diff is a single test file.

## User Impact

No user-visible or runtime change. For maintainers, the `where` filter's coercion/normalization/path/operator gates now regress loudly instead of silently: a future edit that breaks the `=`→`==` normalization, the literal coercion, the nested-path safety, or an operator will fail this suite.

## Evidence

Linux, Node 22.22, `pnpm install` from source, branched off current `main` (`c2ff7d0`). Compiled with `tsc -p tsconfig.json` and run with the repo's `node --test` harness.

**12/12 pass on clean `main`:**

```text
$ node --test dist/test/where.test.js
# tests 12
# pass 12
# fail 0
```

**Non-vacuous — the suite bites when the target is mutated** (mutation applied to `src/commands/stdlib/where.ts`, recompiled, suite re-run, then reverted):

| Mutation to `where.ts` | Result |
| --- | --- |
| drop the `=` → `==` normalization | 3 fail |
| drop the `"true"` → boolean coercion | 1 fail |
| `>=` returns `left > right` | 1 fail |
| `getPath` stops traversing (`cur = cur`) | 10 fail |
| *(reverted — control)* | **12 pass** |

**Format / lint on the new file:**

```text
$ oxfmt --check test/where.test.ts        # All matched files use the correct format.
$ oxlint --tsconfig tsconfig.json test/where.test.ts   # exit 0
```

**Scope note:** the full suite has 69 pre-existing failures on `main@c2ff7d0` that are unrelated to this change (they exercise subprocess/CLI/LLM paths — e.g. the approval-CLI, `bin_smoke`, cost tracking — that don't run in this sandbox). The count is identical with and without this file (309 tests → 69 fail without it; 321 tests → 69 fail with it), and all 12 added tests pass — this diff adds no failure and touches no production code.

_Generated by [Claude Code](https://claude.ai/code/session_01VFYwKK9F66vQt1DHS7arXq)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpLQSFLXSkqD4h5UNtfL1G)_