### PR TITLE
fix(deps): resolve fast-uri security alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: 3.1.4
+
 importers:
 
   .:
@@ -443,8 +446,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -710,13 +713,13 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   json-schema-traverse@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - '.'
 
+overrides:
+  fast-uri: 3.1.4
+
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - '@typescript/typescript-aix-ppc64@7.0.2'


### PR DESCRIPTION
## What Problem This Solves

Resolves the open high-severity `fast-uri` Dependabot alert:

- Alert 1: https://github.com/openclaw/lobster/security/dependabot/1
- GHSA-v2hh-gcrm-f6hx: https://github.com/advisories/GHSA-v2hh-gcrm-f6hx
- Vulnerable range: `>= 3.0.0, <= 3.1.3`
- First patched release: `3.1.4`

## Why This Change Was Made

Adds a workspace override for `fast-uri@3.1.4` and refreshes the lockfile so Ajv resolves the patched release. The direct dependency graph and application behavior remain unchanged.

## User Impact

Lobster no longer installs the vulnerable `fast-uri@3.1.3` transitive dependency. There is no user-facing API or workflow change.

## Evidence

- Signed commit: `06695a055b7eab83fc73f36c6a52ec998c31d40a`
- AWS Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_6e8c241f26c1
- Provider: AWS Crabbox, Node.js 24.18.0, pnpm 10.34.4
- `CI=1 pnpm install --frozen-lockfile`: passed
- `pnpm lint`: passed with 0 errors and 4 pre-existing warnings
- `pnpm test`: 309 passed, 0 failed
- `pnpm audit --prod`: no known vulnerabilities
- Structured autoreview: clean, no accepted or actionable findings
