### PR TITLE
fix: Lobster cannot create its cache or state directories on Windows

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -123,11 +123,18 @@ async function syncDirectory(dir: string) {
  * directory as an extended-length path (`\\?\C:\...`). `path.resolve` keeps
  * that prefix, so such a path never compares equal to the plain drive path we
  * walk toward and `path.relative` between the two yields an absolute path.
- * Strip the prefix so both ends of the chain share one root form.
+ * Map the namespaces that have a plain equivalent back to it so both ends of the
+ * chain share one root form.
+ *
+ * Device namespaces with no drive-letter or UNC equivalent, such as
+ * `\\?\Volume{GUID}\...`, are returned unchanged: stripping their prefix would
+ * leave a relative path and break an explicitly configured state directory.
  */
-function stripExtendedLengthPrefix(target: string) {
-	if (target.startsWith("\\\\?\\UNC\\")) return `\\\\${target.slice(8)}`;
-	if (target.startsWith("\\\\?\\")) return target.slice(4);
+export function stripExtendedLengthPrefix(target: string) {
+	if (!target.startsWith("\\\\?\\")) return target;
+	const rest = target.slice(4);
+	if (rest.startsWith("UNC\\")) return `\\\\${rest.slice(4)}`;
+	if (/^[A-Za-z]:[\\/]/.test(rest)) return rest;
 	return target;
 }
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -118,9 +118,22 @@ async function syncDirectory(dir: string) {
 	}
 }
 
+/**
+ * On Windows, `fs.mkdir(..., { recursive: true })` reports the first created
+ * directory as an extended-length path (`\\?\C:\...`). `path.resolve` keeps
+ * that prefix, so such a path never compares equal to the plain drive path we
+ * walk toward and `path.relative` between the two yields an absolute path.
+ * Strip the prefix so both ends of the chain share one root form.
+ */
+function stripExtendedLengthPrefix(target: string) {
+	if (target.startsWith("\\\\?\\UNC\\")) return `\\\\${target.slice(8)}`;
+	if (target.startsWith("\\\\?\\")) return target.slice(4);
+	return target;
+}
+
 async function syncCreatedDirectoryChain(firstCreated: string, finalDir: string) {
-	const final = path.resolve(finalDir);
-	let current = path.resolve(firstCreated);
+	const final = path.resolve(stripExtendedLengthPrefix(finalDir));
+	let current = path.resolve(stripExtendedLengthPrefix(firstCreated));
 
 	await syncDirectory(path.dirname(current));
 	while (current !== final) {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -124,7 +124,8 @@ async function syncDirectory(dir: string) {
  * that prefix, so such a path never compares equal to the plain drive path we
  * walk toward and `path.relative` between the two yields an absolute path.
  * Map the namespaces that have a plain equivalent back to it so both ends of the
- * chain share one root form.
+ * chain share one root form. The UNC marker is matched without regard to case,
+ * because Windows accepts a lowercase "unc" namespace component just as well.
  *
  * Device namespaces with no drive-letter or UNC equivalent, such as
  * `\\?\Volume{GUID}\...`, are returned unchanged: stripping their prefix would
@@ -133,7 +134,7 @@ async function syncDirectory(dir: string) {
 export function stripExtendedLengthPrefix(target: string) {
 	if (!target.startsWith("\\\\?\\")) return target;
 	const rest = target.slice(4);
-	if (rest.startsWith("UNC\\")) return `\\\\${rest.slice(4)}`;
+	if (/^UNC\\/i.test(rest)) return `\\\\${rest.slice(4)}`;
 	if (/^[A-Za-z]:[\\/]/.test(rest)) return rest;
 	return target;
 }

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -15,6 +15,7 @@ import {
 	keyToPath,
 	withFileLock,
 	ensureDirectory,
+	stripExtendedLengthPrefix,
 	writeStateJson,
 	readStateJsonWithLock as readStateJson,
 	writeFileAtomic,
@@ -1038,4 +1039,19 @@ test("ensureDirectory creates missing parent directories", async () => {
 	// Re-running must stay a no-op once the whole chain already exists.
 	await ensureDirectory(nested);
 	assert.equal((await fsp.stat(nested)).isDirectory(), true);
+});
+
+test("stripExtendedLengthPrefix maps only namespaces with a plain equivalent", () => {
+	assert.equal(stripExtendedLengthPrefix("\\\\?\\C:\\lobster\\state"), "C:\\lobster\\state");
+	assert.equal(
+		stripExtendedLengthPrefix("\\\\?\\UNC\\server\\share\\state"),
+		"\\\\server\\share\\state",
+	);
+
+	// A device namespace has no drive-letter form, so stripping it would leave a
+	// relative path and break an explicitly configured state directory.
+	const volume = "\\\\?\\Volume{6f4c2b1a-0000-0000-0000-000000000000}\\lobster\\state";
+	assert.equal(stripExtendedLengthPrefix(volume), volume);
+
+	assert.equal(stripExtendedLengthPrefix("/tmp/lobster/state"), "/tmp/lobster/state");
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1048,6 +1048,13 @@ test("stripExtendedLengthPrefix maps only namespaces with a plain equivalent", (
 		"\\\\server\\share\\state",
 	);
 
+	// Windows matches the namespace component case-insensitively, so a lowercase
+	// marker names the same share and must map to the same plain path.
+	assert.equal(
+		stripExtendedLengthPrefix("\\\\?\\unc\\server\\share\\state"),
+		"\\\\server\\share\\state",
+	);
+
 	// A device namespace has no drive-letter form, so stripping it would leave a
 	// relative path and break an explicitly configured state directory.
 	const volume = "\\\\?\\Volume{6f4c2b1a-0000-0000-0000-000000000000}\\lobster\\state";

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -14,6 +14,7 @@ import {
 	diffAndStore,
 	keyToPath,
 	withFileLock,
+	ensureDirectory,
 	writeStateJson,
 	readStateJsonWithLock as readStateJson,
 	writeFileAtomic,
@@ -1025,4 +1026,16 @@ test("SDK writeState removes temp files when replacement fails", async () => {
 	await assert.rejects(() => writeState("sdk-state", { ok: true }, ctx));
 	const leftovers = (await fsp.readdir(tmp)).filter((f) => f.includes(".tmp"));
 	assert.deepEqual(leftovers, []);
+});
+
+test("ensureDirectory creates missing parent directories", async () => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "lobster-ensure-dir-"));
+	const nested = path.join(tmp, "alpha", "beta", "gamma");
+
+	await ensureDirectory(nested);
+	assert.equal((await fsp.stat(nested)).isDirectory(), true);
+
+	// Re-running must stay a no-op once the whole chain already exists.
+	await ensureDirectory(nested);
+	assert.equal((await fsp.stat(nested)).isDirectory(), true);
 });


### PR DESCRIPTION
Closes #125

## What Problem This Solves

Resolves a problem where Lobster cannot write anything to disk on Windows the first time it needs to create a directory. On a clean Windows machine the very first `llm.invoke` / `llm_task.invoke` call, `state.set`, `diff.last`, or approval gate fails with a confusing `ENOENT` that points at a path the user never asked for:

```
ENOENT: no such file or directory, open 'C:\Users\<user>\AppData\Local\Temp\lobster-cache-XXXXXX\llm.invoke\C:'
```

The directory Lobster wanted is in fact created before the throw, so running the same command a second time succeeds. That makes the failure look intermittent and lands it squarely on first-run experience: it only breaks the run a new Windows user makes.

## Why This Change Was Made

On Windows, `fs.mkdir(..., { recursive: true })` reports the first created directory as an extended-length path (`\\?\C:\...`), while the directory Lobster asked for is a plain drive path. `path.resolve` preserves that prefix, so the directory-sync walk compares two values that can never converge, `path.relative` between them returns an absolute path, and the walk steps into `...\<dir>\C:` and syncs a directory that does not exist.

The fix maps the extended-length namespaces that have a plain equivalent — drive-letter and `UNC\` — back to that equivalent on both ends of the chain before resolving, so the walk always operates in one root form.

Namespaces without a plain equivalent, such as `\\?\Volume{GUID}\...`, are deliberately returned untouched. They are a legitimate value for `LOBSTER_STATE_DIR`, and stripping their prefix would leave a relative path that resolves against the current drive — a regression against behavior `main` handles today. `stripExtendedLengthPrefix` is exported so that contract is pinned by a direct test rather than inferred from directory-creation behavior, which also keeps the coverage meaningful on non-Windows machines.

Non-goals: this does not change the atomic-write or fsync semantics introduced for #108/#111, and it does not touch the remaining Windows-specific test failures in the suite (the largest group is POSIX file-mode assertions such as `0o600`, which Windows cannot satisfy).

## User Impact

Windows users can run Lobster on a machine that has never run it before. LLM response caching, `state.set`, workflow resume state, `diff.last` snapshots, and approval short-ID indexes all persist on the first attempt instead of throwing `ENOENT`. Explicitly configured extended-length state directories keep working exactly as they do today. Nothing changes for macOS or Linux users.

## Evidence

Windows 11 Pro 10.0.26200, Node v22.20.0, pnpm 10.34.4, branched from `main` @ `0ac962e`. Paths below are abbreviated.

**The defect, reduced to `path` semantics.** `mkdir` reports one form, Lobster walks toward another:

```
mkdir returned: "\\\\?\\C:\\...\\repro-XXXXXX\\llm.invoke"
final  : C:\...\repro-XXXXXX\llm.invoke
current: \\?\C:\...\repro-XXXXXX\llm.invoke
equal? : false
relative: "C:\\...\\repro-XXXXXX\\llm.invoke"
split[0]: "C:"
```

`split[0]` is what the walk takes as its next chain segment.

**Directory-creation regression test, without the fix (production change stashed, tests kept):**

```
$ node --test --test-name-pattern "ensureDirectory creates missing parent" dist/test/state.test.js
not ok 1 - ensureDirectory creates missing parent directories
  ---
  failureType: 'testCodeFailure'
  error: "ENOENT: no such file or directory, open 'C:\\...\\lobster-ensure-dir-XXXXXX\\alpha\\C:'"
  code: 'ENOENT'
  stack: |-
    async Object.open (node:internal/fs/promises:641:25)
    async syncDirectory (.../dist/src/state/store.js:47:18)
    async syncCreatedDirectoryChain (.../dist/src/state/store.js:71:9)
    async ensureDirectory (.../dist/src/state/store.js:82:9)
  ...
# tests 1
# pass 0
# fail 1
```

**Namespace test, against an unconditional strip** (the naive version of this fix, which would regress a configured Volume GUID state directory):

```
$ node --test --test-name-pattern "stripExtendedLengthPrefix" dist/test/state.test.js
not ok 1 - stripExtendedLengthPrefix maps only namespaces with a plain equivalent
  expected: '\\?\Volume{6f4c2b1a-0000-0000-0000-000000000000}\lobster\state'
  actual:   'Volume{6f4c2b1a-0000-0000-0000-000000000000}\lobster\state'
```

**Both tests on this branch:**

```
$ node --test --test-name-pattern "ensureDirectory creates missing parent|stripExtendedLengthPrefix" dist/test/state.test.js
ok 1 - ensureDirectory creates missing parent directories
ok 2 - stripExtendedLengthPrefix maps only namespaces with a plain equivalent
# tests 2
# pass 2
# fail 0
```

**Full suite, before and after.** Windows has other pre-existing failures in this suite that this PR does not address, so the number that matters is the delta:

```
main @ 0ac962e            # tests 309   # pass 202   # fail 107
this branch               # tests 311   # pass 237   # fail  74
```

Two added tests, and 33 previously failing tests now pass. Those 33 are the ones that write an LLM cache entry, a state file, a diff snapshot, or an approval index into a fresh temp directory.

**Static checks:**

```
$ pnpm typecheck
> tsc -p tsconfig.json --noEmit
(no output)

$ pnpm lint
> pnpm format:check && oxlint --tsconfig tsconfig.json bin src test
Checking formatting...
All matched files use the correct format.
Finished in 200ms on 118 files using 20 threads.
```

`oxlint` reports the same four pre-existing warnings as `main` and none in the changed files.
