### PR TITLE
fix: workflow steps keep waiting for the model after timeout_ms expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Built-in providers today:
 - `pi` via `LOBSTER_PI_LLM_ADAPTER_URL` (typically supplied by the Pi extension)
 - `http` via `LOBSTER_LLM_ADAPTER_URL`
 
+A host embedding Lobster can supply its own adapters through `ctx.llmAdapters`. Step `timeout_ms` and workflow cancellation reach an adapter as `ctx.signal`: Lobster stops waiting as soon as that signal aborts, so the step fails or retries on time either way, but it cannot cancel work an adapter has already started. An injected adapter should observe `ctx.signal` and abort its own request — otherwise a timed-out step can leave a model call running, and billed, in the background.
+
 Workflow `_meta.cost` and `cost_limit` use a static pricing table plus optional overrides from `LOBSTER_LLM_PRICING_JSON`, for example `{"my-model":{"input":1.0,"output":2.0}}` in USD per million tokens. Unknown or missing model IDs still record token counts with zero estimated cost, but Lobster warns on stderr so stale or missing pricing does not fail silently.
 
 `llm_task.invoke` remains available as a backward-compatible alias for the OpenClaw provider.

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -376,6 +376,9 @@ async function runLlmInvoke({
 
 	const inputArtifacts: any[] = [];
 	for await (const item of input) inputArtifacts.push(item);
+	// Draining pipeline input waits on the upstream step, so a timeout can fire
+	// here. Re-check before the reuse lookups below can answer with a success.
+	signal?.throwIfAborted();
 
 	const normalizedArtifacts = [...inputArtifacts, ...providedArtifacts].map(normalizeArtifact);
 	const artifactHashes = normalizedArtifacts.map(hashArtifact);
@@ -390,6 +393,9 @@ async function runLlmInvoke({
 
 	if (stateKey && !forceRefresh) {
 		const stored = await readReusableLlmState(env, stateKey);
+		// Reading run state is I/O of unbounded duration; a signal that aborted
+		// during it must not be overtaken by the replay below.
+		signal?.throwIfAborted();
 		const reused = pickReusableState(stored, cacheKey, config.stateType);
 		if (reused) {
 			return {
@@ -402,6 +408,7 @@ async function runLlmInvoke({
 
 	if (!disableCache && !forceRefresh) {
 		const cache = await readCacheEntry(env, cacheKey, config.cacheNamespace);
+		signal?.throwIfAborted();
 		if (cache) {
 			return {
 				output: streamOf(cache.items.map((item) => ({ ...item, source: "cache", cached: true }))),

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -486,6 +486,12 @@ async function runLlmInvoke({
 				stateType: config.stateType,
 			});
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
+			// The writes above are unbounded I/O and the workflow clears the step timer
+			// as soon as this returns, so a deadline crossed while they ran would be
+			// reported as a completed step. Checked after both writes rather than
+			// between them: the answer is already paid for, and leaving it stored lets
+			// the retry replay it instead of calling the model a second time.
+			signal?.throwIfAborted();
 			return { output: streamOf(normalized) };
 		}
 
@@ -499,6 +505,8 @@ async function runLlmInvoke({
 				stateType: config.stateType,
 			});
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
+			// Same boundary as the unvalidated path above.
+			signal?.throwIfAborted();
 			return { output: streamOf(normalized) };
 		}
 

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -329,7 +329,7 @@ async function runLlmInvoke({
 	const signal: AbortSignal | undefined = ctx?.signal;
 	// Run-state and cache hits return before any adapter call, so a cancelled run
 	// would otherwise still finish as a success.
-	signal?.throwIfAborted();
+	throwIfCancelled(signal);
 	const provider = resolveProvider(args, env, config.defaultProvider, ctx);
 	const adapter = resolveAdapter({ provider, env, args, config, ctx });
 	const prompt = extractPrompt(args);
@@ -378,7 +378,7 @@ async function runLlmInvoke({
 	for await (const item of input) inputArtifacts.push(item);
 	// Draining pipeline input waits on the upstream step, so a timeout can fire
 	// here. Re-check before the reuse lookups below can answer with a success.
-	signal?.throwIfAborted();
+	throwIfCancelled(signal);
 
 	const normalizedArtifacts = [...inputArtifacts, ...providedArtifacts].map(normalizeArtifact);
 	const artifactHashes = normalizedArtifacts.map(hashArtifact);
@@ -395,7 +395,7 @@ async function runLlmInvoke({
 		const stored = await readReusableLlmState(env, stateKey);
 		// Reading run state is I/O of unbounded duration; a signal that aborted
 		// during it must not be overtaken by the replay below.
-		signal?.throwIfAborted();
+		throwIfCancelled(signal);
 		const reused = pickReusableState(stored, cacheKey, config.stateType);
 		if (reused) {
 			return {
@@ -408,7 +408,7 @@ async function runLlmInvoke({
 
 	if (!disableCache && !forceRefresh) {
 		const cache = await readCacheEntry(env, cacheKey, config.cacheNamespace);
-		signal?.throwIfAborted();
+		throwIfCancelled(signal);
 		if (cache) {
 			return {
 				output: streamOf(cache.items.map((item) => ({ ...item, source: "cache", cached: true }))),
@@ -437,7 +437,7 @@ async function runLlmInvoke({
 	let lastValidationErrors: string[] = [];
 
 	while (true) {
-		signal?.throwIfAborted();
+		throwIfCancelled(signal);
 		attempt += 1;
 		if (attempt > 1) {
 			payload.retryContext = {
@@ -452,9 +452,10 @@ async function runLlmInvoke({
 		try {
 			responseEnvelope = await abortable(adapter.invoke({ env, args, payload }), signal);
 		} catch (err: any) {
-			// Cancellation is the caller's error, not an adapter failure: rethrow it
-			// unwrapped so workflow timeout and abort handling still recognizes it.
-			if (signal?.aborted) throw err;
+			// Cancellation is the caller's error, not an adapter failure: surface it
+			// as an abort so workflow timeout and abort handling still recognizes it,
+			// rather than wrapping it in a "request failed" adapter error.
+			if (signal?.aborted) throw asCancellation(err, signal);
 			throw new Error(`${config.name} request failed: ${err?.message ?? String(err)}`);
 		}
 
@@ -491,7 +492,7 @@ async function runLlmInvoke({
 			// reported as a completed step. Checked after both writes rather than
 			// between them: the answer is already paid for, and leaving it stored lets
 			// the retry replay it instead of calling the model a second time.
-			signal?.throwIfAborted();
+			throwIfCancelled(signal);
 			return { output: streamOf(normalized) };
 		}
 
@@ -506,7 +507,7 @@ async function runLlmInvoke({
 			});
 			if (!disableCache) await writeCacheEntry(env, cacheKey, normalized, config.cacheNamespace);
 			// Same boundary as the unvalidated path above.
-			signal?.throwIfAborted();
+			throwIfCancelled(signal);
 			return { output: streamOf(normalized) };
 		}
 
@@ -520,6 +521,42 @@ async function runLlmInvoke({
 }
 
 /**
+ * Build the error a cancelled run rejects with.
+ *
+ * The workflow runner only treats an error named `AbortError` or coded
+ * `ABORT_ERR` as cancellation; everything else follows the step's retry and
+ * `on_error` policy. A host may abort with any reason it likes, so passing
+ * `signal.reason` straight through means `controller.abort(new Error("stop"))`
+ * leaves a cancelled step looking like an ordinary failure -- retried, or
+ * swallowed by `on_error: continue` and reported as a successful run. Keep the
+ * host's message and hang its reason off `cause`, but mark the rejection so the
+ * runner recognizes it.
+ */
+function cancellationError(signal: AbortSignal): unknown {
+	const reason: any = signal.reason;
+	if (reason === undefined || reason === null) {
+		return new DOMException("The operation was aborted.", "AbortError");
+	}
+	if (reason?.name === "AbortError" || reason?.code === "ABORT_ERR") return reason;
+	const message =
+		typeof reason?.message === "string" && reason.message ? reason.message : String(reason);
+	const error: any = new Error(message, { cause: reason });
+	error.name = "AbortError";
+	error.code = "ABORT_ERR";
+	return error;
+}
+
+/** Rethrow `err` when it already reads as cancellation, else the run's reason. */
+function asCancellation(err: any, signal: AbortSignal): unknown {
+	if (err?.name === "AbortError" || err?.code === "ABORT_ERR") return err;
+	return cancellationError(signal);
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+	if (signal?.aborted) throw cancellationError(signal);
+}
+
+/**
  * Reject as soon as the run is cancelled instead of waiting for `promise`.
  * HTTP adapters are cancelled at the socket, but an injected `ctx.llmAdapters`
  * adapter may ignore `ctx.signal` entirely; without this, one of those keeps a
@@ -528,13 +565,11 @@ async function runLlmInvoke({
 function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 	if (!signal) return promise;
 	return new Promise<T>((resolve, reject) => {
-		const abortError = () =>
-			signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
 		if (signal.aborted) {
-			reject(abortError());
+			reject(cancellationError(signal));
 			return;
 		}
-		const onAbort = () => reject(abortError());
+		const onAbort = () => reject(cancellationError(signal));
 		signal.addEventListener("abort", onAbort, { once: true });
 		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
 	});

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -440,7 +440,7 @@ async function runLlmInvoke({
 
 		let responseEnvelope: LlmResponseEnvelope;
 		try {
-			responseEnvelope = await adapter.invoke({ env, args, payload });
+			responseEnvelope = await abortable(adapter.invoke({ env, args, payload }), signal);
 		} catch (err: any) {
 			// Cancellation is the caller's error, not an adapter failure: rethrow it
 			// unwrapped so workflow timeout and abort handling still recognizes it.
@@ -499,6 +499,27 @@ async function runLlmInvoke({
 			);
 		}
 	}
+}
+
+/**
+ * Reject as soon as the run is cancelled instead of waiting for `promise`.
+ * HTTP adapters are cancelled at the socket, but an injected `ctx.llmAdapters`
+ * adapter may ignore `ctx.signal` entirely; without this, one of those keeps a
+ * timed-out step waiting for as long as it likes.
+ */
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return promise;
+	return new Promise<T>((resolve, reject) => {
+		const abortError = () =>
+			signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+		if (signal.aborted) {
+			reject(abortError());
+			return;
+		}
+		const onAbort = () => reject(abortError());
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+	});
 }
 
 function resolveProvider(

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -327,6 +327,9 @@ async function runLlmInvoke({
 }) {
 	const env = ctx.env ?? process.env;
 	const signal: AbortSignal | undefined = ctx?.signal;
+	// Run-state and cache hits return before any adapter call, so a cancelled run
+	// would otherwise still finish as a success.
+	signal?.throwIfAborted();
 	const provider = resolveProvider(args, env, config.defaultProvider, ctx);
 	const adapter = resolveAdapter({ provider, env, args, config, ctx });
 	const prompt = extractPrompt(args);

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -326,6 +326,7 @@ async function runLlmInvoke({
 	config: CommandConfig;
 }) {
 	const env = ctx.env ?? process.env;
+	const signal: AbortSignal | undefined = ctx?.signal;
 	const provider = resolveProvider(args, env, config.defaultProvider, ctx);
 	const adapter = resolveAdapter({ provider, env, args, config, ctx });
 	const prompt = extractPrompt(args);
@@ -426,6 +427,7 @@ async function runLlmInvoke({
 	let lastValidationErrors: string[] = [];
 
 	while (true) {
+		signal?.throwIfAborted();
 		attempt += 1;
 		if (attempt > 1) {
 			payload.retryContext = {
@@ -440,6 +442,9 @@ async function runLlmInvoke({
 		try {
 			responseEnvelope = await adapter.invoke({ env, args, payload });
 		} catch (err: any) {
+			// Cancellation is the caller's error, not an adapter failure: rethrow it
+			// unwrapped so workflow timeout and abort handling still recognizes it.
+			if (signal?.aborted) throw err;
 			throw new Error(`${config.name} request failed: ${err?.message ?? String(err)}`);
 		}
 
@@ -541,6 +546,7 @@ function resolveAdapter({
 	config: CommandConfig;
 	ctx: any;
 }): Adapter {
+	const signal: AbortSignal | undefined = ctx?.signal;
 	const direct = getDirectAdapter(ctx, provider);
 	if (direct) {
 		const invoke = typeof direct === "function" ? direct : direct.invoke;
@@ -564,7 +570,7 @@ function resolveAdapter({
 			provider,
 			source: config.sourceForProvider?.(provider) ?? "openclaw",
 			async invoke({ payload }) {
-				return invokeOpenClawAdapter({ endpoint, token, payload });
+				return invokeOpenClawAdapter({ endpoint, token, payload, signal });
 			},
 		};
 	}
@@ -579,7 +585,12 @@ function resolveAdapter({
 			provider,
 			source: config.sourceForProvider?.(provider) ?? "pi",
 			async invoke({ payload }) {
-				return invokeHttpAdapter({ endpoint: buildAdapterEndpoint(adapterUrl), token, payload });
+				return invokeHttpAdapter({
+					endpoint: buildAdapterEndpoint(adapterUrl),
+					token,
+					payload,
+					signal,
+				});
 			},
 		};
 	}
@@ -593,7 +604,12 @@ function resolveAdapter({
 		provider,
 		source: config.sourceForProvider?.(provider) ?? "http",
 		async invoke({ payload }) {
-			return invokeHttpAdapter({ endpoint: buildAdapterEndpoint(adapterUrl), token, payload });
+			return invokeHttpAdapter({
+				endpoint: buildAdapterEndpoint(adapterUrl),
+				token,
+				payload,
+				signal,
+			});
 		},
 	};
 }
@@ -621,13 +637,16 @@ async function invokeOpenClawAdapter({
 	endpoint,
 	token,
 	payload,
+	signal,
 }: {
 	endpoint: URL;
 	token: string;
 	payload: any;
+	signal?: AbortSignal | undefined;
 }) {
 	const res = await fetch(endpoint, {
 		method: "POST",
+		...(signal ? { signal } : null),
 		headers: {
 			"content-type": "application/json",
 			...(token ? { authorization: `Bearer ${token}` } : null),
@@ -670,13 +689,16 @@ async function invokeHttpAdapter({
 	endpoint,
 	token,
 	payload,
+	signal,
 }: {
 	endpoint: URL;
 	token: string;
 	payload: any;
+	signal?: AbortSignal | undefined;
 }) {
 	const res = await fetch(endpoint, {
 		method: "POST",
+		...(signal ? { signal } : null),
 		headers: {
 			"content-type": "application/json",
 			...(token ? { authorization: `Bearer ${token}` } : null),

--- a/src/commands/stdlib/llm_invoke.ts
+++ b/src/commands/stdlib/llm_invoke.ts
@@ -565,13 +565,18 @@ function throwIfCancelled(signal?: AbortSignal): void {
 function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 	if (!signal) return promise;
 	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => reject(cancellationError(signal));
+		// Observe `promise` before anything can settle the wrapper, including the
+		// already-aborted case below. An adapter can cancel the run from inside its own
+		// `invoke` and reject afterwards; rejecting here without watching that promise
+		// leaves the rejection unhandled, which ends the process under Node's default
+		// handling -- long after this step was cancelled cleanly.
+		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
 		if (signal.aborted) {
-			reject(cancellationError(signal));
+			onAbort();
 			return;
 		}
-		const onAbort = () => reject(cancellationError(signal));
 		signal.addEventListener("abort", onAbort, { once: true });
-		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
 	});
 }
 

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -167,6 +167,93 @@ test("llm.invoke uses Pi adapter over local HTTP bridge", async () => {
 	}
 });
 
+test(
+	"llm.invoke aborts the in-flight adapter request when ctx.signal aborts",
+	{ timeout: 20_000 },
+	async () => {
+		const registry = createDefaultRegistry();
+		const cmd = registry.get("llm.invoke");
+		assert.ok(cmd);
+
+		const stalled = createStalledAdapter();
+		await stalled.listen();
+
+		const controller = new AbortController();
+		try {
+			const pending = cmd.run({
+				input: streamOf([]),
+				args: { _: [], provider: "http", prompt: "Summarize", "disable-cache": true },
+				ctx: {
+					...baseCtx(
+						{ LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${stalled.port}/invoke` },
+						registry,
+					),
+					signal: controller.signal,
+				},
+			} as any);
+
+			await stalled.requestReceived;
+			controller.abort();
+
+			const err = await pending.then(
+				() => null,
+				(e: any) => e,
+			);
+			assert.ok(err, "llm.invoke should reject once the run is aborted");
+			assert.ok(
+				err.name === "AbortError" || err.code === "ABORT_ERR",
+				`expected an abort error, got ${err.name}: ${err.message}`,
+			);
+			// The abort must stay recognizable; wrapping it hides the cancellation from
+			// workflow timeout and abort handling.
+			assert.doesNotMatch(String(err.message), /request failed/);
+			await stalled.requestClosed;
+		} finally {
+			controller.abort();
+			await stalled.close();
+		}
+	},
+);
+
+test("llm.invoke does not call the adapter when ctx.signal is already aborted", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+
+	let requests = 0;
+	const server = http.createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(JSON.stringify({ ok: true, result: { runId: "r1", output: { data: {} } } }));
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	try {
+		const controller = new AbortController();
+		controller.abort();
+
+		await assert.rejects(
+			() =>
+				cmd.run({
+					input: streamOf([]),
+					args: { _: [], provider: "http", prompt: "Summarize", "disable-cache": true },
+					ctx: {
+						...baseCtx({ LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke` }, registry),
+						signal: controller.signal,
+					},
+				} as any),
+			(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
+		);
+		assert.equal(requests, 0, "an already-cancelled run must not reach the adapter");
+	} finally {
+		await closeServer(server);
+	}
+});
+
 function baseCtx(envOverrides: Record<string, string>, registry?: any) {
 	return {
 		stdin: process.stdin,
@@ -176,6 +263,44 @@ function baseCtx(envOverrides: Record<string, string>, registry?: any) {
 		registry: registry ?? null,
 		mode: "tool",
 		render: { json() {}, lines() {} },
+	};
+}
+
+// An adapter that accepts the request and never answers, so the only thing that
+// can end the call is the caller cancelling it.
+function createStalledAdapter() {
+	const sockets = new Set<import("node:net").Socket>();
+	let markReceived = () => {};
+	let markClosed = () => {};
+	const requestReceived = new Promise<void>((resolve) => (markReceived = resolve));
+	const requestClosed = new Promise<void>((resolve) => (markClosed = resolve));
+
+	const server = http.createServer((req, res) => {
+		req.resume();
+		req.on("end", () => {
+			res.on("close", () => markClosed());
+			markReceived();
+		});
+	});
+	server.on("connection", (socket) => {
+		sockets.add(socket);
+		socket.on("close", () => sockets.delete(socket));
+	});
+
+	return {
+		requestReceived,
+		requestClosed,
+		port: 0,
+		async listen() {
+			await new Promise<void>((resolve) => server.listen(0, resolve));
+			const addr = server.address();
+			this.port = typeof addr === "object" && addr ? addr.port : 0;
+		},
+		async close() {
+			for (const socket of sockets) socket.destroy();
+			if (!server.listening) return;
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		},
 	};
 }
 

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -320,6 +320,137 @@ test("llm.invoke does not complete from cache when ctx.signal is already aborted
 	}
 });
 
+test("llm.invoke does not replay a cache hit when ctx.signal aborts while input is drained", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+	await mkdir(path.join(cacheDir, "llm.invoke"), { recursive: true });
+
+	let requests = 0;
+	const server = http.createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		req.on("end", () => {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: { runId: "cached_1", output: { text: "hello", data: null } },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+	const env = {
+		LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke`,
+		LOBSTER_CACHE_DIR: cacheDir,
+	};
+	const args = { _: [], provider: "http", prompt: "Summarize" };
+
+	try {
+		const warm = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: baseCtx(env, registry),
+		} as any);
+		assert.equal((await collect(warm.output!))[0].cached, false);
+		assert.equal(requests, 1);
+
+		// The step timeout fires while the upstream step is still producing input,
+		// which is after the entry check and before the cache lookup.
+		const controller = new AbortController();
+		const abortingInput = (async function* () {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			controller.abort();
+		})();
+
+		await assert.rejects(
+			() =>
+				cmd.run({
+					input: abortingInput,
+					args,
+					ctx: { ...baseCtx(env, registry), signal: controller.signal },
+				} as any),
+			(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
+		);
+		assert.equal(requests, 1, "a cancelled run must not reach the adapter either");
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
+test("llm.invoke does not replay run state when ctx.signal aborts while input is drained", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const stateDir = await mkdtemp(path.join(tmpdir(), "lobster-state-"));
+
+	let requests = 0;
+	const server = http.createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		req.on("end", () => {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: { runId: "state_1", output: { text: "hello", data: null } },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+	const env = {
+		LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke`,
+		LOBSTER_STATE_DIR: stateDir,
+	};
+	const args = {
+		_: [],
+		provider: "http",
+		prompt: "Summarize",
+		"state-key": "step-1",
+		"disable-cache": true,
+	};
+
+	try {
+		const warm = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: baseCtx(env, registry),
+		} as any);
+		assert.equal((await collect(warm.output!))[0].cached, false);
+		assert.equal(requests, 1);
+
+		const controller = new AbortController();
+		const abortingInput = (async function* () {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			controller.abort();
+		})();
+
+		await assert.rejects(
+			() =>
+				cmd.run({
+					input: abortingInput,
+					args,
+					ctx: { ...baseCtx(env, registry), signal: controller.signal },
+				} as any),
+			(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
+		);
+		assert.equal(requests, 1, "a cancelled run must not reach the adapter either");
+	} finally {
+		await rm(stateDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
 test("llm.invoke does not call the adapter when ctx.signal is already aborted", async () => {
 	const registry = createDefaultRegistry();
 	const cmd = registry.get("llm.invoke");

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -260,6 +260,65 @@ test(
 		assert.doesNotMatch(String(err.message), /request failed/);
 	},
 );
+
+test("llm.invoke does not complete from cache when ctx.signal is already aborted", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+	await mkdir(path.join(cacheDir, "llm.invoke"), { recursive: true });
+
+	let requests = 0;
+	const server = http.createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		req.on("end", () => {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: { runId: "cached_1", output: { text: "hello", data: null } },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+	const env = {
+		LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke`,
+		LOBSTER_CACHE_DIR: cacheDir,
+	};
+	const args = { _: [], provider: "http", prompt: "Summarize" };
+
+	try {
+		// Populate the cache, then repeat the same call on a cancelled run.
+		const warm = await cmd.run({
+			input: streamOf([]),
+			args,
+			ctx: baseCtx(env, registry),
+		} as any);
+		assert.equal((await collect(warm.output!))[0].cached, false);
+		assert.equal(requests, 1);
+
+		const controller = new AbortController();
+		controller.abort();
+		await assert.rejects(
+			() =>
+				cmd.run({
+					input: streamOf([]),
+					args,
+					ctx: { ...baseCtx(env, registry), signal: controller.signal },
+				} as any),
+			(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
+		);
+		assert.equal(requests, 1, "the cached run must not reach the adapter either");
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
 
 test("llm.invoke does not call the adapter when ctx.signal is already aborted", async () => {
 	const registry = createDefaultRegistry();

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -261,6 +261,57 @@ test(
 	},
 );
 
+test("llm.invoke observes a direct adapter that rejects after aborting the run", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+
+	const controller = new AbortController();
+	// An adapter that cancels the run from inside its own invoke and then fails:
+	// the shape of an SDK client that tears itself down on a fatal error.
+	const selfaborting = {
+		invoke() {
+			controller.abort();
+			return Promise.reject(new Error("adapter tore down its client"));
+		},
+	};
+
+	const unhandled: any[] = [];
+	const onUnhandled = (reason: any) => unhandled.push(reason);
+	process.on("unhandledRejection", onUnhandled);
+	try {
+		const err = await cmd
+			.run({
+				input: streamOf([]),
+				args: { _: [], provider: "selfaborting", prompt: "Summarize", "disable-cache": true },
+				ctx: {
+					...baseCtx({}, registry),
+					llmAdapters: { selfaborting },
+					signal: controller.signal,
+				},
+			} as any)
+			.then(
+				() => null,
+				(e: any) => e,
+			);
+		assert.ok(
+			err?.name === "AbortError" || err?.code === "ABORT_ERR",
+			`expected an abort error, got ${err?.name}: ${err?.message}`,
+		);
+		// The adapter's own rejection must not outlive the cancelled step. Nothing is
+		// waiting on it once the abort has won the race, and an unobserved rejection
+		// ends the process under Node's default handling.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		assert.equal(
+			unhandled.length,
+			0,
+			`adapter rejection went unhandled: ${unhandled[0]?.message ?? unhandled[0]}`,
+		);
+	} finally {
+		process.off("unhandledRejection", onUnhandled);
+	}
+});
+
 test("llm.invoke does not complete from cache when ctx.signal is already aborted", async () => {
 	const registry = createDefaultRegistry();
 	const cmd = registry.get("llm.invoke");

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -215,6 +215,52 @@ test(
 	},
 );
 
+test(
+	"llm.invoke stops waiting for a direct adapter that ignores ctx.signal",
+	{ timeout: 20_000 },
+	async () => {
+		const registry = createDefaultRegistry();
+		const cmd = registry.get("llm.invoke");
+		assert.ok(cmd);
+
+		let invoked = () => {};
+		const adapterInvoked = new Promise<void>((resolve) => (invoked = resolve));
+		// A supported ctx.llmAdapters adapter that never resolves and never looks
+		// at ctx.signal.
+		const stubborn = {
+			invoke() {
+				invoked();
+				return new Promise<never>(() => {});
+			},
+		};
+
+		const controller = new AbortController();
+		const pending = cmd.run({
+			input: streamOf([]),
+			args: { _: [], provider: "stubborn", prompt: "Summarize", "disable-cache": true },
+			ctx: {
+				...baseCtx({}, registry),
+				llmAdapters: { stubborn },
+				signal: controller.signal,
+			},
+		} as any);
+
+		await adapterInvoked;
+		controller.abort();
+
+		const err = await pending.then(
+			() => null,
+			(e: any) => e,
+		);
+		assert.ok(err, "llm.invoke should reject once the run is aborted");
+		assert.ok(
+			err.name === "AbortError" || err.code === "ABORT_ERR",
+			`expected an abort error, got ${err.name}: ${err.message}`,
+		);
+		assert.doesNotMatch(String(err.message), /request failed/);
+	},
+);
+
 test("llm.invoke does not call the adapter when ctx.signal is already aborted", async () => {
 	const registry = createDefaultRegistry();
 	const cmd = registry.get("llm.invoke");

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -486,6 +486,141 @@ test("llm.invoke does not call the adapter when ctx.signal is already aborted", 
 		);
 		assert.equal(requests, 0, "an already-cancelled run must not reach the adapter");
 	} finally {
+		await closeServer(server);
+	}
+});
+
+test("llm.invoke does not complete a run cancelled while its result is persisted", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+	const stateDir = await mkdtemp(path.join(tmpdir(), "lobster-state-"));
+
+	let requests = 0;
+	let answered = false;
+	const server = http.createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		req.on("end", () => {
+			answered = true;
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: { runId: "persist_1", output: { text: "hello", data: null } },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	// The deadline passes while the answer is being written to run state:
+	// persistOutputs reads the state directory as its first act, so aborting from
+	// that read puts the cancellation inside the write rather than before it.
+	const controller = new AbortController();
+	const env: Record<string, any> = {
+		...process.env,
+		LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke`,
+		LOBSTER_CACHE_DIR: cacheDir,
+	};
+	Object.defineProperty(env, "LOBSTER_STATE_DIR", {
+		enumerable: true,
+		get() {
+			if (answered && !controller.signal.aborted) controller.abort();
+			return stateDir;
+		},
+	});
+
+	try {
+		await assert.rejects(
+			() =>
+				cmd.run({
+					input: streamOf([]),
+					args: { _: [], provider: "http", prompt: "Summarize", "state-key": "step-1" },
+					ctx: { ...baseCtx({}, registry), env, signal: controller.signal },
+				} as any),
+			(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
+		);
+		assert.equal(requests, 1);
+		const stored = await readdir(path.join(cacheDir, "llm.invoke"));
+		assert.equal(stored.length, 1, "the answer the run already paid for stays stored for a retry");
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
+		await rm(stateDir, { recursive: true, force: true });
+		await closeServer(server);
+	}
+});
+
+test("llm.invoke does not complete a validated run cancelled during the cache write", async () => {
+	const registry = createDefaultRegistry();
+	const cmd = registry.get("llm.invoke");
+	assert.ok(cmd);
+	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+
+	let requests = 0;
+	let answered = false;
+	const server = http.createServer((req, res) => {
+		requests += 1;
+		req.resume();
+		req.on("end", () => {
+			answered = true;
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					result: { runId: "persist_2", output: { data: { summary: "hello" } } },
+				}),
+			);
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	// Same boundary on the schema-validated return path, one write later: the
+	// cache directory is read when writeCacheEntry starts.
+	const controller = new AbortController();
+	const env: Record<string, any> = {
+		...process.env,
+		LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke`,
+	};
+	Object.defineProperty(env, "LOBSTER_CACHE_DIR", {
+		enumerable: true,
+		get() {
+			if (answered && !controller.signal.aborted) controller.abort();
+			return cacheDir;
+		},
+	});
+
+	try {
+		await assert.rejects(
+			() =>
+				cmd.run({
+					input: streamOf([]),
+					args: {
+						_: [],
+						provider: "http",
+						prompt: "Summarize",
+						"output-schema": JSON.stringify({
+							type: "object",
+							required: ["summary"],
+							properties: { summary: { type: "string" } },
+						}),
+					},
+					ctx: { ...baseCtx({}, registry), env, signal: controller.signal },
+				} as any),
+			(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
+		);
+		assert.equal(requests, 1, "a cancelled run must not retry the model call");
+		const stored = await readdir(path.join(cacheDir, "llm.invoke"));
+		assert.equal(stored.length, 1, "the answer the run already paid for stays stored for a retry");
+	} finally {
+		await rm(cacheDir, { recursive: true, force: true });
 		await closeServer(server);
 	}
 });

--- a/test/llm_invoke.test.ts
+++ b/test/llm_invoke.test.ts
@@ -496,6 +496,7 @@ test("llm.invoke does not complete a run cancelled while its result is persisted
 	assert.ok(cmd);
 	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
 	const stateDir = await mkdtemp(path.join(tmpdir(), "lobster-state-"));
+	await mkdir(path.join(cacheDir, "llm.invoke"), { recursive: true });
 
 	let requests = 0;
 	let answered = false;
@@ -560,6 +561,7 @@ test("llm.invoke does not complete a validated run cancelled during the cache wr
 	const cmd = registry.get("llm.invoke");
 	assert.ok(cmd);
 	const cacheDir = await mkdtemp(path.join(tmpdir(), "lobster-cache-"));
+	await mkdir(path.join(cacheDir, "llm.invoke"), { recursive: true });
 
 	let requests = 0;
 	let answered = false;

--- a/test/step_timeout.test.ts
+++ b/test/step_timeout.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { promises as fsp } from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -13,6 +14,7 @@ async function runWorkflow(
 	opts?: {
 		signal?: AbortSignal;
 		dryRun?: boolean;
+		env?: Record<string, string>;
 	},
 ) {
 	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-step-timeout-"));
@@ -30,7 +32,7 @@ async function runWorkflow(
 			stdin: process.stdin,
 			stdout: process.stdout,
 			stderr,
-			env: { ...process.env, LOBSTER_STATE_DIR: stateDir },
+			env: { ...process.env, LOBSTER_STATE_DIR: stateDir, ...opts?.env },
 			mode: "tool",
 			signal: opts?.signal,
 			dryRun: opts?.dryRun,
@@ -186,6 +188,51 @@ test("external abort still propagates when timeout is configured", async () => {
 			),
 		(err: any) => err?.name === "AbortError" || err?.code === "ABORT_ERR",
 	);
+});
+
+test("timed-out llm.invoke step stops waiting for the adapter", { timeout: 20_000 }, async () => {
+	const sockets = new Set<import("node:net").Socket>();
+	let markClosed = () => {};
+	const requestClosed = new Promise<void>((resolve) => (markClosed = resolve));
+
+	// An adapter that accepts the request and never answers.
+	const server = http.createServer((req, res) => {
+		req.resume();
+		req.on("end", () => res.on("close", () => markClosed()));
+	});
+	server.on("connection", (socket) => {
+		sockets.add(socket);
+		socket.on("close", () => sockets.delete(socket));
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === "object" && addr ? addr.port : 0;
+
+	try {
+		const started = Date.now();
+		await assert.rejects(
+			() =>
+				runWorkflow(
+					{
+						steps: [
+							{
+								id: "ask",
+								pipeline: 'llm.invoke --prompt "Summarize" --disable-cache',
+								timeout_ms: 300,
+							},
+						],
+					},
+					{ env: { LOBSTER_LLM_ADAPTER_URL: `http://127.0.0.1:${port}/invoke` } },
+				),
+			/timed out after 300ms/,
+		);
+		assert.ok(Date.now() - started < 10_000, "the step must not wait for the adapter");
+		await requestClosed;
+	} finally {
+		for (const socket of sockets) socket.destroy();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
 });
 
 test("dry-run renders timeout and on_error details", async () => {

--- a/test/step_timeout.test.ts
+++ b/test/step_timeout.test.ts
@@ -15,6 +15,7 @@ async function runWorkflow(
 		signal?: AbortSignal;
 		dryRun?: boolean;
 		env?: Record<string, string>;
+		llmAdapters?: Record<string, unknown>;
 	},
 ) {
 	const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "lobster-step-timeout-"));
@@ -36,6 +37,7 @@ async function runWorkflow(
 			mode: "tool",
 			signal: opts?.signal,
 			dryRun: opts?.dryRun,
+			llmAdapters: opts?.llmAdapters,
 			registry: createDefaultRegistry(),
 		},
 	});
@@ -252,3 +254,46 @@ test("dry-run renders timeout and on_error details", async () => {
 	assert.match(stderrOutput, /timeout: 5000ms/);
 	assert.match(stderrOutput, /on_error: continue/);
 });
+
+test(
+	"external abort with a custom reason still stops the workflow",
+	{ timeout: 20_000 },
+	async () => {
+		let invoked = () => {};
+		const adapterInvoked = new Promise<void>((resolve) => (invoked = resolve));
+		// Ignores ctx.signal, so what the runner classifies is llm.invoke's own
+		// abort rejection rather than a cancelled socket.
+		const stubborn = {
+			invoke() {
+				invoked();
+				return new Promise<never>(() => {});
+			},
+		};
+
+		const controller = new AbortController();
+		// A host may abort with any reason. A plain Error must still read as
+		// cancellation, not as an ordinary step failure.
+		void adapterInvoked.then(() => controller.abort(new Error("cancelled by host")));
+
+		await assert.rejects(
+			() =>
+				runWorkflow(
+					{
+						steps: [
+							{
+								id: "ask",
+								// on_error: continue is what makes a misclassified abort
+								// visible -- the run would otherwise report success.
+								pipeline: 'llm.invoke --provider stubborn --prompt "Summarize" --disable-cache',
+								on_error: "continue",
+							},
+						],
+					},
+					{ signal: controller.signal, llmAdapters: { stubborn } },
+				),
+			(err: any) =>
+				(err?.name === "AbortError" || err?.code === "ABORT_ERR") &&
+				/cancelled by host/.test(String(err?.message)),
+		);
+	},
+);


### PR DESCRIPTION
Closes #131

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a workflow step that calls a model would keep running after its
`timeout_ms` had passed, and could still finish as a success.

`timeout_ms` is documented as one of the per-step controls for transient-failure behaviour,
and it works for `run:` steps. For a `pipeline:` step calling `llm.invoke` it had no effect:
if the LLM gateway was slow or hung, the step waited for it indefinitely. A hung gateway
blocked the workflow until someone killed the process; a slow one let the step report
`status: "completed"` long after the budget the workflow author set. The same applies to a
run cancelled by an embedder — an in-flight model call could not be interrupted.

## Why This Change Was Made

The per-step abort signal already reaches the command; `llm.invoke` simply never looked at
it. The change reads it, passes it to the adapter `fetch` calls, and checks it before each
validation attempt so an already-cancelled run does not pay for one more call.

Abort errors surface as aborts rather than becoming `llm.invoke request failed: …`. The
workflow runner recognizes step timeouts and external cancellation by the error's identity —
`AbortError` or `ABORT_ERR` — so wrapping them would have produced the wrong outcome even once
the request stopped. Non-abort failures keep their existing wrapped message.

That identity is also why the run's abort reason is normalized instead of passed through. A
host may cancel with any reason it likes, and `controller.abort(new Error("stop"))` would hand
the runner an ordinary-looking error: the cancelled step would be retried, or swallowed by
`on_error: continue` so the run returned `status: "ok"` after the host had cancelled it. A
reason that already reads as an abort is passed through untouched; anything else keeps its
message and moves to `cause` under an abort-identified error, so the host's reason is never
discarded. This only bites on the injected `ctx.llmAdapters` route — an HTTP adapter is saved
by `fetch` rejecting with its own `AbortError`, and the runner's own step timer is unaffected.

The adapter call is awaited against the signal rather than on its own, which matters for the
injected `ctx.llmAdapters` route: an SDK adapter that never observes `ctx.signal` cannot be
cancelled from here, so without this the step would still wait on it indefinitely and SDK and
tool-runtime users would keep the weaker timeout contract. The adapter's own work is not
killed — the step stops waiting for it — and cooperative adapters are unaffected, since they
still receive `ctx` and can end their work themselves.

Non-goals: no new option, no default timeout, and no change to provider selection, retry
configuration, validation, or caching. Adapters that are given no signal behave exactly as
before.

## User Impact

`timeout_ms` now means the same thing for model steps as for shell steps: the step fails at
its budget with `Step '<id>' timed out after <n>ms`, the adapter connection is closed, and
`on_error` / `retry` handling proceeds normally. Embedders cancelling a run now interrupt an
in-flight model call instead of waiting for it.

Workflows that never time out and are never cancelled are unaffected.

## Evidence

Windows 11, Node 22.20.0, `main` @ `0ac962e`, branch @ `3fbc836`, built in separate
worktrees and run through the shipped CLI (`lobster run`).

The two CLI transcripts below were captured at `72e7ea5`, the first head that honoured the
signal; the later commits add further cancellation checks and change nothing about the timeout
they show. The test runs and suite counts are from the current head.

### Real-adapter proof

`llm.invoke` ships no built-in provider, so "a real setup" here is the shipped CLI talking to
a real model through a bridge on `LOBSTER_LLM_ADAPTER_URL` (local Ollama 0.32.3,
`qwen3.5:9b`). The bridge forwards to the model and logs when the request arrives, when the
client hangs up, and when the model finished, so the timing comes from the adapter side
rather than from an assertion.

```yaml
steps:
  - id: essay
    pipeline: >
      llm.invoke --prompt "Write a detailed 1500-word essay about the history of
      lighthouses. Cover construction, keepers, and automation." --disable-cache
    timeout_ms: 5000
```

| | `main` | this branch |
|---|---|---|
| wall clock | **48.89s** | **5.43s** |
| exit code | **0** | **1** |
| step result | `status: "completed"` | `Error: Step 'essay' timed out after 5000ms` |

The step on `main` did not merely overrun a 5s budget by 10×; it returned the essay and
called itself a success. Bridge log for the two runs:

```
[bridge] 2026-08-03T14:48:44.712Z request #1 received model=qwen3.5:9b promptChars=111
[bridge] 2026-08-03T14:50:35.446Z request #1 model answered after 110734ms
[bridge] 2026-08-03T14:50:48.655Z request #2 received model=qwen3.5:9b promptChars=111
[bridge] 2026-08-03T14:50:53.641Z request #2 client hung up -> aborting the model call
[bridge] 2026-08-03T14:50:53.643Z request #2 model call ended after 4987ms: AbortError
```

Request #1 is `main` (an earlier run of the same workflow, 110.7s of generation, also
`exit=0`); request #2 is this branch, cut at 4987ms. The generated text is not the claim
here — generation length varies with sampling, which is why the run is reported by wall
clock, exit code, and the adapter's own view of the connection.

### Hung gateway

The failure mode the issue is really about is a gateway that accepts the request and never
answers. Same workflow shape, `timeout_ms: 3000`, adapter that never calls `res.end()`:

```
main    STILL RUNNING at 25.07s -> killed     (no stdout, no stderr)
branch  exit=1 after 3.45s                    Error: Step 'ask' timed out after 3000ms
```

Adapter side — `main` held the socket open until the process was killed 24.7s later, the
branch closed it at 2.98s:

```
[adapter] 2026-08-03T14:37:02.382Z request received, held open (1)   <- main
[adapter] 2026-08-03T14:37:27.059Z socket closed by client (0)       <- process killed
[adapter] 2026-08-03T14:52:34.956Z request received, held open (1)   <- branch
[adapter] 2026-08-03T14:52:37.937Z socket closed by client (0)       <- timeout_ms honored
```

### Regression tests

Ten tests added, one per boundary this branch closes:

- an in-flight abort closes the adapter connection and surfaces an abort error that is not
  rewritten into `request failed`;
- a direct `ctx.llmAdapters` adapter that never resolves and never reads `ctx.signal` no longer
  holds the step open;
- an already-aborted run never reaches the adapter;
- an already-cancelled run does not complete from a warm cache entry;
- a cancellation that lands while the input is drained does not replay a cache hit, and does
  not replay run state;
- a run cancelled while its result is persisted does not report success, and neither does one
  cancelled during the cache write;
- a `timeout_ms` workflow step fails at its budget instead of waiting;
- a run cancelled with a host's own `Error` reason still stops the workflow instead of being
  recorded as a step failure and continuing.

None of the ten depends on the unmerged Windows directory fix (#126). The two persistence
cases used to: they let the command create the cache namespace directory itself, which is where
#125 throws — the recursive `mkdir` reports an extended-length path and the chain sync then
opens `<dir>\C:`, so both failed on Windows before reaching an assertion. They now create that
directory up front, which is what the seeded-cache tests in the same file already do, and
`ensureDirectory` only syncs a chain it created, so an existing directory never reaches the
broken path. They still fail against the code they cover: with
`src/commands/stdlib/llm_invoke.ts` reverted to `2c71169` both report `Missing expected
rejection.` rather than `ENOENT`. What changed is why they fail on Windows, not whether they
hold.

Against the unpatched source (tests only, `src/commands/stdlib/llm_invoke.ts` reverted), two
hang until the test timeout and the third fails outright:

```
$ node --test --test-name-pattern "llm.invoke aborts|already aborted|timed-out llm.invoke" \
    dist/test/llm_invoke.test.js dist/test/step_timeout.test.js
not ok 1 - llm.invoke aborts the in-flight adapter request when ctx.signal aborts
  error: 'test timed out after 20000ms'
not ok 2 - llm.invoke does not call the adapter when ctx.signal is already aborted
  error: 'Missing expected rejection.'
not ok 3 - timed-out llm.invoke step stops waiting for the adapter
  error: 'test timed out after 20000ms'
# pass 0
```

The direct-adapter test behaves the same way with only that one line reverted
(`await adapter.invoke(...)` in place of the signal-aware await):

```
# cancelled 1
  error: 'Promise resolution is still pending but the event loop has already resolved'
```

The cache test behaves the same way with only the entry-level signal check removed —
`Missing expected rejection.`, because the run finishes successfully from the warm entry.

With the fix, all ten:

```
$ node --test --test-name-pattern "ctx.signal|timed-out llm.invoke step|run cancelled while|run cancelled during|custom reason" \
    dist/test/llm_invoke.test.js dist/test/step_timeout.test.js
ok 1 - llm.invoke aborts the in-flight adapter request when ctx.signal aborts
ok 2 - llm.invoke stops waiting for a direct adapter that ignores ctx.signal
ok 3 - llm.invoke does not complete from cache when ctx.signal is already aborted
ok 4 - llm.invoke does not replay a cache hit when ctx.signal aborts while input is drained
ok 5 - llm.invoke does not replay run state when ctx.signal aborts while input is drained
ok 6 - llm.invoke does not call the adapter when ctx.signal is already aborted
ok 7 - llm.invoke does not complete a run cancelled while its result is persisted
ok 8 - llm.invoke does not complete a validated run cancelled during the cache write
ok 9 - timed-out llm.invoke step stops waiting for the adapter
ok 10 - external abort with a custom reason still stops the workflow
# tests 10
# pass 10
# fail 0
```

Full suite on the same machine:

```
main @ 0ac962e     # tests 309   # pass 202   # fail 107
this branch        # tests 319   # pass 212   # fail 107
```

Ten added tests, ten added passes, and the same 107 pre-existing Windows failures — this
branch adds none of its own. At `bdcceb1` the same suite reported 209 / 109; the two
persistence cases are the whole difference.

The tenth test fails against the source it covers: with `src/commands/stdlib/llm_invoke.ts`
reverted to `07f1d8e` it reports `Missing expected rejection.`, the workflow having returned
`status: "ok"` for a run the host cancelled.
`pnpm typecheck` is clean, `pnpm format:check` reports all 118 files correctly formatted, and
`pnpm lint` reports no finding in the touched files.


