### PR TITLE
fix: workflow run crashes when a step exits before reading its stdin

### DIFF
--- a/src/commands/stdlib/exec.ts
+++ b/src/commands/stdlib/exec.ts
@@ -108,6 +108,12 @@ function runProcess(command, argv, { env, cwd, stdin, signal }) {
 			stderr += d;
 		});
 
+		// A child that exits before draining stdin (e.g. a fast preamble
+		// failure) surfaces EPIPE on this socket as an 'error' event; without a
+		// listener that crashes the whole process. The close handler already
+		// reports the real exit code and stderr, so stdin write errors are safe
+		// to ignore.
+		child.stdin.on("error", () => {});
 		if (typeof stdin === "string") {
 			child.stdin.setDefaultEncoding("utf8");
 			child.stdin.write(stdin);

--- a/src/commands/stdlib/exec.ts
+++ b/src/commands/stdlib/exec.ts
@@ -108,11 +108,8 @@ function runProcess(command, argv, { env, cwd, stdin, signal }) {
 			stderr += d;
 		});
 
-		// A child that exits before draining stdin (e.g. a fast preamble
-		// failure) surfaces EPIPE on this socket as an 'error' event; without a
-		// listener that crashes the whole process. The close handler already
-		// reports the real exit code and stderr, so stdin write errors are safe
-		// to ignore.
+		// EPIPE is expected when the child exits before draining stdin; the
+		// close handler reports the real exit code and stderr.
 		child.stdin.on("error", () => {});
 		if (typeof stdin === "string") {
 			child.stdin.setDefaultEncoding("utf8");

--- a/src/commands/stdlib/exec.ts
+++ b/src/commands/stdlib/exec.ts
@@ -108,8 +108,6 @@ function runProcess(command, argv, { env, cwd, stdin, signal }) {
 			stderr += d;
 		});
 
-		// EPIPE is expected when the child exits before draining stdin; the
-		// close handler reports the real exit code and stderr.
 		child.stdin.on("error", () => {});
 		if (typeof stdin === "string") {
 			child.stdin.setDefaultEncoding("utf8");

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -2801,11 +2801,8 @@ async function runShellCommand({
 			stderr += d;
 		});
 
-		// A child that exits before draining stdin (e.g. a fast preamble
-		// failure) surfaces EPIPE on this socket as an 'error' event; without a
-		// listener that crashes the whole process. The close handler already
-		// reports the real exit code and stderr, so stdin write errors are safe
-		// to ignore.
+		// EPIPE is expected when the child exits before draining stdin; the
+		// close handler reports the real exit code and stderr.
 		child.stdin.on("error", () => {});
 		if (typeof stdin === "string") {
 			child.stdin.setDefaultEncoding("utf8");

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -2801,8 +2801,6 @@ async function runShellCommand({
 			stderr += d;
 		});
 
-		// EPIPE is expected when the child exits before draining stdin; the
-		// close handler reports the real exit code and stderr.
 		child.stdin.on("error", () => {});
 		if (typeof stdin === "string") {
 			child.stdin.setDefaultEncoding("utf8");

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -2801,6 +2801,12 @@ async function runShellCommand({
 			stderr += d;
 		});
 
+		// A child that exits before draining stdin (e.g. a fast preamble
+		// failure) surfaces EPIPE on this socket as an 'error' event; without a
+		// listener that crashes the whole process. The close handler already
+		// reports the real exit code and stderr, so stdin write errors are safe
+		// to ignore.
+		child.stdin.on("error", () => {});
 		if (typeof stdin === "string") {
 			child.stdin.setDefaultEncoding("utf8");
 			child.stdin.write(stdin);

--- a/test/step_stdin_epipe.test.ts
+++ b/test/step_stdin_epipe.test.ts
@@ -27,12 +27,10 @@ async function runWorkflow(workflow: unknown) {
 }
 
 test("a step that exits before draining large stdin fails cleanly instead of crashing", async () => {
-	// The first step's stdout exceeds the OS pipe buffer (64KB on Linux), so the
-	// engine's write into the second step's stdin is still pending when that
-	// step exits without reading. Before the stdin error guard, the resulting
-	// EPIPE was emitted as an unhandled 'error' event on the stdin socket and
-	// took down the whole engine process (losing approval gates and resume
-	// tokens) instead of reporting the step failure.
+	// 300KB exceeds the OS pipe buffer (64KB on Linux), so the write to the
+	// second step's stdin is still pending when that step exits without reading.
+	// Before the EPIPE guard, this crashed the engine instead of reporting the
+	// step failure.
 	await assert.rejects(
 		() =>
 			runWorkflow({

--- a/test/step_stdin_epipe.test.ts
+++ b/test/step_stdin_epipe.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { promises as fsp } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createDefaultRegistry } from "../src/commands/registry.js";
+import { runWorkflowFile } from "../src/workflows/file.js";
+
+async function runWorkflow(workflow: unknown) {
+	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-stdin-epipe-"));
+	const stateDir = path.join(tmpDir, "state");
+	const filePath = path.join(tmpDir, "workflow.lobster");
+	await fsp.writeFile(filePath, JSON.stringify(workflow, null, 2), "utf8");
+
+	return runWorkflowFile({
+		filePath,
+		ctx: {
+			stdin: process.stdin,
+			stdout: process.stdout,
+			stderr: process.stderr,
+			env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+			mode: "tool",
+			registry: createDefaultRegistry(),
+		},
+	});
+}
+
+test("a step that exits before draining large stdin fails cleanly instead of crashing", async () => {
+	// The first step's stdout exceeds the OS pipe buffer (64KB on Linux), so the
+	// engine's write into the second step's stdin is still pending when that
+	// step exits without reading. Before the stdin error guard, the resulting
+	// EPIPE was emitted as an unhandled 'error' event on the stdin socket and
+	// took down the whole engine process (losing approval gates and resume
+	// tokens) instead of reporting the step failure.
+	await assert.rejects(
+		() =>
+			runWorkflow({
+				steps: [
+					{
+						id: "big",
+						command: "node -e \"process.stdout.write('x'.repeat(300000))\"",
+					},
+					{
+						id: "fast_fail",
+						command: 'node -e "process.exit(1)"',
+						stdin: "$big.stdout",
+					},
+				],
+			}),
+		/workflow command failed \(1\)/,
+	);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running a workflow whose step receives a large piped `stdin` (larger than the OS pipe buffer, 64KB on Linux) would crash the entire `lobster run` process when that step exits before reading its input — for example a shell script failing an early `set -e` preamble check (missing file, unwritable state directory). Instead of the normal `workflow command failed (N)` error, the engine died with:

```
Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:87:19)
Emitted 'error' event on Socket instance at:
...
```

The crash destroys the run's approval gate and resume token and swallows the failing step's real exit code and stderr, so operators see a Node stack trace instead of their step's actual error. Hit in production on 2026-07-17 by a multi-step sales workflow handing a ~250KB JSON envelope between steps.

## Why This Change Was Made

`runShellCommand` (workflow shell steps) and the stdlib `exec` runner write step stdin to the spawned child without an `error` listener on `child.stdin`, so a pending write failing with EPIPE becomes an unhandled `'error'` event and takes down the process. The fix attaches a no-op `error` handler before writing in both spawn sites: stdin write errors are always a symptom of child exit, and the existing `close` handler already reports the authoritative exit code and stderr. No behavior change for healthy steps; non-goal: retrying or buffering stdin.

## User Impact

A step that fails fast now surfaces as the normal `workflow command failed (N): <stderr>` rejection — approval gates, resume tokens, and `on_error` handling keep working, and the step's real error is visible instead of an engine stack trace.

## Evidence

### Regression test (automated)

```
$ node --test dist/test/step_stdin_epipe.test.js
TAP version 13
# Subtest: a step that exits before draining large stdin fails cleanly instead of crashing
ok 1 - a step that exits before draining large stdin fails cleanly instead of crashing
  ---
  duration_ms: 78.131327
  type: 'test'
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
```

### Full test suite

```
# tests 310
# suites 0
# pass 310
# fail 0
# cancelled 0
# skipped 0
# todo 0
```

### Lint

```
$ oxlint --tsconfig tsconfig.json bin src test
Found 4 warnings and 0 errors.   (pre-existing, not from this PR)
```

### End-to-end proof: 250KB piped stdin → fast-exiting step

**Before fix (main branch — unpatched):**

```
$ lobster run 250KB-pipe-to-fast-fail.lobster
node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:87:19)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}

Node.js v22.21.1
exit code: 1
```

**After fix (PR branch):**

```
$ lobster run 250KB-pipe-to-fast-fail.lobster
Error: workflow command failed (1): node -e "process.exit(1)"
exit code: 1
```

The fix surfaces the step's real exit code and stderr instead of crashing with an unhandled EPIPE. Approval gates, resume tokens, and `on_error` handling all remain operative.
