### PR TITLE
fix: cached LLM answers are returned when temperature or max output tokens change

### DIFF
--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -389,6 +389,8 @@ async function runLlmInvoke({
 		schemaVersion,
 		artifactHashes,
 		outputSchema: userOutputSchema,
+		temperature,
+		maxOutputTokens,
 	});
 
 	if (stateKey && !forceRefresh) {
@@ -834,6 +836,8 @@ function computeCacheKey({
 	schemaVersion,
 	artifactHashes,
 	outputSchema,
+	temperature,
+	maxOutputTokens,
 }: {
 	provider: SupportedProvider;
 	prompt: string;
@@ -841,8 +845,10 @@ function computeCacheKey({
 	schemaVersion: string;
 	artifactHashes: string[];
 	outputSchema: any;
+	temperature: number | null;
+	maxOutputTokens: number | null;
 }) {
-	const payload = {
+	const payload: Record<string, any> = {
 		provider,
 		prompt,
 		model: model || `${provider}-default`,
@@ -850,6 +856,11 @@ function computeCacheKey({
 		artifactHashes,
 		outputSchema: outputSchema ?? null,
 	};
+	// Guard on the same predicates that decide whether each parameter is sent to
+	// the adapter, so keys for invocations that omit them stay byte-identical and
+	// caches written by earlier releases remain valid.
+	if (Number.isFinite(temperature ?? NaN)) payload.temperature = Number(temperature);
+	if (Number.isFinite(maxOutputTokens ?? NaN)) payload.maxOutputTokens = Number(maxOutputTokens);
 	return createHash("sha256").update(stableStringify(payload)).digest("hex");
 }
 

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -107,6 +107,8 @@ const validateResponseEnvelope = ajv.compile(responseSchema);
 
 const DEFAULT_MAX_VALIDATION_RETRIES = 1;
 const STATE_VERSION = 1;
+// Identity version of the response cache key. See computeCacheKey.
+const CACHE_KEY_VERSION = 2;
 
 type BuiltInProvider = "openclaw" | "pi" | "http";
 type SupportedProvider = BuiltInProvider | string;
@@ -848,19 +850,24 @@ function computeCacheKey({
 	temperature: number | null;
 	maxOutputTokens: number | null;
 }) {
-	const payload: Record<string, any> = {
+	// `null` is the identity of an omitted parameter, distinct from any value a caller can
+	// pass, so an omitted request can never resolve to an entry written with an explicit one.
+	// The version separates this identity from the keys earlier releases wrote, where the two
+	// parameters were absent from the payload and a sampled answer therefore shared a key with
+	// an unsampled request. Bump it whenever the fields below change: entries under older
+	// versions become unreachable, which costs one re-invocation and never a wrong replay.
+	const payload = {
+		cacheKeyVersion: CACHE_KEY_VERSION,
 		provider,
 		prompt,
 		model: model || `${provider}-default`,
 		schemaVersion,
 		artifactHashes,
 		outputSchema: outputSchema ?? null,
+		// The same predicate that decides whether each parameter is sent to the adapter.
+		temperature: Number.isFinite(temperature ?? NaN) ? Number(temperature) : null,
+		maxOutputTokens: Number.isFinite(maxOutputTokens ?? NaN) ? Number(maxOutputTokens) : null,
 	};
-	// Guard on the same predicates that decide whether each parameter is sent to
-	// the adapter, so keys for invocations that omit them stay byte-identical and
-	// caches written by earlier releases remain valid.
-	if (Number.isFinite(temperature ?? NaN)) payload.temperature = Number(temperature);
-	if (Number.isFinite(maxOutputTokens ?? NaN)) payload.maxOutputTokens = Number(maxOutputTokens);
 	return createHash("sha256").update(stableStringify(payload)).digest("hex");
 }
 

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -1,13 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import http from "node:http";
 import { promises as fsp } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createDefaultRegistry } from "../src/commands/registry.js";
-import { keyToPath } from "../src/state/store.js";
+import { keyToPath, stableStringify } from "../src/state/store.js";
 
 function streamOf(items: any[]) {
 	return (async function* () {
@@ -244,25 +245,52 @@ test("llm.invoke re-invokes the adapter when --max-output-tokens changes", async
 	}
 });
 
-test("llm.invoke keeps its established cache key when sampling parameters are unset", async () => {
+test("llm.invoke does not replay a cache entry written before sampling was keyed", async () => {
 	const registry = createDefaultRegistry();
 	const cmd = registry.get("llm.invoke");
 	assert.ok(cmd);
 	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+	const args = {
+		_: [],
+		provider: "pi",
+		model: "test-model",
+		prompt: "Cache key stability",
+		"schema-version": "v1",
+	};
 
+	// The identity earlier releases hashed: sampling parameters were absent from the payload,
+	// so an answer sampled at temperature 0.9 was stored under the same key a request that
+	// omits sampling computes. Reading that entry back would serve sampling nobody asked for.
+	const legacyKey = createHash("sha256")
+		.update(
+			stableStringify({
+				provider: "pi",
+				prompt: "Cache key stability",
+				model: "test-model",
+				schemaVersion: "v1",
+				artifactHashes: [],
+				outputSchema: null,
+			}),
+		)
+		.digest("hex");
+
+	const requestLog: any[] = [];
 	const server = http.createServer((req, res) => {
 		if (req.method !== "POST" || req.url !== "/invoke") {
 			res.writeHead(404);
 			res.end("nope");
 			return;
 		}
-		req.resume();
+		let buf = "";
+		req.setEncoding("utf8");
+		req.on("data", (d) => (buf += d));
 		req.on("end", () => {
+			requestLog.push(JSON.parse(buf || "{}"));
 			res.writeHead(200, { "content-type": "application/json" });
 			res.end(
 				JSON.stringify({
 					ok: true,
-					result: { runId: "pi_1", output: { format: "text", text: "ok" } },
+					result: { runId: "pi_1", output: { format: "text", text: "fresh" } },
 				}),
 			);
 		});
@@ -273,15 +301,29 @@ test("llm.invoke keeps its established cache key when sampling parameters are un
 	const port = typeof addr === "object" && addr ? addr.port : 0;
 
 	try {
+		await mkdir(path.join(cacheDir, "llm.invoke"), { recursive: true });
+		await writeFile(
+			path.join(cacheDir, "llm.invoke", `${legacyKey}.json`),
+			JSON.stringify({
+				cacheKey: legacyKey,
+				storedAt: "2026-08-01T00:00:00.000Z",
+				items: [
+					{
+						kind: "llm.invoke",
+						cacheKey: legacyKey,
+						status: "completed",
+						source: "pi",
+						cached: false,
+						output: { format: "text", text: "sampled at 0.9" },
+					},
+				],
+			}),
+			"utf8",
+		);
+
 		const result = await cmd.run({
 			input: streamOf([]),
-			args: {
-				_: [],
-				provider: "pi",
-				model: "test-model",
-				prompt: "Cache key stability",
-				"schema-version": "v1",
-			},
+			args,
 			ctx: baseCtx(
 				{
 					LOBSTER_PI_LLM_ADAPTER_URL: `http://127.0.0.1:${port}`,
@@ -292,12 +334,10 @@ test("llm.invoke keeps its established cache key when sampling parameters are un
 		} as any);
 
 		const items = await collect(result.output!);
-		// Pinned so cache entries written before sampling parameters were hashed keep
-		// resolving. If this value moves, every existing on-disk cache entry is orphaned.
-		assert.equal(
-			items[0].cacheKey,
-			"b137c449800e145fa522ea974ad5d9d079a4dad96263f991ab3b2a9efe262912",
-		);
+		assert.equal(requestLog.length, 1);
+		assert.equal(items[0].source, "pi");
+		assert.equal(items[0].output.text, "fresh");
+		assert.notEqual(items[0].cacheKey, legacyKey);
 	} finally {
 		await rm(cacheDir, { recursive: true, force: true });
 		await closeServer(server);

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -91,6 +91,219 @@ test("llm.invoke auto-detects OpenClaw provider and normalizes output", async ()
 	}
 });
 
+test("llm.invoke re-invokes the adapter when --temperature changes", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	const requestLog: any[] = [];
+	const server = http.createServer((req, res) => {
+		if (req.method !== "POST" || req.url !== "/invoke") {
+			res.writeHead(404);
+			res.end("nope");
+			return;
+		}
+		let buf = "";
+		req.setEncoding("utf8");
+		req.on("data", (d) => (buf += d));
+		req.on("end", () => {
+			const parsed = JSON.parse(buf || "{}");
+			requestLog.push(parsed);
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: {
+						runId: `pi_${requestLog.length}`,
+						model: parsed.model,
+						prompt: parsed.prompt,
+						output: { format: "text", text: `temperature=${parsed.temperature}` },
+					},
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+	const ctxEnv = {
+		LOBSTER_PI_LLM_ADAPTER_URL: `http://127.0.0.1:${port}`,
+		LOBSTER_CACHE_DIR: cacheDir,
+	};
+
+	try {
+		const runWith = async (temperature: number) => {
+			const result = await cmd.run({
+				input: streamOf([]),
+				args: {
+					_: [],
+					provider: "pi",
+					model: "test-model",
+					prompt: "Sampling parameters matter",
+					"schema-version": "v1",
+					temperature,
+				},
+				ctx: baseCtx(ctxEnv, registry),
+			} as any);
+			return collect(result.output!);
+		};
+
+		const cold = await runWith(0.1);
+		assert.equal(cold[0].source, "pi");
+		assert.equal(requestLog.length, 1);
+		assert.equal(requestLog[0].temperature, 0.1);
+
+		const changed = await runWith(0.9);
+		assert.equal(changed[0].source, "pi");
+		assert.equal(requestLog.length, 2);
+		assert.equal(requestLog[1].temperature, 0.9);
+		assert.notEqual(changed[0].cacheKey, cold[0].cacheKey);
+
+		const replay = await runWith(0.1);
+		assert.equal(replay[0].source, "cache");
+		assert.equal(replay[0].cacheKey, cold[0].cacheKey);
+		assert.equal(requestLog.length, 2);
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
+test("llm.invoke re-invokes the adapter when --max-output-tokens changes", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	const requestLog: any[] = [];
+	const server = http.createServer((req, res) => {
+		if (req.method !== "POST" || req.url !== "/invoke") {
+			res.writeHead(404);
+			res.end("nope");
+			return;
+		}
+		let buf = "";
+		req.setEncoding("utf8");
+		req.on("data", (d) => (buf += d));
+		req.on("end", () => {
+			const parsed = JSON.parse(buf || "{}");
+			requestLog.push(parsed);
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: {
+						runId: `pi_${requestLog.length}`,
+						output: { format: "text", text: `budget=${parsed.maxOutputTokens}` },
+					},
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+	const ctxEnv = {
+		LOBSTER_PI_LLM_ADAPTER_URL: `http://127.0.0.1:${port}`,
+		LOBSTER_CACHE_DIR: cacheDir,
+	};
+
+	try {
+		const runWith = async (maxOutputTokens: number) => {
+			const result = await cmd.run({
+				input: streamOf([]),
+				args: {
+					_: [],
+					provider: "pi",
+					model: "test-model",
+					prompt: "Token budget matters",
+					"schema-version": "v1",
+					"max-output-tokens": maxOutputTokens,
+				},
+				ctx: baseCtx(ctxEnv, registry),
+			} as any);
+			return collect(result.output!);
+		};
+
+		const cold = await runWith(64);
+		assert.equal(cold[0].source, "pi");
+		assert.equal(requestLog.length, 1);
+		assert.equal(requestLog[0].maxOutputTokens, 64);
+
+		const changed = await runWith(4096);
+		assert.equal(changed[0].source, "pi");
+		assert.equal(requestLog.length, 2);
+		assert.equal(requestLog[1].maxOutputTokens, 4096);
+		assert.notEqual(changed[0].cacheKey, cold[0].cacheKey);
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
+test("llm.invoke keeps its established cache key when sampling parameters are unset", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	const server = http.createServer((req, res) => {
+		if (req.method !== "POST" || req.url !== "/invoke") {
+			res.writeHead(404);
+			res.end("nope");
+			return;
+		}
+		req.resume();
+		req.on("end", () => {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: { runId: "pi_1", output: { format: "text", text: "ok" } },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	try {
+		const result = await cmd.run({
+			input: streamOf([]),
+			args: {
+				_: [],
+				provider: "pi",
+				model: "test-model",
+				prompt: "Cache key stability",
+				"schema-version": "v1",
+			},
+			ctx: baseCtx(
+				{
+					LOBSTER_PI_LLM_ADAPTER_URL: `http://127.0.0.1:${port}`,
+					LOBSTER_CACHE_DIR: cacheDir,
+				},
+				registry,
+			),
+		} as any);
+
+		const items = await collect(result.output!);
+		// Pinned so cache entries written before sampling parameters were hashed keep
+		// resolving. If this value moves, every existing on-disk cache entry is orphaned.
+		assert.equal(
+			items[0].cacheKey,
+			"b137c449800e145fa522ea974ad5d9d079a4dad96263f991ab3b2a9efe262912",
+		);
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
 test("llm.invoke uses Pi adapter over local HTTP bridge", async () => {
 	const registry = createDefaultRegistry();
 	const cmd = registry.get("llm.invoke");


### PR DESCRIPTION
Closes #129

## What Problem This Solves

Resolves a problem where users who change `--temperature` or `--max-output-tokens` on a prompt they have run before get the old answer back instead of a new one. The model is never called, the command reports success, and the only trace is a `source: "cache"` field deep in the output item. Someone tuning temperature to widen or tighten variation sees identical output at every setting and has no signal that their flag was ignored.

The same key drives `--state-key` reuse, so a resumed workflow replays the stale answer as well.

## Why This Change Was Made

`--temperature` and `--max-output-tokens` were already resolved and sent to the adapter as part of the request payload, but they were not part of the value the cache is addressed by. Since they change what the model produces, they belong in the key.

Both parameters now go into the payload unconditionally, with `null` as the identity of an omitted one — an identity no caller can produce, and distinct from an explicit `0`. The payload also carries a `cacheKeyVersion`.

That last part is the design decision worth reviewing, and it is a revision of the earlier approach on this branch. Hashing the parameters only when they were set kept the omitted-parameter key byte-identical to what earlier releases wrote, which preserved every existing cache entry. But it left one collision behind: an entry that an earlier release stored for a request sampled at an explicit temperature sits under exactly the key a request that omits sampling computes. After upgrading, an unsampled request could therefore be served a sampled answer — the same class of defect this PR exists to fix, just reached from the other direction. Versioning the identity closes it. Entries written under the previous identity become unreachable rather than ambiguous: the cost is one re-invocation per prompt after the upgrade, never a wrong replay.

`metadata` deliberately stays out, for three reasons: it is set unconditionally whenever `--metadata-json` is present, so including it would invalidate the cache of everyone using that flag; it carries correlation data such as run and trace ids rather than decode-time model parameters, so keying on it would drive the hit rate toward zero; and callers who genuinely want metadata to segment the cache can already bump `--schema-version`, which is in the key.

Non-goals: no change to what is sent to adapters, to cache file layout or location, or to the run-state record shape. Records written by earlier versions still parse — they are simply addressed by a key nobody computes anymore.

## User Impact

Changing `--temperature` or `--max-output-tokens` now calls the model again, and switching back to a previous value is still a cache hit rather than a fresh charge.

The upgrade costs one cache miss per distinct prompt: entries on disk were written under the previous cache identity and are no longer addressed. Nothing is deleted, no command fails, and the first invocation of each prompt after upgrading repopulates the cache under the new identity. This is deliberate — the alternative preserved those entries at the price of letting a pre-upgrade sampled answer be replayed for a request that asked for no sampling at all.

## Evidence

Windows 11 Pro 10.0.26200, Node v22.20.0, pnpm 10.34.4, branched from `main` @ `0ac962e`.

Three tests are added, all regression tests: two for the stale-replay defect this PR closes, and one for the upgrade collision described above. All runs below have #126 applied locally so the whole file can execute on Windows — see the note under the suite table.

**Against `main` — all three defects visible:**

```
$ node --test dist/test/llm_invoke.test.js
ok 1 - llm.invoke auto-detects OpenClaw provider and normalizes output
not ok 2 - llm.invoke re-invokes the adapter when --temperature changes
    'cache' !== 'pi'
  expected: 'pi'
  actual: 'cache'
not ok 3 - llm.invoke re-invokes the adapter when --max-output-tokens changes
    'cache' !== 'pi'
  expected: 'pi'
  actual: 'cache'
not ok 4 - llm.invoke does not replay a cache entry written before sampling was keyed
    0 !== 1
  expected: 1
  actual: 0
ok 5 - llm.invoke uses Pi adapter over local HTTP bridge
# tests 5
# pass 2
# fail 3
```

`'cache' !== 'pi'` in tests 2 and 3 is the user-visible symptom exactly: the second invocation never reached the adapter. In test 4, `0 !== 1` counts requests that arrived at the adapter — zero, because the pre-existing cache entry was served instead.

**Against the previously reviewed head (`1760cb3`, sampling parameters hashed only when set):**

```
$ node --test dist/test/llm_invoke.test.js
ok 1 - llm.invoke auto-detects OpenClaw provider and normalizes output
ok 2 - llm.invoke re-invokes the adapter when --temperature changes
ok 3 - llm.invoke re-invokes the adapter when --max-output-tokens changes
not ok 4 - llm.invoke does not replay a cache entry written before sampling was keyed
    0 !== 1
  expected: 1
  actual: 0
ok 5 - llm.invoke uses Pi adapter over local HTTP bridge
# tests 5
# pass 4
# fail 1
```

This is the reported finding, reproduced as a test: the original defect was fixed, and the upgrade collision was not. Test 4 writes a cache entry under the key the old code computed for this request — recorded in the test by rebuilding that exact payload, not by copying a hash — and then invokes with no sampling parameters at all. Under the old identity the stored answer comes back and the adapter is never called.

**With this change:**

```
$ node --test dist/test/llm_invoke.test.js
ok 1 - llm.invoke auto-detects OpenClaw provider and normalizes output
ok 2 - llm.invoke re-invokes the adapter when --temperature changes
ok 3 - llm.invoke re-invokes the adapter when --max-output-tokens changes
ok 4 - llm.invoke does not replay a cache entry written before sampling was keyed
ok 5 - llm.invoke uses Pi adapter over local HTTP bridge
# tests 5
# pass 5
# fail 0
```

Test 2 also asserts that returning to the first temperature is a cache hit against the original key, so the fix partitions the cache rather than defeating it.

**Full suite:**

```
main @ 0ac962e                        # tests 309   # pass 202   # fail 107
this branch                           # tests 312   # pass 203   # fail 109
this branch, with #126 applied        # tests 312   # pass 238   # fail  74
```

The middle row needs an explanation. `ensureDirectory` currently throws on Windows (#125), so any test that writes a cache entry fails there — including two of the three added here. With that separate fix applied locally the whole file passes, which is the run shown above. On macOS and Linux the middle row does not apply. The three tests do not depend on #126 in any other way, and this PR does not touch `src/state/store.ts`.

### Real-adapter proof

The runs above use stub adapters, so here is the same behavior end to end through the shipped CLI against a real model. The adapter is a thin bridge that forwards the `llm.invoke` payload to a local Ollama server (Ollama 0.32.3, `qwen3.5:9b`) and logs every request it receives. `llm.invoke` has no built-in provider, so a bridge on `LOBSTER_LLM_ADAPTER_URL` is what a real setup looks like here.

This block was captured at `1760cb3`, before the identity was versioned. What it demonstrates — a changed sampling parameter reaches the model, and returning to a previous value is still a cache hit — is unchanged by the version field. What does change is the literal key values shown: adding `cacheKeyVersion` and the two `null` entries moves every hash. The partitioning is the claim; the digests are incidental to it.

Each block below is three `lobster run` invocations of the same prompt, changing only `--temperature`, against a cache directory that starts empty:

```
lobster run --mode tool "llm.invoke --provider http --model qwen3.5:9b --temperature <T> --prompt '...'"
```

**On `main`:**

```
[run 1] --temperature 0.2
    source   : http
    cacheKey : 9f01fcf137d2dc5f4f25
    text     : "Claw & Crustacean"
    adapter calls so far: 1

[run 2] --temperature 1.4   (only the sampling parameter changed)
    source   : cache
    cacheKey : 9f01fcf137d2dc5f4f25
    text     : "Claw & Crustacean"
    adapter calls so far: 1

[run 3] --temperature 0.2   (back to the first value)
    source   : cache
    cacheKey : 9f01fcf137d2dc5f4f25
    text     : "Claw & Crustacean"
    adapter calls so far: 1
```

Three runs, **one** model call. Run 2 asked for a very different temperature and the model was never consulted — same key, replayed answer.

**On this branch:**

```
[run 1] --temperature 0.2
    source   : http
    cacheKey : abc2ae1a5aeecd511b7e
    text     : "Claw & Brew"
    adapter calls so far: 2

[run 2] --temperature 1.4   (only the sampling parameter changed)
    source   : http
    cacheKey : 196932deff562e4ba791
    text     : "Claw & Brew"
    adapter calls so far: 3

[run 3] --temperature 0.2   (back to the first value)
    source   : cache
    cacheKey : abc2ae1a5aeecd511b7e
    text     : "Claw & Brew"
    adapter calls so far: 3
```

Three runs, **two** model calls. Run 2 reaches the model under its own key; run 3 returns to the first temperature and hits run 1's entry, so the cache still partitions rather than being defeated.

The adapter's own log, counting what actually arrived (the counter spans both blocks; call #1 is `main` run 1, calls #2 and #3 are this branch's runs 1 and 2):

```
[adapter] listening on http://127.0.0.1:8791 -> http://127.0.0.1:11434
[adapter] call #1 2026-08-02T08:18:15.371Z model=qwen3.5:9b temperature=0.2 maxOutputTokens=unset
[adapter] call #2 2026-08-02T08:18:18.922Z model=qwen3.5:9b temperature=0.2 maxOutputTokens=unset
[adapter] call #3 2026-08-02T08:18:19.932Z model=qwen3.5:9b temperature=1.4 maxOutputTokens=unset
```

`main` never produced a `temperature=1.4` line; this branch did.

Two notes on how this run was set up, so the numbers are reproducible rather than surprising:

- The generated text is not the evidence here and is not expected to differ per temperature — sampling is stochastic and this prompt is short. What the change is claimed to fix is whether the model is consulted at all, which is what the adapter log counts.
- The cache namespace directory was created ahead of each block. Without that, `ensureDirectory` throws on Windows before the cache is ever written (#125, fixed by #126) and the first run of every block fails for an unrelated reason. That is a separate defect and does not affect the key computation being measured here.

### Real-adapter proof at the final head (`2b3cef0`)

The block above was captured before the identity was versioned, so it does not exercise the upgrade path. This one does, at the final head, against the same real model.

The legacy entry is not reconstructed by hashing a payload by hand — that would make the proof depend on my own reading of the old code. It is written by the **real pre-fix build**: `main` at `0ac962e`, running the shipped CLI, answering a genuine `--temperature 0.9` request. The resulting cache directory is copied byte-for-byte into two upgrade arms, so both see exactly the cache an upgrading user would have. Digests truncated to 16 hex characters.

```
### 1. main (0ac962e) writes the legacy entry
$ lobster run --mode tool "llm.invoke --provider http --model qwen3.5:9b --temperature 0.9 --prompt '...'"
  adapter requests during this run: 1
    [adapter] call #1 model=qwen3.5:9b temperature=0.9 maxOutputTokens=<absent>
  cacheKey : c4989977967b06ff...
  source   : http   cached=false
  text     : "A lobster trap is a baited cage designed to capture and hold lobsters for harvest."

### 2. 1760cb3 upgrade arm, sampling omitted  -> the collision
$ lobster run --mode tool "llm.invoke --provider http --model qwen3.5:9b --prompt '...'"
  adapter requests during this run: 0
  cacheKey : c4989977967b06ff...          <- identical to the entry written for temperature 0.9
  source   : cache  cached=true
  text     : "A lobster trap is a baited cage designed to capture and hold lobsters for harvest."

### 3. 2b3cef0 upgrade arm, sampling omitted  -> the fix
$ lobster run --mode tool "llm.invoke --provider http --model qwen3.5:9b --prompt '...'"
  adapter requests during this run: 1
    [adapter] call #2 model=qwen3.5:9b temperature=<absent> maxOutputTokens=<absent>
  cacheKey : fe51cd3bcae99fc0...
  source   : http   cached=false
  text     : "A lobster trap is used to capture and hold lobsters in the ocean."

### 4. 2b3cef0, the identical request repeated -> cache still works
$ lobster run --mode tool "llm.invoke --provider http --model qwen3.5:9b --prompt '...'"
  adapter requests during this run: 0
  cacheKey : fe51cd3bcae99fc0...
  source   : cache  cached=true
  text     : "A lobster trap is used to capture and hold lobsters in the ocean."
```

| arm | key for the unsampled request | adapter calls | served |
|---|---|---|---|
| `1760cb3` | `c4989977967b06ff...` — the legacy key | 0 | the answer sampled at 0.9 |
| `2b3cef0` | `fe51cd3bcae99fc0...` — new identity | 1 | a fresh answer |
| `2b3cef0`, repeated | `fe51cd3bcae99fc0...` | 0 | its own entry |

Block 2 is the control that makes block 3 mean something: without it, "the adapter was called once" is equally consistent with an entry seeded under a key nothing would ever compute. `1760cb3` computes the legacy key for a request that names no sampling parameter and hands back the 0.9-sampled text byte-for-byte with zero adapter calls. Block 4 separates "the legacy entry is unreachable" from "caching broke".

After the run both entries sit in the same namespace directory:

```
c4989977967b06ff...  storedAt=2026-08-04T06:12:54.033Z  text="A lobster trap is a baited cage designed to capture and hold lobsters for harvest."
fe51cd3bcae99fc0...  storedAt=2026-08-04T06:12:55.563Z  text="A lobster trap is used to capture and hold lobsters in the ocean."
```

Nothing is deleted or rewritten — the old entry is unaddressed, not destroyed — and the migration cost is exactly the one re-invocation in block 3, once per distinct prompt.

Setup: three worktrees at `0ac962e`, `1760cb3` and `2b3cef0`, each built with `tsc -p tsconfig.build.json`, one counting bridge process shared across all four runs so the call numbering is continuous. The two setup caveats from the previous block still apply: the cache namespace directory is pre-created because of #125, and the generated text is not the claim.

**Static checks:**

```
$ pnpm typecheck
> tsc -p tsconfig.json --noEmit
(no output)

$ pnpm lint
> pnpm format:check && oxlint --tsconfig tsconfig.json bin src test
Checking formatting...
All matched files use the correct format.
```

`oxlint` reports the same four pre-existing warnings as `main` and none in the changed files.

## Note for reviewers

The new tests are placed after the first test in `test/llm_invoke.test.ts` rather than at the end of the file, so this branch does not collide with the tests #124 appends there. The production change sits between #124's hunks and does not overlap any of them.

