### PR TITLE
fix: abort gog.gmail.send with the same process helper as search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Lobster will be documented in this file.
 
 ## Unreleased
 
+- Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).
 
 ## 2026.6.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Lobster will be documented in this file.
 ## Unreleased
 
 - Honor cancellation and step timeouts in `gog.gmail.send` by terminating the gog process tree the same way `gog.gmail.search` already does.
+- Do not automatically retry a timed-out or failed `gog.gmail.send` step. Killing the local client cannot prove Gmail did not already accept the message.
 - Add first-class `openclaw.agent` workflow turns with configured agent, session, model, thinking, and timeout selection delegated to OpenClaw. Thanks to [@Stoff81](https://github.com/Stoff81) (Issue [#117](https://github.com/openclaw/lobster/issues/117)).
 
 ## 2026.6.11

--- a/src/commands/stdlib/gog_gmail_send.ts
+++ b/src/commands/stdlib/gog_gmail_send.ts
@@ -1,31 +1,4 @@
-import { spawn } from "node:child_process";
-
-function run(cmd: string, argv: string[], env: Record<string, string | undefined>, cwd?: string) {
-	return new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve, reject) => {
-		const child = spawn(cmd, argv, {
-			env: { ...process.env, ...env },
-			cwd,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-
-		let stdout = "";
-		let stderr = "";
-		child.stdout?.on("data", (d) => (stdout += String(d)));
-		child.stderr?.on("data", (d) => (stderr += String(d)));
-
-		child.on("error", (err: any) => {
-			if (err?.code === "ENOENT") {
-				reject(new Error("gog not found on PATH (install: https://github.com/steipete/gogcli)"));
-				return;
-			}
-			reject(err);
-		});
-
-		child.on("close", (code) => {
-			resolve({ stdout, stderr, code });
-		});
-	});
-}
+import { runAbortableProcess } from "../../abortable_process.js";
 
 type Draft = {
 	to: string;
@@ -103,7 +76,15 @@ export const gogGmailSendCommand = {
 			];
 
 			const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
-			const res = await run(gogBin, argv, ctx.env, process.cwd());
+			const res = await runAbortableProcess({
+				command: gogBin,
+				argv,
+				env: { ...process.env, ...ctx.env },
+				cwd: process.cwd(),
+				signal: ctx.signal,
+				forceTerminationSignal: ctx.forceTerminationSignal,
+				notFoundMessage: "gog not found on PATH (install: https://github.com/steipete/gogcli)",
+			});
 			if (res.code !== 0) {
 				throw new Error(`gog.gmail.send failed (${res.code ?? "?"}): ${res.stderr.slice(0, 400)}`);
 			}

--- a/src/commands/stdlib/gog_gmail_send.ts
+++ b/src/commands/stdlib/gog_gmail_send.ts
@@ -76,6 +76,7 @@ export const gogGmailSendCommand = {
 			];
 
 			const argv = isScript ? [gogBinRaw, ...argvBase] : argvBase;
+			ctx.onNonRetryableSideEffect?.();
 			const res = await runAbortableProcess({
 				command: gogBin,
 				argv,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -28,6 +28,7 @@ export async function runPipeline({
 	requestInputResume = undefined,
 	requestInputEnabled = true,
 	onExecutionStart = undefined,
+	onNonRetryableSideEffect = undefined,
 }: {
 	pipeline: any[];
 	registry: any;
@@ -47,6 +48,7 @@ export async function runPipeline({
 	requestInputResume?: CommandInputResume | undefined;
 	requestInputEnabled?: boolean;
 	onExecutionStart?: (() => void | Promise<void>) | undefined;
+	onNonRetryableSideEffect?: (() => void) | undefined;
 }) {
 	if (dryRun) {
 		return dryRunPipeline({ pipeline, registry, stderr });
@@ -83,6 +85,7 @@ export async function runPipeline({
 		llmSpendLedger,
 		signal,
 		forceTerminationSignal,
+		onNonRetryableSideEffect,
 	};
 
 	for (let idx = 0; idx < pipeline.length; idx++) {

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -192,7 +192,23 @@ type RunContext = {
 	_onResumeStateResolved?: (stateKey: string) => void;
 	_onExecutionStarted?: () => void | Promise<void>;
 	_onExecutionInterrupted?: () => void;
+	_onNonRetryableSideEffect?: () => void;
 };
+
+const NON_RETRYABLE_STEP_ERROR = Symbol("lobster.nonRetryableStepError");
+
+function markStepErrorNonRetryable(error: unknown): Error {
+	const normalized = error instanceof Error ? error : new Error(String(error));
+	Object.defineProperty(normalized, NON_RETRYABLE_STEP_ERROR, { value: true });
+	return normalized;
+}
+
+function isStepErrorNonRetryable(error: unknown): boolean {
+	return Boolean(
+		error instanceof Error &&
+		(error as Error & { [NON_RETRYABLE_STEP_ERROR]?: boolean })[NON_RETRYABLE_STEP_ERROR],
+	);
+}
 
 const PARALLEL_BRANCH_ABORT_SETTLE_TIMEOUT_MS = 500;
 
@@ -1246,6 +1262,11 @@ export async function runWorkflowFile({
 				result: WorkflowStepResult;
 				parallelBranchResults: Record<string, WorkflowStepResult> | null;
 			}> => {
+				let attemptHadNonRetryableSideEffect = false;
+				const markNonRetryableSideEffect = () => {
+					attemptHadNonRetryableSideEffect = true;
+					ctx._onNonRetryableSideEffect?.();
+				};
 				ctx.signal?.throwIfAborted();
 				// Combine external cancellation and optional per-step timeout into one signal.
 				let stepSignal: AbortSignal | undefined = ctx.signal;
@@ -1347,7 +1368,11 @@ export async function runWorkflowFile({
 									stepId: branch.id,
 									pipelineText,
 									inputValue,
-									ctx: { ...ctx, signal: branchSignal },
+									ctx: {
+										...ctx,
+										signal: branchSignal,
+										_onNonRetryableSideEffect: markNonRetryableSideEffect,
+									},
 									llmSpendLedger: ledgerFor(branch.id),
 									env: branchEnv,
 									cwd: branchCwd,
@@ -1467,6 +1492,7 @@ export async function runWorkflowFile({
 								_onExecutionInterrupted: () => {
 									ctx._onExecutionInterrupted?.();
 								},
+								_onNonRetryableSideEffect: markNonRetryableSideEffect,
 							},
 						});
 						if (subResult.status === "needs_approval" || subResult.status === "needs_input") {
@@ -1524,7 +1550,11 @@ export async function runWorkflowFile({
 							stepId: step.id,
 							pipelineText,
 							inputValue,
-							ctx: { ...ctx, signal: stepSignal },
+							ctx: {
+								...ctx,
+								signal: stepSignal,
+								_onNonRetryableSideEffect: markNonRetryableSideEffect,
+							},
 							llmSpendLedger,
 							env,
 							cwd,
@@ -1545,6 +1575,11 @@ export async function runWorkflowFile({
 					}
 
 					return { result, parallelBranchResults };
+				} catch (error) {
+					if (attemptHadNonRetryableSideEffect) {
+						throw markStepErrorNonRetryable(error);
+					}
+					throw error;
 				} finally {
 					if (timeoutId !== undefined) clearTimeout(timeoutId);
 				}
@@ -1564,7 +1599,7 @@ export async function runWorkflowFile({
 									) {
 										return false;
 									}
-									if (stepTouchesEmailSend(step)) {
+									if (isStepErrorNonRetryable(error)) {
 										return false;
 									}
 									const message = error?.message ?? String(error);
@@ -2556,25 +2591,6 @@ function evaluateCondition(condition: unknown, results: Record<string, WorkflowS
 	if (trimmed === "true") return true;
 	if (trimmed === "false") return false;
 	return evaluateConditionExpression(trimmed, results);
-}
-
-function collectStepCommandText(step: WorkflowStep): string[] {
-	const texts: string[] = [];
-	if (typeof step.pipeline === "string") texts.push(step.pipeline);
-	if (typeof step.command === "string") texts.push(step.command);
-	if (typeof step.run === "string") texts.push(step.run);
-	for (const branch of step.parallel?.branches ?? []) {
-		if (typeof branch.pipeline === "string") texts.push(branch.pipeline);
-		if (typeof branch.command === "string") texts.push(branch.command);
-		if (typeof branch.run === "string") texts.push(branch.run);
-	}
-	return texts;
-}
-
-function stepTouchesEmailSend(step: WorkflowStep): boolean {
-	return collectStepCommandText(step).some((text) =>
-		/(^|[\s|])gog\.gmail\.send(?=$|[\s|])/.test(text),
-	);
 }
 
 function isApprovalStep(approval: WorkflowStep["approval"]) {
@@ -3635,6 +3651,7 @@ async function runPipelineStep({
 				}
 			: undefined,
 		onExecutionStart,
+		onNonRetryableSideEffect: ctx._onNonRetryableSideEffect,
 	});
 	stdout.end();
 	ctx.signal?.throwIfAborted();

--- a/src/workflows/file.ts
+++ b/src/workflows/file.ts
@@ -1564,6 +1564,9 @@ export async function runWorkflowFile({
 									) {
 										return false;
 									}
+									if (stepTouchesEmailSend(step)) {
+										return false;
+									}
 									const message = error?.message ?? String(error);
 									return !/halted (for approval inside|before completion at) pipeline/.test(
 										message,
@@ -2553,6 +2556,25 @@ function evaluateCondition(condition: unknown, results: Record<string, WorkflowS
 	if (trimmed === "true") return true;
 	if (trimmed === "false") return false;
 	return evaluateConditionExpression(trimmed, results);
+}
+
+function collectStepCommandText(step: WorkflowStep): string[] {
+	const texts: string[] = [];
+	if (typeof step.pipeline === "string") texts.push(step.pipeline);
+	if (typeof step.command === "string") texts.push(step.command);
+	if (typeof step.run === "string") texts.push(step.run);
+	for (const branch of step.parallel?.branches ?? []) {
+		if (typeof branch.pipeline === "string") texts.push(branch.pipeline);
+		if (typeof branch.command === "string") texts.push(branch.command);
+		if (typeof branch.run === "string") texts.push(branch.run);
+	}
+	return texts;
+}
+
+function stepTouchesEmailSend(step: WorkflowStep): boolean {
+	return collectStepCommandText(step).some((text) =>
+		/(^|[\s|])gog\.gmail\.send(?=$|[\s|])/.test(text),
+	);
 }
 
 function isApprovalStep(approval: WorkflowStep["approval"]) {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -3657,6 +3657,124 @@ test("parallel timeout kills in-flight sends without retrying", async () => {
 	}
 });
 
+test("a templated Gmail send pipeline is not retried after timeout", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-templated-send-retry-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const filePath = join(dir, "workflow.lobster");
+		const sendStarted = join(dir, "send-started");
+		const sendInvocations = join(dir, "send-invocations");
+		await writeFile(
+			filePath,
+			JSON.stringify({
+				args: { send_pipeline: { default: "gog.gmail.send" } },
+				steps: [
+					{
+						id: "draft",
+						run: `${JSON.stringify(process.execPath)} -e "process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))"`,
+					},
+					{
+						id: "send",
+						pipeline: "${send_pipeline}",
+						stdin: "$draft.json",
+						timeout_ms: 80,
+						retry: { max: 2, delay_ms: 0 },
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		const run = runToolRequest({
+			filePath,
+			ctx: {
+				cwd: dir,
+				registry: createDefaultRegistry(),
+				env: {
+					...process.env,
+					LOBSTER_STATE_DIR: join(dir, "state"),
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+					MOCK_GOG_COMPLETION_DELAY_MS: "300",
+				},
+			},
+		});
+
+		await waitForFile(sendStarted);
+		const result = await run;
+		assert.equal(result.ok, false);
+		assert.match(result.error?.message ?? "", /timed out|timeout|abort|cancel/i);
+		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("a parent does not retry a child workflow after the child sends Gmail", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-composed-send-retry-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const childPath = join(dir, "child.lobster");
+		const parentPath = join(dir, "parent.lobster");
+		const sendStarted = join(dir, "send-started");
+		const sendInvocations = join(dir, "send-invocations");
+		await writeFile(
+			childPath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "draft",
+						run: `${JSON.stringify(process.execPath)} -e "process.stdout.write(JSON.stringify({to:'user@example.com',subject:'Hello',body:'World'}))"`,
+					},
+					{ id: "send", pipeline: "gog.gmail.send", stdin: "$draft.json" },
+					{ id: "fail", run: `${JSON.stringify(process.execPath)} -e "process.exit(1)"` },
+				],
+			}),
+			"utf8",
+		);
+		await writeFile(
+			parentPath,
+			JSON.stringify({
+				steps: [
+					{
+						id: "child",
+						workflow: "./child.lobster",
+						retry: { max: 2, delay_ms: 0 },
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		const result = await runToolRequest({
+			filePath: parentPath,
+			ctx: {
+				cwd: dir,
+				registry: createDefaultRegistry(),
+				env: {
+					...process.env,
+					LOBSTER_STATE_DIR: join(dir, "state"),
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
+					MOCK_GOG_COMPLETION_DELAY_MS: "50",
+				},
+			},
+		});
+
+		assert.equal(result.ok, false);
+		assert.match(result.error?.message ?? "", /workflow command failed/);
+		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
+		assert.equal(invocations.length, 1);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("approval resume token cannot replay a send after downstream cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-resume-cancel-replay-"));
 	try {

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -3584,7 +3584,7 @@ test("workflow pipeline terminates an in-flight send and halts under cancellatio
 	}
 });
 
-test("parallel timeout kills in-flight sends before retrying", async () => {
+test("parallel timeout kills in-flight sends without retrying", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-parallel-timeout-send-settlement-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -3647,7 +3647,11 @@ test("parallel timeout kills in-flight sends before retrying", async () => {
 			"a timeout must kill its in-flight send before retry policy returns",
 		);
 		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
-		assert.equal(invocations.length, 2);
+		assert.equal(
+			invocations.length,
+			1,
+			"a timed-out send must not retry; Gmail may already have accepted the first message",
+		);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}

--- a/test/cancellation.test.ts
+++ b/test/cancellation.test.ts
@@ -3343,7 +3343,7 @@ test("process-tree escalation survives a short-lived caller", async () => {
 	}
 });
 
-test("an in-flight gog.gmail.send completes and halts the pipeline after cancellation", async () => {
+test("an in-flight gog.gmail.send is terminated and the pipeline halts after cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-cancel-send-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -3387,28 +3387,29 @@ test("an in-flight gog.gmail.send completes and halts the pipeline after cancell
 					MOCK_GOG_SEND_TERMINATED_FILE: sendTerminated,
 					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
 					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
-					MOCK_GOG_COMPLETION_DELAY_MS: "100",
+					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+					MOCK_GOG_COMPLETION_DELAY_MS: "5000",
 				},
 			},
 		});
 
 		await waitForFile(sendStarted);
+		const childPid = Number(await readFile(sendStarted, "utf8"));
 		controller.abort();
 		const immediate = await observeSettlement(run, 50);
 		const envelope = await run;
 
-		assert.equal(
-			immediate.settled,
-			false,
-			"an already-started send must not report an ambiguous abort",
-		);
+		assert.equal(immediate.settled, false, "workflow must wait for the send child to exit");
 		assertCancellationEnvelope(envelope);
 		assert.equal(downstreamStarted, false, "cancellation must stop later pipeline stages");
-		await waitForFile(sendCompleted, 500);
+		if (process.platform !== "win32") {
+			await waitForFile(sendTerminated, 500);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 700));
+		assert.equal(processIsRunning(childPid), false);
 		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
 		assert.equal(invocations.length, 1, "cancellation must prevent the second send from starting");
-		assert.equal(await fileExists(sendTerminated), false);
-		assert.equal(await fileExists(sendCompleted), true);
+		assert.equal(await fileExists(sendCompleted), false, "a cancelled send must not finish");
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
@@ -3492,7 +3493,7 @@ test("cancellation after a Gmail send interrupts a blocked next draft read", asy
 	}
 });
 
-test("workflow pipeline halts after an in-flight send completes under cancellation", async () => {
+test("workflow pipeline terminates an in-flight send and halts under cancellation", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-workflow-cancel-send-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -3554,34 +3555,36 @@ test("workflow pipeline halts after an in-flight send completes under cancellati
 					MOCK_GOG_SEND_TERMINATED_FILE: sendTerminated,
 					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
 					MOCK_GOG_SEND_INVOCATIONS_FILE: sendInvocations,
-					MOCK_GOG_COMPLETION_DELAY_MS: "100",
+					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+					MOCK_GOG_COMPLETION_DELAY_MS: "5000",
 				},
 			},
 		});
 
 		await waitForFile(sendStarted);
+		const childPid = Number(await readFile(sendStarted, "utf8"));
 		controller.abort();
 		const immediate = await observeSettlement(run, 50);
 		const envelope = await run;
 
-		assert.equal(
-			immediate.settled,
-			false,
-			"an already-started workflow send must return a definitive result",
-		);
+		assert.equal(immediate.settled, false, "workflow must wait for the send child to exit");
 		assertCancellationEnvelope(envelope);
-		await waitForFile(sendCompleted, 500);
+		if (process.platform !== "win32") {
+			await waitForFile(sendTerminated, 500);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 700));
+		assert.equal(processIsRunning(childPid), false);
 		assert.equal(nestedStarted, false, "cancellation must stop the next nested pipeline stage");
 		assert.equal(laterStarted, false, "cancellation must stop later workflow steps");
 		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
 		assert.equal(invocations.length, 1);
-		assert.equal(await fileExists(sendTerminated), false);
+		assert.equal(await fileExists(sendCompleted), false, "a cancelled send must not finish");
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
 });
 
-test("parallel timeout waits for in-flight sends before retrying", async () => {
+test("parallel timeout kills in-flight sends before retrying", async () => {
 	const dir = await mkdtemp(join(tmpdir(), "lobster-parallel-timeout-send-settlement-"));
 	try {
 		const repoRoot = join(__dirname, "..", "..");
@@ -3640,8 +3643,8 @@ test("parallel timeout waits for in-flight sends before retrying", async () => {
 		assert.match(result.error?.message ?? "", /timed out|timeout|abort|cancel/i);
 		assert.equal(
 			await fileExists(sendCompleted),
-			true,
-			"a timeout must wait for its in-flight send before retry policy returns",
+			false,
+			"a timeout must kill its in-flight send before retry policy returns",
 		);
 		const invocations = (await readFile(sendInvocations, "utf8")).trim().split(/\r?\n/);
 		assert.equal(invocations.length, 2);

--- a/test/gog_gmail_send.test.ts
+++ b/test/gog_gmail_send.test.ts
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { gogGmailSendCommand } from "../src/commands/stdlib/gog_gmail_send.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function streamOf(items: unknown[]) {
+	return (async function* () {
+		for (const item of items) yield item;
+	})();
+}
+
+async function fileExists(path: string) {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForFile(path: string, timeoutMs = 5000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await fileExists(path)) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for ${path}`);
+}
+
+function processIsRunning(pid: number) {
+	try {
+		const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+		const state = stat.slice(stat.lastIndexOf(")") + 2, stat.lastIndexOf(")") + 3);
+		if (state === "Z") return false;
+	} catch {
+		// /proc is unavailable on macOS and Windows.
+	}
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+test("aborting gog.gmail.send terminates the sleeper gog child", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "lobster-gmail-send-abort-"));
+	try {
+		const repoRoot = join(__dirname, "..", "..");
+		const mockGog = join(repoRoot, "test", "fixtures", "mock-gog-cancellation.mjs");
+		const sendStarted = join(dir, "send-started");
+		const sendTerminated = join(dir, "send-terminated");
+		const sendCompleted = join(dir, "send-completed");
+		const descendantStarted = join(dir, "descendant-started");
+		const descendantCompleted = join(dir, "descendant-completed");
+		const controller = new AbortController();
+
+		const run = gogGmailSendCommand.run({
+			input: streamOf([{ to: "user@example.com", subject: "Hello", body: "World" }]),
+			args: {},
+			ctx: {
+				signal: controller.signal,
+				env: {
+					...process.env,
+					GOG_BIN: mockGog,
+					MOCK_GOG_SEND_STARTED_FILE: sendStarted,
+					MOCK_GOG_SEND_TERMINATED_FILE: sendTerminated,
+					MOCK_GOG_SEND_COMPLETED_FILE: sendCompleted,
+					MOCK_GOG_DESCENDANT_STARTED_FILE: descendantStarted,
+					MOCK_GOG_DESCENDANT_COMPLETED_FILE: descendantCompleted,
+					MOCK_GOG_TERMINATION_DELAY_MS: "1000",
+					MOCK_GOG_COMPLETION_DELAY_MS: "5000",
+				},
+			},
+		});
+
+		await waitForFile(sendStarted);
+		await waitForFile(descendantStarted);
+		const childPid = Number(await readFile(sendStarted, "utf8"));
+		const descendantPid = Number(await readFile(descendantStarted, "utf8"));
+		assert.ok(Number.isInteger(childPid) && childPid > 0);
+		assert.ok(Number.isInteger(descendantPid) && descendantPid > 0);
+		controller.abort(new Error("abort in-flight gog.gmail.send"));
+
+		await assert.rejects(run, (err: unknown) => {
+			assert.ok(err instanceof Error);
+			assert.match(err.message, /abort/i);
+			return true;
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 700));
+		assert.equal(processIsRunning(childPid), false, "gog send child must not remain after abort");
+		assert.equal(
+			processIsRunning(descendantPid),
+			false,
+			"gog send descendants must be killed after abort",
+		);
+		if (process.platform !== "win32") {
+			assert.equal(await fileExists(sendTerminated), true);
+		}
+		assert.equal(await fileExists(sendCompleted), false, "a cancelled send must not finish");
+		assert.equal(
+			await fileExists(descendantCompleted),
+			false,
+			"a send descendant must not finish after abort",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What Problem This Solves

`gog.gmail.send` spawned `gog` with a local helper that ignored `ctx.signal`. Workflow `timeout_ms` and CLI abort left the child running until it exited. `gog.gmail.search` already uses `runAbortableProcess`.

## Evidence

```console
Red (unfixed, sleeper GOG_BIN): Missing expected rejection after 5032ms
Green (fixed): same test passed in 1016ms; child gone
$ pnpm test
531 pass, 0 fail, 3 skipped
```

## Real behavior proof
Behavior addressed: Abort/timeout on `gog.gmail.send` now kills the gog child the same way search already does.
Real environment tested: macOS, Node from the worktree, lobster `/tmp/oc-impl-lobster-abort` head `a10d3b9`.
Exact steps or command run after this patch: `pnpm test` (includes `test/gog_gmail_send.test.ts` sleeper abort)
Evidence after fix: red/green recorded above.
Observed result after fix: abort rejects in about 1s and the sleeper plus descendant are gone.
What was not tested: A live Gmail send against a real gogcli account.
