### PR TITLE
fix: schema validation failures cost one more model call than configured

### DIFF
--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -488,7 +488,7 @@ async function runLlmInvoke({
 		}
 
 		lastValidationErrors = collectAjvErrors(validator.errors);
-		if (attempt > maxValidationRetries + 1) {
+		if (attempt > maxValidationRetries) {
 			throw new Error(
 				`${config.name} output failed schema validation: ${lastValidationErrors.join("; ")}`,
 			);

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -275,7 +275,8 @@ export function createLlmInvokeCommand(config: CommandConfig): LobsterCommand {
 					"schema-version": { type: "string", description: "Logical schema version for caching" },
 					"max-validation-retries": {
 						type: "number",
-						description: "Retries when schema validation fails",
+						description:
+							"Extra model calls allowed after the first when schema validation fails (default 1)",
 					},
 					temperature: { type: "number", description: "Sampling temperature" },
 					"max-output-tokens": { type: "number", description: "Max completion tokens" },
@@ -301,7 +302,8 @@ export function createLlmInvokeCommand(config: CommandConfig): LobsterCommand {
 				"Features:",
 				"  - Typed payload validation before invoking the adapter.",
 				"  - Run-state + file cache so resumes do not re-call the LLM.",
-				"  - Optional JSON-schema enforcement with bounded retries.",
+				"  - Optional JSON-schema enforcement, retried at most --max-validation-retries times",
+				"    after the first call.",
 				"",
 				"Config:",
 				...config.helpConfig.map((line) => `  - ${line}`),

--- a/test/llm_task_invoke.test.ts
+++ b/test/llm_task_invoke.test.ts
@@ -163,6 +163,132 @@ test("llm_task.invoke retries when schema validation fails", async () => {
 	}
 });
 
+test("llm_task.invoke makes a single model call when --max-validation-retries is 0", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm_task.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	let calls = 0;
+	const server = http.createServer((req, res) => {
+		if (req.method !== "POST" || req.url !== "/tools/invoke") {
+			res.writeHead(404);
+			res.end();
+			return;
+		}
+		calls += 1;
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(
+			JSON.stringify({
+				ok: true,
+				result: {
+					ok: true,
+					result: { runId: `attempt_${calls}`, output: { data: { foo: "bar" } } },
+				},
+			}),
+		);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	try {
+		await assert.rejects(
+			cmd.run({
+				input: streamOf([]),
+				args: {
+					_: [],
+					model: "claude-3-opus",
+					prompt: "Decide",
+					"output-schema": '{"type":"object","required":["decision"]}',
+					"max-validation-retries": 0,
+				},
+				ctx: baseCtx(
+					{ LOBSTER_CACHE_DIR: cacheDir, CLAWD_URL: `http://localhost:${port}` },
+					registry,
+				),
+			} as any),
+			/output failed schema validation/,
+		);
+		assert.equal(calls, 1);
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
+test("llm_task.invoke retries validation exactly once by default", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm_task.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	const bodyLog: any[] = [];
+	const server = http.createServer((req, res) => {
+		if (req.method !== "POST" || req.url !== "/tools/invoke") {
+			res.writeHead(404);
+			res.end();
+			return;
+		}
+		let buf = "";
+		req.setEncoding("utf8");
+		req.on("data", (chunk) => (buf += chunk));
+		req.on("end", () => {
+			bodyLog.push(JSON.parse(buf || "{}"));
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: {
+						ok: true,
+						result: {
+							runId: `attempt_${bodyLog.length}`,
+							output: { data: { foo: "bar" } },
+						},
+					},
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	try {
+		await assert.rejects(
+			cmd.run({
+				input: streamOf([]),
+				args: {
+					_: [],
+					model: "claude-3-opus",
+					prompt: "Decide",
+					"output-schema": '{"type":"object","required":["decision"]}',
+				},
+				ctx: baseCtx(
+					{
+						LOBSTER_CACHE_DIR: cacheDir,
+						CLAWD_URL: `http://localhost:${port}`,
+						LOBSTER_LLM_VALIDATION_RETRIES: "",
+						LLM_TASK_VALIDATION_RETRIES: "",
+					},
+					registry,
+				),
+			} as any),
+			/output failed schema validation/,
+		);
+
+		assert.equal(bodyLog.length, 2);
+		assert.equal(bodyLog[0].args.retryContext, undefined);
+		assert.equal(bodyLog[1].args.retryContext.attempt, 2);
+		assert.ok(bodyLog[1].args.retryContext.validationErrors.length >= 1);
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
 test("llm_task.invoke persists to run state so resume skips remote call", async () => {
 	const stateDir = await mkdtemp(path.join(tmpdir(), "lobster-state-"));
 	const registry = createDefaultRegistry();


### PR DESCRIPTION
Closes #127

## What Problem This Solves

Resolves a problem where `llm.invoke` and `llm_task.invoke` charge users for one more model call than their retry budget allows. When a provider keeps returning output that does not satisfy `--output-schema`, the command sends `N + 2` requests for `--max-validation-retries N` instead of `N + 1`:

| `--max-validation-retries` | calls before | calls after |
|---|---|---|
| `0` | 2 | 1 |
| `1` (default) | 3 | 2 |
| `2` | 4 | 3 |

`0` is the case that stings. A user who explicitly opts out of retries — typically because the model is expensive or the step is on a tight `cost_limit` — still pays for a second call on every failing step. Workflows with a `cost_limit` therefore reach their ceiling earlier than their configuration implies, and the overspend is invisible because the command does fail with the correct error.

## Why This Change Was Made

The attempt counter is 1-based and was compared against the retry budget plus one, so the initial request was never charged against the budget. `attempt` counts calls and `--max-validation-retries` counts retries, so the budget is exhausted the moment `attempt` exceeds the retry count.

This moves only the failure bound. The success path is untouched: a response that validates still returns on whichever attempt produced it, and the existing coverage for a budget of 2 that succeeds on call 2 passes unchanged. `payload.retryContext` is assigned at the top of each iteration and is unaffected — with `0` retries it is now correctly never sent at all, which is what "no retries" should mean.

Non-goals: this does not change what counts as a validation failure, the default budget of 1, or the `LOBSTER_LLM_VALIDATION_RETRIES` / `LLM_TASK_VALIDATION_RETRIES` resolution order.

## User Impact

`--max-validation-retries N` now costs exactly `N + 1` model calls in the worst case, matching what the flag says. Setting it to `0` means the model is called once. Users on metered providers stop paying for a retry they did not ask for, and `cost_limit` budgets track the configured retry policy.

## Evidence

Windows 11 Pro 10.0.26200, Node v22.20.0, pnpm 10.34.4, branched from `main` @ `0ac962e`.

The two new tests count the requests a stub adapter actually receives, rather than matching on the error message — both the old and new code reject with the same error, so the call count is the only thing that distinguishes them.

**Without the fix (production change stashed, tests kept):**

```
$ node --test dist/test/llm_task_invoke.test.js
ok 2 - llm_task.invoke retries when schema validation fails
not ok 3 - llm_task.invoke makes a single model call when --max-validation-retries is 0
    Expected values to be strictly equal:
  expected: 1
  actual: 2
not ok 4 - llm_task.invoke retries validation exactly once by default
    Expected values to be strictly equal:
  expected: 2
  actual: 3
```

**With the fix:**

```
$ node --test dist/test/llm_task_invoke.test.js
ok 1 - llm_task.invoke posts to /tools/invoke (clawd) and normalizes result
ok 2 - llm_task.invoke retries when schema validation fails
ok 3 - llm_task.invoke makes a single model call when --max-validation-retries is 0
ok 4 - llm_task.invoke retries validation exactly once by default
ok 5 - llm_task.invoke persists to run state so resume skips remote call
ok 6 - llm_task.invoke reuses file cache when URL unavailable
not ok 7 - llm_task.invoke treats corrupt file cache as a miss and rewrites it atomically (#111)
ok 8 - llm_task.invoke uses CLAWD_URL (/tools/invoke) without requiring --url/--model
# tests 8
# pass 7
# fail 1
```

Test 2 passes in both runs, which is the point: the success path does not move. Test 7 is a pre-existing Windows failure unrelated to this change — it asserts a POSIX file mode (`0o600`, reported as `0o666` on Windows).

The runs above were taken with #126 applied locally, because `ensureDirectory` currently throws on Windows and six of the eight tests in this file cannot reach their assertions without it (#125). On an unpatched Windows checkout of this branch only the two new tests pass, since they never get as far as writing a cache entry. Neither issue interacts with the change in this PR.

**Full suite, this branch, unpatched:**

```
main @ 0ac962e            # tests 309   # pass 202   # fail 107
this branch               # tests 311   # pass 204   # fail 107
```

Two added tests, two added passes, no change in failures. The 107 pre-existing failures on this platform are tracked separately in #125.

### Real-adapter proof

The runs above use a stub adapter, so here is the same behavior end to end through the shipped CLI against a real model. `llm.invoke` has no built-in provider, so a bridge on `LOBSTER_LLM_ADAPTER_URL` is what a real setup looks like here: the adapter forwards each payload to a local Ollama server (Ollama 0.32.3, `qwen3.5:9b`, CUDA) and logs every request it receives, so the call count comes from the adapter side rather than from an assertion.

Every run is the same step against a cache and state directory that start empty:

```
lobster run --mode tool "llm.invoke --provider http --model qwen3.5:9b \
  --output-schema '{\"type\":\"object\",\"properties\":{\"sku\":{\"type\":\"string\"},\"price\":{\"type\":\"number\"}},\"required\":[\"sku\",\"price\"]}' \
  [--max-validation-retries N] --prompt 'In one short sentence, what is a lobster trap used for?'"
```

The prompt asks for one sentence of prose while the schema requires an object, so the model's answer never parses into `output.data` and validation fails on every attempt. That is what makes the failure persistent and the retry bound observable. The model's wording is not the claim here — the number of adapter requests is.

**On `main`:**

```
$ lobster run --mode tool "llm.invoke ... --max-validation-retries 0"
[main r=0] call #1 2026-08-03T05:29:15.216Z model=qwen3.5:9b retryContext=absent
[main r=0]   -> 95 chars, output.data=null
[main r=0] call #2 2026-08-03T05:29:33.893Z model=qwen3.5:9b retryContext=present(attempt=2)
[main r=0]   -> 95 chars, output.data=null
exit code: 1
CLI error : "message": "llm.invoke output failed schema validation: / must be object"
adapter requests for this run: 2

$ lobster run --mode tool "llm.invoke ... (default retries)"
[main default] call #1 2026-08-03T05:29:44.265Z model=qwen3.5:9b retryContext=absent
[main default]   -> 111 chars, output.data=null
[main default] call #2 2026-08-03T05:29:45.650Z model=qwen3.5:9b retryContext=present(attempt=2)
[main default]   -> 53 chars, output.data=null
[main default] call #3 2026-08-03T05:29:46.413Z model=qwen3.5:9b retryContext=present(attempt=3)
[main default]   -> 169 chars, output.data=null
exit code: 1
CLI error : "message": "llm.invoke output failed schema validation: / must be object"
adapter requests for this run: 3
```

**On this branch:**

```
$ lobster run --mode tool "llm.invoke ... --max-validation-retries 0"
[branch r=0] call #1 2026-08-03T05:29:59.424Z model=qwen3.5:9b retryContext=absent
[branch r=0]   -> 60 chars, output.data=null
exit code: 1
CLI error : "message": "llm.invoke output failed schema validation: / must be object"
adapter requests for this run: 1

$ lobster run --mode tool "llm.invoke ... (default retries)"
[branch default] call #1 2026-08-03T05:30:05.039Z model=qwen3.5:9b retryContext=absent
[branch default]   -> 181 chars, output.data=null
[branch default] call #2 2026-08-03T05:30:06.435Z model=qwen3.5:9b retryContext=present(attempt=2)
[branch default]   -> 41 chars, output.data=null
exit code: 1
CLI error : "message": "llm.invoke output failed schema validation: / must be object"
adapter requests for this run: 2
```

Measured against the real model, through the real CLI:

| `--max-validation-retries` | `main` | this branch |
|---|---|---|
| `0` | 2 requests | 1 request |
| default (`1`) | 3 requests | 2 requests |

Both branches fail with the same message and the same exit code — only the bill changes. The `retryContext=present(attempt=2)` line in the `main` zero-retry run is the extra call in the open: a request the user explicitly opted out of, sent to the model and paid for, tagged as a retry.

**The success path, same setup, still returns on the first call.** Swapping the prompt for one the model can satisfy (`Reply with only a JSON object ... {"sku": "LOB-1", "price": 12.5}`), on this branch with retries set to `0`:

```
$ lobster run --mode tool "llm.invoke ... --max-validation-retries 0"
[branch success r=0] call #1 2026-08-03T05:30:32.204Z model=qwen3.5:9b retryContext=absent
[branch success r=0]   -> 32 chars, output.data=object
exit code: 0
adapter requests for this run: 1
```

A valid response returns immediately, so the tightened bound only ever cuts the call that was never inside the budget.

As with the test runs above, these four measurements were taken with #126 applied on top of both trees, since `ensureDirectory` currently throws on Windows before the CLI can create its cache directory (#125). That patch touches `src/state/store.ts` only and does not interact with the retry bound.

**Static checks:**

```
$ pnpm typecheck
> tsc -p tsconfig.json --noEmit
(no output)

$ pnpm lint
> pnpm format:check && oxlint --tsconfig tsconfig.json bin src test
Checking formatting...
All matched files use the correct format.
```

`oxlint` reports the same four pre-existing warnings as `main` and none in the changed files.

