### PR TITLE
feat(llm.invoke): add MiniMax provider adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Use `llm.invoke` from a native `pipeline:` step for model-backed work:
 llm.invoke --prompt 'Summarize this diff'
 llm.invoke --provider openclaw --prompt 'Summarize this diff'
 llm.invoke --provider pi --prompt 'Summarize this diff'
+llm.invoke --provider minimax --prompt 'Summarize this diff'
 ```
 
 Provider resolution order:
@@ -270,6 +271,7 @@ Built-in providers today:
 - `openclaw` via `OPENCLAW_URL` / `OPENCLAW_TOKEN`
 - `pi` via `LOBSTER_PI_LLM_ADAPTER_URL` (typically supplied by the Pi extension)
 - `http` via `LOBSTER_LLM_ADAPTER_URL`
+- `minimax` via `MINIMAX_API_KEY`, calling the OpenAI-compatible endpoint. Select the endpoint with `--region global_en` (default) or `--region cn_zh`, or override with `--base-url`. Models default to `MiniMax-M3` (also `MiniMax-M2.7`).
 
 Workflow `_meta.cost` and `cost_limit` use a static pricing table plus optional overrides from `LOBSTER_LLM_PRICING_JSON`, for example `{"my-model":{"input":1.0,"output":2.0}}` in USD per million tokens. Unknown or missing model IDs still record token counts with zero estimated cost, but Lobster warns on stderr so stale or missing pricing does not fail silently.
 

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -106,7 +106,13 @@ const validateResponseEnvelope = ajv.compile(responseSchema);
 const DEFAULT_MAX_VALIDATION_RETRIES = 1;
 const STATE_VERSION = 1;
 
-type BuiltInProvider = "openclaw" | "pi" | "http";
+type BuiltInProvider = "openclaw" | "pi" | "http" | "minimax";
+
+const MINIMAX_DEFAULT_MODEL = "MiniMax-M3";
+const MINIMAX_REGION_BASE_URLS: Record<string, string> = {
+	global_en: "https://api.minimax.io/v1",
+	cn_zh: "https://api.minimaxi.com/v1",
+};
 type SupportedProvider = BuiltInProvider | string;
 
 type LlmResponseEnvelope = {
@@ -208,10 +214,11 @@ export const llmInvokeCommand = createLlmInvokeCommand({
 	helpTitle: "llm.invoke — call a configured LLM adapter with caching and schema validation",
 	helpConfig: [
 		"Provider resolution order: --provider, LOBSTER_LLM_PROVIDER, then environment auto-detect.",
-		"Built-in providers: openclaw, pi, http.",
+		"Built-in providers: openclaw, pi, http, minimax.",
 		"OpenClaw provider uses OPENCLAW_URL (CLAWD_URL also supported) and OPENCLAW_TOKEN.",
 		"Pi provider uses LOBSTER_PI_LLM_ADAPTER_URL and is intended to be supplied by a Pi extension.",
 		"Generic http provider uses LOBSTER_LLM_ADAPTER_URL and optional LOBSTER_LLM_ADAPTER_TOKEN.",
+		"MiniMax provider uses MINIMAX_API_KEY with --region global_en (default) or cn_zh; models default to MiniMax-M3 (also MiniMax-M2.7).",
 	],
 	helpExamples: [
 		"llm.invoke --prompt 'Write summary'",
@@ -258,7 +265,8 @@ export function createLlmInvokeCommand(config: CommandConfig): LobsterCommand {
 				properties: {
 					provider: {
 						type: "string",
-						description: "LLM adapter provider (openclaw, pi, http). Optional if auto-detected.",
+						description:
+							"LLM adapter provider (openclaw, pi, http, minimax). Optional if auto-detected.",
 					},
 					token: {
 						type: "string",
@@ -268,6 +276,14 @@ export function createLlmInvokeCommand(config: CommandConfig): LobsterCommand {
 					model: {
 						type: "string",
 						description: "Model identifier. Optional; adapter defaults may apply if omitted.",
+					},
+					region: {
+						type: "string",
+						description: "MiniMax region selector: global_en (default) or cn_zh.",
+					},
+					"base-url": {
+						type: "string",
+						description: "Override the provider base URL (MiniMax OpenAI-compatible endpoint).",
 					},
 					"artifacts-json": { type: "string", description: "JSON array of artifacts to send" },
 					"metadata-json": { type: "string", description: "JSON object of metadata to include" },
@@ -506,7 +522,12 @@ function resolveProvider(
 		.trim()
 		.toLowerCase();
 	if (explicit) {
-		if (explicit === "openclaw" || explicit === "pi" || explicit === "http") {
+		if (
+			explicit === "openclaw" ||
+			explicit === "pi" ||
+			explicit === "http" ||
+			explicit === "minimax"
+		) {
 			return explicit;
 		}
 		if (getDirectAdapter(ctx, explicit)) {
@@ -523,6 +544,7 @@ function resolveProvider(
 	if (String(env.LOBSTER_PI_LLM_ADAPTER_URL ?? "").trim()) return "pi";
 	if (String(env.OPENCLAW_URL ?? env.CLAWD_URL ?? "").trim()) return "openclaw";
 	if (String(env.LOBSTER_LLM_ADAPTER_URL ?? "").trim()) return "http";
+	if (String(env.MINIMAX_API_KEY ?? env.LOBSTER_MINIMAX_API_KEY ?? "").trim()) return "minimax";
 	throw new Error(
 		"llm.invoke could not resolve a provider. Set --provider or LOBSTER_LLM_PROVIDER",
 	);
@@ -580,6 +602,23 @@ function resolveAdapter({
 			source: config.sourceForProvider?.(provider) ?? "pi",
 			async invoke({ payload }) {
 				return invokeHttpAdapter({ endpoint: buildAdapterEndpoint(adapterUrl), token, payload });
+			},
+		};
+	}
+
+	if (provider === "minimax") {
+		const token = String(
+			args.token ?? env.MINIMAX_API_KEY ?? env.LOBSTER_MINIMAX_API_KEY ?? "",
+		).trim();
+		if (!token) {
+			throw new Error(`${config.name} requires MINIMAX_API_KEY for provider=minimax`);
+		}
+		const endpoint = buildMinimaxEndpoint(resolveMinimaxBaseUrl(args, env));
+		return {
+			provider,
+			source: config.sourceForProvider?.(provider) ?? "minimax",
+			async invoke({ payload }) {
+				return invokeMinimaxAdapter({ endpoint, token, payload });
 			},
 		};
 	}
@@ -700,6 +739,129 @@ async function invokeHttpAdapter({
 		return parsed as LlmResponseEnvelope;
 	}
 	return { ok: true, result: parsed } as LlmResponseEnvelope;
+}
+
+function resolveMinimaxRegion(args: any, env: any): "global_en" | "cn_zh" {
+	const raw = String(args.region ?? env.MINIMAX_REGION ?? "")
+		.trim()
+		.toLowerCase();
+	if (["cn", "cn_zh", "china", "zh"].includes(raw)) return "cn_zh";
+	return "global_en";
+}
+
+export function resolveMinimaxBaseUrl(args: any, env: any) {
+	const explicit = String(args["base-url"] ?? env.MINIMAX_BASE_URL ?? "").trim();
+	if (explicit) return explicit;
+	return MINIMAX_REGION_BASE_URLS[resolveMinimaxRegion(args, env)];
+}
+
+export function buildMinimaxEndpoint(rawUrl: string) {
+	const endpoint = new URL(rawUrl);
+	const normalizedPath = endpoint.pathname.replace(/\/+$/, "");
+	if (!normalizedPath.endsWith("/chat/completions")) {
+		endpoint.pathname = `${normalizedPath}/chat/completions`;
+	}
+	return endpoint;
+}
+
+function buildMinimaxMessages(payload: Record<string, any>) {
+	const parts: string[] = [];
+	if (payload.prompt) parts.push(String(payload.prompt));
+	const artifacts = Array.isArray(payload.artifacts) ? payload.artifacts : [];
+	for (const artifact of artifacts) {
+		if (artifact && typeof artifact === "object") {
+			if (typeof artifact.text === "string" && artifact.text.trim()) {
+				parts.push(artifact.text);
+			} else if (artifact.data !== undefined && artifact.data !== null) {
+				parts.push(stableStringify(artifact.data));
+			}
+		}
+	}
+	return [{ role: "user", content: parts.join("\n\n") }];
+}
+
+async function invokeMinimaxAdapter({
+	endpoint,
+	token,
+	payload,
+}: {
+	endpoint: URL;
+	token: string;
+	payload: any;
+}): Promise<LlmResponseEnvelope> {
+	const body: Record<string, any> = {
+		model: payload.model || MINIMAX_DEFAULT_MODEL,
+		messages: buildMinimaxMessages(payload),
+	};
+	if (Number.isFinite(payload.temperature)) body.temperature = Number(payload.temperature);
+	if (Number.isFinite(payload.maxOutputTokens)) body.max_tokens = Number(payload.maxOutputTokens);
+	if (payload.outputSchema) body.response_format = { type: "json_object" };
+
+	const res = await fetch(endpoint, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify(body),
+	});
+
+	const text = await res.text();
+	if (!res.ok) {
+		throw new Error(`${res.status} ${res.statusText}: ${text.slice(0, 400)}`);
+	}
+
+	let parsed: any;
+	try {
+		parsed = text ? JSON.parse(text) : null;
+	} catch {
+		throw new Error("Response was not JSON");
+	}
+
+	const baseResp = parsed?.base_resp;
+	if (baseResp && Number(baseResp.status_code) !== 0) {
+		throw new Error(
+			`minimax adapter error: ${baseResp.status_msg ?? `status_code ${baseResp.status_code}`}`,
+		);
+	}
+
+	const choice = Array.isArray(parsed?.choices) ? parsed.choices[0] : null;
+	const content = typeof choice?.message?.content === "string" ? choice.message.content : null;
+
+	let data: any = null;
+	let format = "text";
+	if (content && content.trim()) {
+		try {
+			const structured = JSON.parse(content);
+			if (structured && typeof structured === "object") {
+				data = structured;
+				format = "json";
+			}
+		} catch {
+			// leave content as plain text
+		}
+	}
+
+	const usage = parsed?.usage ?? {};
+	const usageOut: Record<string, number> = {};
+	const inputTokens = Number(usage.prompt_tokens);
+	if (Number.isFinite(inputTokens)) usageOut.inputTokens = inputTokens;
+	const outputTokens = Number(usage.completion_tokens);
+	if (Number.isFinite(outputTokens)) usageOut.outputTokens = outputTokens;
+	const totalTokens = Number(usage.total_tokens);
+	if (Number.isFinite(totalTokens)) usageOut.totalTokens = totalTokens;
+
+	const output: Record<string, any> = { format, data };
+	if (typeof content === "string") output.text = content;
+
+	const result: Record<string, any> = { output };
+	if (typeof parsed?.id === "string") result.runId = parsed.id;
+	if (typeof parsed?.model === "string") result.model = parsed.model;
+	if (typeof payload.prompt === "string") result.prompt = payload.prompt;
+	result.status = String(choice?.finish_reason ?? "completed");
+	if (Object.keys(usageOut).length) result.usage = usageOut;
+
+	return { ok: true, result: result as LlmResponse };
 }
 
 function resolveModel(args: any, env: any, legacyEnvCompat: boolean | undefined) {
@@ -864,7 +1026,8 @@ function normalizeResult({
 			source !== "openclaw" &&
 			source !== "clawd" &&
 			source !== "pi" &&
-			source !== "http",
+			source !== "http" &&
+			source !== "minimax",
 		attemptCount: attempt,
 	};
 	return [item];

--- a/src/core/cost_tracker.ts
+++ b/src/core/cost_tracker.ts
@@ -28,6 +28,8 @@ const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
 	"claude-haiku-3-5": { input: 0.8, output: 4.0 },
 	"gemini-1.5-pro": { input: 1.25, output: 5.0 },
 	"gemini-1.5-flash": { input: 0.075, output: 0.3 },
+	"MiniMax-M3": { input: 0.6, output: 2.4 },
+	"MiniMax-M2.7": { input: 0.3, output: 1.2 },
 };
 
 const INVALID_PRICING_JSON_WARNING =

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
+import { buildMinimaxEndpoint, resolveMinimaxBaseUrl } from "../src/commands/stdlib/llm_invoke.js";
 
 function streamOf(items: any[]) {
 	return (async function* () {
@@ -165,6 +166,103 @@ test("llm.invoke uses Pi adapter over local HTTP bridge", async () => {
 		await rm(cacheDir, { recursive: true, force: true });
 		await closeServer(server);
 	}
+});
+
+test("llm.invoke uses the MiniMax adapter and normalizes OpenAI-compatible output", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	const requestLog: any[] = [];
+	const server = http.createServer((req, res) => {
+		if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+			res.writeHead(404);
+			res.end("nope");
+			return;
+		}
+		let buf = "";
+		req.setEncoding("utf8");
+		req.on("data", (d) => (buf += d));
+		req.on("end", () => {
+			const parsed = JSON.parse(buf || "{}");
+			requestLog.push({ headers: req.headers, body: parsed });
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					id: "mm_1",
+					model: parsed.model,
+					choices: [
+						{
+							finish_reason: "stop",
+							message: { role: "assistant", content: '{"decision":"reply"}' },
+						},
+					],
+					usage: { prompt_tokens: 12, completion_tokens: 5, total_tokens: 17 },
+					base_resp: { status_code: 0, status_msg: "success" },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	try {
+		const result = await cmd.run({
+			input: streamOf([{ kind: "text", text: "context" }]),
+			args: {
+				_: [],
+				provider: "minimax",
+				prompt: "Decide",
+				"base-url": `http://127.0.0.1:${port}/v1`,
+				"output-schema": '{"type":"object","required":["decision"]}',
+			},
+			ctx: baseCtx({ MINIMAX_API_KEY: "test-key", LOBSTER_CACHE_DIR: cacheDir }, registry),
+		} as any);
+
+		const items = await collect(result.output!);
+		assert.equal(items.length, 1);
+		assert.equal(items[0].kind, "llm.invoke");
+		assert.equal(items[0].source, "minimax");
+		assert.equal(items[0].cached, false);
+		assert.equal(items[0].runId, "mm_1");
+		assert.equal(items[0].model, "MiniMax-M3");
+		assert.equal(items[0].output.format, "json");
+		assert.equal(items[0].output.data.decision, "reply");
+		assert.equal(items[0].usage.inputTokens, 12);
+		assert.equal(items[0].usage.outputTokens, 5);
+		assert.equal(requestLog.length, 1);
+		assert.equal(requestLog[0].headers.authorization, "Bearer test-key");
+		assert.equal(requestLog[0].body.model, "MiniMax-M3");
+		assert.equal(requestLog[0].body.messages[0].role, "user");
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
+test("MiniMax region selection maps to global and China endpoints", () => {
+	assert.equal(resolveMinimaxBaseUrl({}, {}), "https://api.minimax.io/v1");
+	assert.equal(resolveMinimaxBaseUrl({ region: "global_en" }, {}), "https://api.minimax.io/v1");
+	assert.equal(resolveMinimaxBaseUrl({ region: "cn_zh" }, {}), "https://api.minimaxi.com/v1");
+	assert.equal(
+		resolveMinimaxBaseUrl({}, { MINIMAX_REGION: "cn_zh" }),
+		"https://api.minimaxi.com/v1",
+	);
+	assert.equal(
+		resolveMinimaxBaseUrl({ "base-url": "https://proxy.example/v1" }, { MINIMAX_REGION: "cn_zh" }),
+		"https://proxy.example/v1",
+	);
+	assert.equal(
+		buildMinimaxEndpoint("https://api.minimaxi.com/v1").toString(),
+		"https://api.minimaxi.com/v1/chat/completions",
+	);
+	assert.equal(
+		buildMinimaxEndpoint("https://api.minimax.io/v1/chat/completions").toString(),
+		"https://api.minimax.io/v1/chat/completions",
+	);
 });
 
 function baseCtx(envOverrides: Record<string, string>, registry?: any) {


### PR DESCRIPTION
Reason: The typed `llm.invoke` command had no direct MiniMax adapter, so MiniMax models could not be reached without an external bridge.

## What changed

- Add a built-in `minimax` provider to `llm.invoke`. It calls the OpenAI-compatible chat completions endpoint and maps the reply into Lobster's typed response envelope (`runId`, `model`, `output.text`/`output.data`, `usage`, `status`).
- Endpoint selection: `--region global_en` (default) or `--region cn_zh` (also `MINIMAX_REGION`), with a `--base-url` / `MINIMAX_BASE_URL` override. The base URL is normalized to the `/chat/completions` path.
- Authentication via `--token` or `MINIMAX_API_KEY` (`LOBSTER_MINIMAX_API_KEY` also accepted). When `MINIMAX_API_KEY` is set and no other provider is configured, the provider auto-detects.
- Default model `MiniMax-M3` when `--model` is omitted; `MiniMax-M2.7` is also supported.
- Register default per-million-token pricing for `MiniMax-M3` and `MiniMax-M2.7` so `_meta.cost` / `cost_limit` estimate cost without a custom pricing override.
- Document the provider and its region/`base-url` options in the README.

## Tests

- Unit test asserting region → endpoint mapping (default global, `cn_zh`, env and `--base-url` overrides) and `/chat/completions` normalization.
- Integration test driving the adapter against a mock OpenAI-compatible server: bearer auth header, default model, JSON output normalization, token-usage mapping, and a fresh (non-cached) result.

## Checks

- `pnpm run typecheck`
- `pnpm test` (311 passing)
- `pnpm run lint`
